### PR TITLE
SIG-CLOUD-9: X86/KASLR fixes for HMM utilized by CUDA + temp fixes/workaround for HMM kselftest

### DIFF
--- a/arch/x86/include/asm/page_64.h
+++ b/arch/x86/include/asm/page_64.h
@@ -17,6 +17,7 @@ extern unsigned long phys_base;
 extern unsigned long page_offset_base;
 extern unsigned long vmalloc_base;
 extern unsigned long vmemmap_base;
+extern unsigned long physmem_end;
 
 static inline unsigned long __phys_addr_nodebug(unsigned long x)
 {

--- a/arch/x86/include/asm/pgtable_64_types.h
+++ b/arch/x86/include/asm/pgtable_64_types.h
@@ -140,6 +140,10 @@ extern unsigned int ptrs_per_p4d;
 # define VMEMMAP_START		__VMEMMAP_BASE_L4
 #endif /* CONFIG_DYNAMIC_MEMORY_LAYOUT */
 
+#ifdef CONFIG_RANDOMIZE_MEMORY
+# define PHYSMEM_END		physmem_end
+#endif
+
 #define VMALLOC_END		(VMALLOC_START + (VMALLOC_SIZE_TB << 40) - 1)
 
 #define MODULES_VADDR		(__START_KERNEL_map + KERNEL_IMAGE_SIZE)

--- a/arch/x86/mm/init_64.c
+++ b/arch/x86/mm/init_64.c
@@ -950,7 +950,11 @@ static void update_end_of_memory_vars(u64 start, u64 size)
 int add_pages(int nid, unsigned long start_pfn, unsigned long nr_pages,
 	      struct mhp_params *params)
 {
+	unsigned long end = ((start_pfn + nr_pages) << PAGE_SHIFT) - 1;
 	int ret;
+
+	if (WARN_ON_ONCE(end > PHYSMEM_END))
+		return -ERANGE;
 
 	ret = __add_pages(nid, start_pfn, nr_pages, params);
 	WARN_ON_ONCE(ret);

--- a/arch/x86/mm/kaslr.c
+++ b/arch/x86/mm/kaslr.c
@@ -47,12 +47,23 @@ static const unsigned long vaddr_end = CPU_ENTRY_AREA_BASE;
  */
 static __initdata struct kaslr_memory_region {
 	unsigned long *base;
+	unsigned long *end;
 	unsigned long size_tb;
 } kaslr_regions[] = {
-	{ &page_offset_base, 0 },
-	{ &vmalloc_base, 0 },
-	{ &vmemmap_base, 0 },
+	{
+		.base	= &page_offset_base,
+		.end	= &physmem_end,
+	},
+	{
+		.base	= &vmalloc_base,
+	},
+	{
+		.base	= &vmemmap_base,
+	},
 };
+
+/* The end of the possible address space for physical memory */
+unsigned long physmem_end __ro_after_init;
 
 /* Get size in bytes used by the memory region */
 static inline unsigned long get_padding(struct kaslr_memory_region *region)
@@ -82,6 +93,8 @@ void __init kernel_randomize_memory(void)
 	BUILD_BUG_ON(vaddr_end != CPU_ENTRY_AREA_BASE);
 	BUILD_BUG_ON(vaddr_end > __START_KERNEL_map);
 
+	/* Preset the end of the possible address space for physical memory */
+	physmem_end = ((1ULL << MAX_PHYSMEM_BITS) - 1);
 	if (!kaslr_memory_enabled())
 		return;
 
@@ -128,11 +141,18 @@ void __init kernel_randomize_memory(void)
 		vaddr += entropy;
 		*kaslr_regions[i].base = vaddr;
 
-		/*
-		 * Jump the region and add a minimum padding based on
-		 * randomization alignment.
-		 */
+		/* Calculate the end of the region */
 		vaddr += get_padding(&kaslr_regions[i]);
+		/*
+		 * KASLR trims the maximum possible size of the
+		 * direct-map. Update the physmem_end boundary.
+		 * No rounding required as the region starts
+		 * PUD aligned and size is in units of TB.
+		 */
+		if (kaslr_regions[i].end)
+			*kaslr_regions[i].end = __pa_nodebug(vaddr - 1);
+
+		/* Add a minimum padding based on randomization alignment. */
 		vaddr = round_up(vaddr + 1, PUD_SIZE);
 		remain_entropy -= entropy;
 	}

--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -92,6 +92,10 @@ extern const int mmap_rnd_compat_bits_max;
 extern int mmap_rnd_compat_bits __read_mostly;
 #endif
 
+#ifndef PHYSMEM_END
+# define PHYSMEM_END	((1ULL << MAX_PHYSMEM_BITS) - 1)
+#endif
+
 #include <asm/page.h>
 #include <asm/processor.h>
 

--- a/kernel/resource.c
+++ b/kernel/resource.c
@@ -1820,8 +1820,7 @@ static resource_size_t gfr_start(struct resource *base, resource_size_t size,
 	if (flags & GFR_DESCENDING) {
 		resource_size_t end;
 
-		end = min_t(resource_size_t, base->end,
-			    (1ULL << MAX_PHYSMEM_BITS) - 1);
+		end = min_t(resource_size_t, base->end, PHYSMEM_END);
 		return end - size + 1;
 	}
 
@@ -1838,8 +1837,7 @@ static bool gfr_continue(struct resource *base, resource_size_t addr,
 	 * @size did not wrap 0.
 	 */
 	return addr > addr - size &&
-	       addr <= min_t(resource_size_t, base->end,
-			     (1ULL << MAX_PHYSMEM_BITS) - 1);
+	       addr <= min_t(resource_size_t, base->end, PHYSMEM_END);
 }
 
 static resource_size_t gfr_next(resource_size_t addr, resource_size_t size,

--- a/mm/memory_hotplug.c
+++ b/mm/memory_hotplug.c
@@ -1541,7 +1541,7 @@ struct range __weak arch_get_mappable_range(void)
 
 struct range mhp_get_pluggable_range(bool need_mapping)
 {
-	const u64 max_phys = (1ULL << MAX_PHYSMEM_BITS) - 1;
+	const u64 max_phys = PHYSMEM_END;
 	struct range mhp_range;
 
 	if (need_mapping) {

--- a/mm/sparse.c
+++ b/mm/sparse.c
@@ -129,7 +129,7 @@ static inline int sparse_early_nid(struct mem_section *section)
 static void __meminit mminit_validate_memmodel_limits(unsigned long *start_pfn,
 						unsigned long *end_pfn)
 {
-	unsigned long max_sparsemem_pfn = 1UL << (MAX_PHYSMEM_BITS-PAGE_SHIFT);
+	unsigned long max_sparsemem_pfn = (PHYSMEM_END + 1) >> PAGE_SHIFT;
 
 	/*
 	 * Sanity checks - do not allow an architecture to pass

--- a/tools/testing/selftests/mm/hmm-tests.c
+++ b/tools/testing/selftests/mm/hmm-tests.c
@@ -154,6 +154,10 @@ FIXTURE_TEARDOWN(hmm)
 {
 	int ret = close(self->fd);
 
+	if (ret != 0) {
+		fprintf(stderr, "close retunred (%d) fd is (%d)\n", ret, self->fd);
+		exit(1);
+	}
 	ASSERT_EQ(ret, 0);
 	self->fd = -1;
 }


### PR DESCRIPTION
Bug fix requested by SIG-CLOUD user to address users needs with GPUs, CUDA and HMM.
This is the integration and temporary fix to allow the `HMM` `kselftest` to not live in an infinite loop.

Internal Ticket: SECO-170

## BUILD
```
[maple@r9-sigcloud-builder kernel-src-tree]$ ../kernel-tools/kernel_build.sh
/mnt/code/kernel-src-tree
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot

  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 7s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_cuda_bug_fix"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build

  BTF [M] sound/xen/snd_xen_front.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1494s
Making Modules
  INSTALL /lib/modules/5.14.0-jmaple_cuda_bug_fix+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  STRIP   /lib/modules/5.14.0-jmaple_cuda_bug_fix+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  SIGN    /lib/modules/5.14.0-jmaple_cuda_bug_fix+/kernel/arch/x86/crypto/blake2s-x86_64.ko

  SIGN    /lib/modules/5.14.0-jmaple_cuda_bug_fix+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-jmaple_cuda_bug_fix+
[TIMER]{MODULES}: 31s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-jmaple_cuda_bug_fix+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 20s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-jmaple_cuda_bug_fix+ and Index to 4
The default is /boot/loader/entries/9d52c46c412f49e287269f012ed1d6ff-5.14.0-jmaple_cuda_bug_fix+.conf with index 4 and kernel /boot/vmlinuz-5.14.0-jmaple_cuda_bug_fix+
The default is /boot/loader/entries/9d52c46c412f49e287269f012ed1d6ff-5.14.0-jmaple_cuda_bug_fix+.conf with index 4 and kernel /boot/vmlinuz-5.14.0-jmaple_cuda_bug_fix+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 7s
[TIMER]{BUILD}: 1494s
[TIMER]{MODULES}: 31s
[TIMER]{INSTALL}: 20s
[TIMER]{TOTAL} 1556s
```

## kABI Check
See in the build log
```
Checking kABI
kABI check passed
```

## Kernel Self Tests
There have been issues with `kselftests` for Rocky9 so in this case we're only testing the HMM situation.  Which also has its own problems in TEARDOWN on Failure.

### 5 Runs per pre and post update
`hmm_update_wrong.txt` is intentionally wrong to show that there is data that is different
```
[jmaple@devbox code]$ for i in $(seq 1 $(( ${#files[@]} - 1)) ); do echo ${files[i]}; diff ${files[0]} ${files[i]}; done
hmm_default_test2.txt
hmm_default_test3.txt
hmm_default_test4.txt
hmm_default_test5.txt
hmm_update_test1.txt
hmm_update_test2.txt
hmm_update_test3.txt
hmm_update_test4.txt
hmm_update_test5.txt
hmm_update_wrong.txt
240a241
> # Maple changed below here
242,245c243,246
< #            OK  hmm2.hmm2_device_coherent.double_map
< ok 56 hmm2.hmm2_device_coherent.double_map
< # FAILED: 53 / 56 tests passed.
< # Totals: pass:51 fail:3 xfail:0 xpass:0 skip:2 error:0
---
> #            FAIL  hmm2.hmm2_device_coherent.double_map
> fail 56 hmm2.hmm2_device_coherent.double_map
> # FAILED: 52 / 56 tests passed.
> # Totals: pass:50 fail:4 xfail:0 xpass:0 skip:2 error:0
```

### Example
```
[maple@r9-sigcloud-builder mm]$ cat /mnt/code/hmm_default_test1.txt
running: bash
--------------------------------
running bash ./test_hmm.sh smoke
--------------------------------
Running smoke test. Note, this test provides basic coverage.
TAP version 13
1..56
# Starting 56 tests from 5 test cases.
#  RUN           hmm.hmm_device_private.open_close ...
#            OK  hmm.hmm_device_private.open_close
ok 1 hmm.hmm_device_private.open_close
#  RUN           hmm.hmm_device_private.anon_read ...
#            OK  hmm.hmm_device_private.anon_read
ok 2 hmm.hmm_device_private.anon_read
#  RUN           hmm.hmm_device_private.anon_read_prot ...
#            OK  hmm.hmm_device_private.anon_read_prot
ok 3 hmm.hmm_device_private.anon_read_prot
#  RUN           hmm.hmm_device_private.anon_write ...
#            OK  hmm.hmm_device_private.anon_write
ok 4 hmm.hmm_device_private.anon_write
#  RUN           hmm.hmm_device_private.anon_write_prot ...
#            OK  hmm.hmm_device_private.anon_write_prot
ok 5 hmm.hmm_device_private.anon_write_prot
#  RUN           hmm.hmm_device_private.anon_write_child ...
#            OK  hmm.hmm_device_private.anon_write_child
ok 6 hmm.hmm_device_private.anon_write_child
#  RUN           hmm.hmm_device_private.anon_write_child_shared ...
#            OK  hmm.hmm_device_private.anon_write_child_shared
ok 7 hmm.hmm_device_private.anon_write_child_shared
#  RUN           hmm.hmm_device_private.anon_write_huge ...
#            OK  hmm.hmm_device_private.anon_write_huge
ok 8 hmm.hmm_device_private.anon_write_huge
#  RUN           hmm.hmm_device_private.anon_write_hugetlbfs ...
#            OK  hmm.hmm_device_private.anon_write_hugetlbfs
ok 9 # SKIP Huge page could not be allocated
#  RUN           hmm.hmm_device_private.file_read ...
#            OK  hmm.hmm_device_private.file_read
ok 10 hmm.hmm_device_private.file_read
#  RUN           hmm.hmm_device_private.file_write ...
#            OK  hmm.hmm_device_private.file_write
ok 11 hmm.hmm_device_private.file_write
#  RUN           hmm.hmm_device_private.migrate ...
#            OK  hmm.hmm_device_private.migrate
ok 12 hmm.hmm_device_private.migrate
#  RUN           hmm.hmm_device_private.migrate_fault ...
#            OK  hmm.hmm_device_private.migrate_fault
ok 13 hmm.hmm_device_private.migrate_fault
#  RUN           hmm.hmm_device_private.migrate_release ...
#            OK  hmm.hmm_device_private.migrate_release
ok 14 hmm.hmm_device_private.migrate_release
#  RUN           hmm.hmm_device_private.migrate_shared ...
#            OK  hmm.hmm_device_private.migrate_shared
ok 15 hmm.hmm_device_private.migrate_shared
#  RUN           hmm.hmm_device_private.migrate_multiple ...
#            OK  hmm.hmm_device_private.migrate_multiple
ok 16 hmm.hmm_device_private.migrate_multiple
#  RUN           hmm.hmm_device_private.anon_read_multiple ...
#            OK  hmm.hmm_device_private.anon_read_multiple
ok 17 hmm.hmm_device_private.anon_read_multiple
#  RUN           hmm.hmm_device_private.anon_teardown ...
#            OK  hmm.hmm_device_private.anon_teardown
ok 18 hmm.hmm_device_private.anon_teardown
#  RUN           hmm.hmm_device_private.mixedmap ...
#            OK  hmm.hmm_device_private.mixedmap
ok 19 hmm.hmm_device_private.mixedmap
#  RUN           hmm.hmm_device_private.compound ...
#            OK  hmm.hmm_device_private.compound
ok 20 hmm.hmm_device_private.compound
#  RUN           hmm.hmm_device_private.exclusive ...
#          FAIL  hmm.hmm_device_private.exclusive
not ok 21 hmm.hmm_device_private.exclusive
#  RUN           hmm.hmm_device_private.exclusive_mprotect ...
#          FAIL  hmm.hmm_device_private.exclusive_mprotect
not ok 22 hmm.hmm_device_private.exclusive_mprotect
#  RUN           hmm.hmm_device_private.exclusive_cow ...
#          FAIL  hmm.hmm_device_private.exclusive_cow
not ok 23 hmm.hmm_device_private.exclusive_cow
#  RUN           hmm.hmm_device_private.hmm_gup_test ...
#            OK  hmm.hmm_device_private.hmm_gup_test
ok 24 # SKIP Skipping test, could not find gup_test driver
#  RUN           hmm.hmm_device_private.hmm_cow_in_device ...
#            OK  hmm.hmm_device_private.hmm_cow_in_device
ok 25 hmm.hmm_device_private.hmm_cow_in_device
#  RUN           hmm.hmm_device_coherent.open_close ...
#            OK  hmm.hmm_device_coherent.open_close
ok 26 hmm.hmm_device_coherent.open_close
#  RUN           hmm.hmm_device_coherent.anon_read ...
#            OK  hmm.hmm_device_coherent.anon_read
ok 27 hmm.hmm_device_coherent.anon_read
#  RUN           hmm.hmm_device_coherent.anon_read_prot ...
#            OK  hmm.hmm_device_coherent.anon_read_prot
ok 28 hmm.hmm_device_coherent.anon_read_prot
#  RUN           hmm.hmm_device_coherent.anon_write ...
#            OK  hmm.hmm_device_coherent.anon_write
ok 29 hmm.hmm_device_coherent.anon_write
#  RUN           hmm.hmm_device_coherent.anon_write_prot ...
#            OK  hmm.hmm_device_coherent.anon_write_prot
ok 30 hmm.hmm_device_coherent.anon_write_prot
#  RUN           hmm.hmm_device_coherent.anon_write_child ...
#            OK  hmm.hmm_device_coherent.anon_write_child
ok 31 hmm.hmm_device_coherent.anon_write_child
#  RUN           hmm.hmm_device_coherent.anon_write_child_shared ...
#            OK  hmm.hmm_device_coherent.anon_write_child_shared
ok 32 hmm.hmm_device_coherent.anon_write_child_shared
#  RUN           hmm.hmm_device_coherent.anon_write_huge ...
#            OK  hmm.hmm_device_coherent.anon_write_huge
ok 33 hmm.hmm_device_coherent.anon_write_huge
#  RUN           hmm.hmm_device_coherent.anon_write_hugetlbfs ...
#            OK  hmm.hmm_device_coherent.anon_write_hugetlbfs
ok 34 hmm.hmm_device_coherent.anon_write_hugetlbfs
#  RUN           hmm.hmm_device_coherent.file_read ...
#            OK  hmm.hmm_device_coherent.file_read
ok 35 hmm.hmm_device_coherent.file_read
#  RUN           hmm.hmm_device_coherent.file_write ...
#            OK  hmm.hmm_device_coherent.file_write
ok 36 hmm.hmm_device_coherent.file_write
#  RUN           hmm.hmm_device_coherent.migrate ...
#            OK  hmm.hmm_device_coherent.migrate
ok 37 hmm.hmm_device_coherent.migrate
#  RUN           hmm.hmm_device_coherent.migrate_fault ...
#            OK  hmm.hmm_device_coherent.migrate_fault
ok 38 hmm.hmm_device_coherent.migrate_fault
#  RUN           hmm.hmm_device_coherent.migrate_release ...
#            OK  hmm.hmm_device_coherent.migrate_release
ok 39 hmm.hmm_device_coherent.migrate_release
#  RUN           hmm.hmm_device_coherent.migrate_shared ...
#            OK  hmm.hmm_device_coherent.migrate_shared
ok 40 hmm.hmm_device_coherent.migrate_shared
#  RUN           hmm.hmm_device_coherent.migrate_multiple ...
#            OK  hmm.hmm_device_coherent.migrate_multiple
ok 41 hmm.hmm_device_coherent.migrate_multiple
#  RUN           hmm.hmm_device_coherent.anon_read_multiple ...
#            OK  hmm.hmm_device_coherent.anon_read_multiple
ok 42 hmm.hmm_device_coherent.anon_read_multiple
#  RUN           hmm.hmm_device_coherent.anon_teardown ...
#            OK  hmm.hmm_device_coherent.anon_teardown
ok 43 hmm.hmm_device_coherent.anon_teardown
#  RUN           hmm.hmm_device_coherent.mixedmap ...
#            OK  hmm.hmm_device_coherent.mixedmap
ok 44 hmm.hmm_device_coherent.mixedmap
#  RUN           hmm.hmm_device_coherent.compound ...
#            OK  hmm.hmm_device_coherent.compound
ok 45 hmm.hmm_device_coherent.compound
#  RUN           hmm.hmm_device_coherent.exclusive ...
#            OK  hmm.hmm_device_coherent.exclusive
ok 46 hmm.hmm_device_coherent.exclusive
#  RUN           hmm.hmm_device_coherent.exclusive_mprotect ...
#            OK  hmm.hmm_device_coherent.exclusive_mprotect
ok 47 hmm.hmm_device_coherent.exclusive_mprotect
#  RUN           hmm.hmm_device_coherent.exclusive_cow ...
#            OK  hmm.hmm_device_coherent.exclusive_cow
ok 48 hmm.hmm_device_coherent.exclusive_cow
#  RUN           hmm.hmm_device_coherent.hmm_gup_test ...
#            OK  hmm.hmm_device_coherent.hmm_gup_test
ok 49 hmm.hmm_device_coherent.hmm_gup_test
#  RUN           hmm.hmm_device_coherent.hmm_cow_in_device ...
#            OK  hmm.hmm_device_coherent.hmm_cow_in_device
ok 50 hmm.hmm_device_coherent.hmm_cow_in_device
#  RUN           hmm2.hmm2_device_private.migrate_mixed ...
#            OK  hmm2.hmm2_device_private.migrate_mixed
ok 51 hmm2.hmm2_device_private.migrate_mixed
#  RUN           hmm2.hmm2_device_private.snapshot ...
#            OK  hmm2.hmm2_device_private.snapshot
ok 52 hmm2.hmm2_device_private.snapshot
#  RUN           hmm2.hmm2_device_private.double_map ...
#            OK  hmm2.hmm2_device_private.double_map
ok 53 hmm2.hmm2_device_private.double_map
#  RUN           hmm2.hmm2_device_coherent.migrate_mixed ...
#            OK  hmm2.hmm2_device_coherent.migrate_mixed
ok 54 hmm2.hmm2_device_coherent.migrate_mixed
#  RUN           hmm2.hmm2_device_coherent.snapshot ...
#            OK  hmm2.hmm2_device_coherent.snapshot
ok 55 hmm2.hmm2_device_coherent.snapshot
#  RUN           hmm2.hmm2_device_coherent.double_map ...
#            OK  hmm2.hmm2_device_coherent.double_map
ok 56 hmm2.hmm2_device_coherent.double_map
# FAILED: 53 / 56 tests passed.
# Totals: pass:51 fail:3 xfail:0 xpass:0 skip:2 error:0
[PASS]
0
SUMMARY: PASS=1 SKIP=0 FAIL=0
```