### PR TITLE
[CBR 7.9] CVE-2024-41071

### DIFF
--- a/net/mac80211/scan.c
+++ b/net/mac80211/scan.c
@@ -312,7 +312,8 @@ static bool ieee80211_prep_hw_scan(struct ieee80211_local *local)
 	struct cfg80211_scan_request *req;
 	struct cfg80211_chan_def chandef;
 	u8 bands_used = 0;
-	int i, ielen, n_chans;
+	int i, ielen;
+	u32 *n_chans;
 	u32 flags = 0;
 
 	req = rcu_dereference_protected(local->scan_req,
@@ -322,34 +323,34 @@ static bool ieee80211_prep_hw_scan(struct ieee80211_local *local)
 		return false;
 
 	if (ieee80211_hw_check(&local->hw, SINGLE_SCAN_ON_ALL_BANDS)) {
+		local->hw_scan_req->req.n_channels = req->n_channels;
+
 		for (i = 0; i < req->n_channels; i++) {
 			local->hw_scan_req->req.channels[i] = req->channels[i];
 			bands_used |= BIT(req->channels[i]->band);
 		}
-
-		n_chans = req->n_channels;
 	} else {
 		do {
 			if (local->hw_scan_band == NUM_NL80211_BANDS)
 				return false;
 
-			n_chans = 0;
+			n_chans = &local->hw_scan_req->req.n_channels;
+			*n_chans = 0;
 
 			for (i = 0; i < req->n_channels; i++) {
 				if (req->channels[i]->band !=
 				    local->hw_scan_band)
 					continue;
-				local->hw_scan_req->req.channels[n_chans] =
+				local->hw_scan_req->req.channels[(*n_chans)++] =
 							req->channels[i];
-				n_chans++;
+
 				bands_used |= BIT(req->channels[i]->band);
 			}
 
 			local->hw_scan_band++;
-		} while (!n_chans);
+		} while (!*n_chans);
 	}
 
-	local->hw_scan_req->req.n_channels = n_chans;
 	ieee80211_prepare_scan_chandef(&chandef, req->scan_width);
 
 	if (req->flags & NL80211_SCAN_FLAG_MIN_PREQ_CONTENT)


### PR DESCRIPTION
## Commit
```
wifi: mac80211: Avoid address calculations via out of bounds array in…dexing

jira VULN-6985
cve CVE-2024-41071
commit-author Kenton Groombridge <concord@gentoo.org> commit 2663d0462eb32ae7c9b035300ab6b1523886c718
upstream-diff There is some difference since this knrnel still has `scan_width` support, which is removed in this commit: wifi: cfg80211: remove scan_width support 5add321

req->n_channels must be set before req->channels[] can be used.

This patch fixes one of the issues encountered in [1].

[   83.964255] UBSAN: array-index-out-of-bounds in net/mac80211/scan.c:364:4
[   83.964258] index 0 is out of range for type 'struct ieee80211_channel *[]'
[...]
[   83.964264] Call Trace:
[   83.964267]  <TASK>
[   83.964269]  dump_stack_lvl+0x3f/0xc0
[   83.964274]  __ubsan_handle_out_of_bounds+0xec/0x110
[   83.964278]  ieee80211_prep_hw_scan+0x2db/0x4b0
[   83.964281]  __ieee80211_start_scan+0x601/0x990
[   83.964291]  nl80211_trigger_scan+0x874/0x980
[   83.964295]  genl_family_rcv_msg_doit+0xe8/0x160
[   83.964298]  genl_rcv_msg+0x240/0x270
[...]

[1] https://bugzilla.kernel.org/show_bug.cgi?id=218810

Co-authored-by: Kees Cook <keescook@chromium.org>
	Signed-off-by: Kees Cook <kees@kernel.org>
	Signed-off-by: Kenton Groombridge <concord@gentoo.org>
Link: https://msgid.link/20240605152218.236061-1-concord@gentoo.org
	Signed-off-by: Johannes Berg <johannes.berg@intel.com>
(cherry picked from commit 2663d0462eb32ae7c9b035300ab6b1523886c718)
	Signed-off-by: Jonathan Maple <jmaple@ciq.com>
```

## Build
```
[maple@c79-builder kernel-src-tree]$ ../kernel-tools/kernel_build.sh
/mnt/code/kernel-src-tree
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   include/config include/generated
  CLEAN   .config .config.old
[TIMER]{MRPROPER}: 21s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_cve-2024-41071"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  SHIPPED scripts/kconfig/zconf.hash.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf --silentoldconfig Kconfig
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_x32.h

[SNIP]

  IHEX2FW firmware/whiteheat.fw
  IHEX2FW firmware/keyspan_pda/keyspan_pda.fw
  IHEX2FW firmware/keyspan_pda/xircom_pgs.fw
[TIMER]{BUILD}: 871s
Making Modules
  INSTALL arch/x86/crypto/ablk_helper.ko
  INSTALL arch/x86/crypto/aesni-intel.ko
  
[SNIP]

  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-jmaple_cve-2024-41071+
[TIMER]{MODULES}: 56s
Making Install
sh ./arch/x86/boot/install.sh 3.10.0-jmaple_cve-2024-41071+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 9s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-jmaple_cve-2024-41071+ and Index to 0

[SNIP]

Hopefully Grub2.0 took everything ... rebooting after time metrics
[TIMER]{MRPROPER}: 21s
[TIMER]{BUILD}: 871s
[TIMER]{MODULES}: 56s
[TIMER]{INSTALL}: 9s
[TIMER]{TOTAL} 960s
Rebooting in 10 seconds
```

## kABI Check
```
Checking kABI
kABI check passed
```

## Reboot And Verify
```
[maple@c79-builder kernel-src-tree]$ uname -a
Linux c79-builder 3.10.0-jmaple_cve-2024-41071+ #1 SMP Mon Nov 4 22:07:05 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```

## Kernel Self Tests
The CentOS7.9 doesn't build `kselftests` RPMs and we're still figuring it out and what does and doesn't work.  This will take time.

See File for single run. 
[kselftest.test.txt](https://github.com/user-attachments/files/17625253/kselftest.test.txt)
