### PR TITLE
PR for CVEs CVE-2023-6622 and CVE-2024-26642

### DIFF
--- a/net/netfilter/nf_tables_api.c
+++ b/net/netfilter/nf_tables_api.c
@@ -4152,6 +4152,9 @@ static int nf_tables_newset(struct net *net, struct sock *nlsk,
 		if ((flags & (NFT_SET_EVAL | NFT_SET_OBJECT)) ==
 			     (NFT_SET_EVAL | NFT_SET_OBJECT))
 			return -EOPNOTSUPP;
+		if ((flags & (NFT_SET_ANONYMOUS | NFT_SET_TIMEOUT | NFT_SET_EVAL)) ==
+			     (NFT_SET_ANONYMOUS | NFT_SET_TIMEOUT))
+			return -EOPNOTSUPP;
 	}
 
 	dtype = 0;

--- a/net/netfilter/nft_dynset.c
+++ b/net/netfilter/nft_dynset.c
@@ -274,10 +274,15 @@ static int nft_dynset_init(const struct nft_ctx *ctx,
 			priv->expr_array[i] = dynset_expr;
 			priv->num_exprs++;
 
-			if (set->num_exprs &&
-			    dynset_expr->ops != set->exprs[i]->ops) {
-				err = -EOPNOTSUPP;
-				goto err_expr_free;
+			if (set->num_exprs) {
+				if (i >= set->num_exprs) {
+					err = -EINVAL;
+					goto err_expr_free;
+				}
+				if (dynset_expr->ops != set->exprs[i]->ops) {
+					err = -EOPNOTSUPP;
+					goto err_expr_free;
+				}
 			}
 			i++;
 		}


### PR DESCRIPTION
Jira VULN-683
Jira VULN-827

```
/home/g.v.rose/prj/kernel-build-tmp
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-debug-branch"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h

[SNIP]

  DEPMOD  4.18.0-debug-branch+
[TIMER]{MODULES}: 70s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-debug-branch+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 19s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-debug-branch+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 979s
[TIMER]{MODULES}: 70s
[TIMER]{INSTALL}: 19s
[TIMER]{TOTAL} 1077s
Rebooting in 10 seconds
```

```
[g.v.rose@lts86-base ~]$ uname -a
Linux lts86-base 4.18.0-debug-branch+ #1 SMP Tue Nov 5 11:56:16 EST 2024 x86_64 x86_64 x86_64 GNU/Linux
[g.v.rose@lts86-base ~]$ 
```

Kernel selftest log before our changes: 
[kernel-selftest-before.log](https://github.com/user-attachments/files/17636814/kernel-selftest-before.log)

Kernel selftest log after our changes:
[kernel-selftest-after.log](https://github.com/user-attachments/files/17636816/kernel-selftest-after.log)

Minor changes from run to run - nothing related to our changes.  During kernel selftesting with lockdep enabled, several lockdep warnings are emitted - this happens with or without our changes and does not change the test results.

[kst-debug-tmp-ldpon.log](https://github.com/user-attachments/files/17636949/kst-debug-tmp-ldpon.log)

Netfilter tests showed no changes from previous runs.
[nftables-test.log](https://github.com/user-attachments/files/17637021/nftables-test.log)


