### PR TITLE
Fix CVE-2021-47461

### DIFF
--- a/fs/userfaultfd.c
+++ b/fs/userfaultfd.c
@@ -1801,9 +1801,15 @@ static int userfaultfd_writeprotect(struct userfaultfd_ctx *ctx,
 	if (mode_wp && mode_dontwake)
 		return -EINVAL;
 
-	ret = mwriteprotect_range(ctx->mm, uffdio_wp.range.start,
-				  uffdio_wp.range.len, mode_wp,
-				  &ctx->mmap_changing);
+	if (mmget_not_zero(ctx->mm)) {
+		ret = mwriteprotect_range(ctx->mm, uffdio_wp.range.start,
+					  uffdio_wp.range.len, mode_wp,
+					  &ctx->mmap_changing);
+		mmput(ctx->mm);
+	} else {
+		return -ESRCH;
+	}
+
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
jira VULN-4370
cve CVE-2021-47461
commit-author Nadav Amit <namit@vmware.com>
commit cb185d5f1ebf900f4ae3bf84cee212e6dd035aca

A race is possible when a process exits, its VMAs are removed by exit_mmap() and at the same time userfaultfd_writeprotect() is called.

The race was detected by KASAN on a development kernel, but it appears to be possible on vanilla kernels as well.

Use mmget_not_zero() to prevent the race as done in other userfaultfd operations.

Link: https://lkml.kernel.org/r/20210921200247.25749-1-namit@vmware.com Fixes: 63b2d4174c4ad ("userfaultfd: wp: add the writeprotect API to userfaultfd ioctl")
	Signed-off-by: Nadav Amit <namit@vmware.com>
	Tested-by: Li  Wang <liwang@redhat.com>
	Reviewed-by: Peter Xu <peterx@redhat.com>
	Cc: Andrea Arcangeli <aarcange@redhat.com>
	Cc: <stable@vger.kernel.org>
	Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
	Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
(cherry picked from commit cb185d5f1ebf900f4ae3bf84cee212e6dd035aca)
	Signed-off-by: Greg Rose <g.v.rose@ciq.com>
```
  CLEAN   .config .config.old .version Module.symvers
[TIMER]{MRPROPER}: 29s
x86_64 architecture detected, copying config
'configs/kernel-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-debug-branch"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig

[SNIP]

  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-debug-branch+
[TIMER]{MODULES}: 117s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-debug-branch+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 36s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-debug-branch+ and Index to 3
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 29s
[TIMER]{BUILD}: 3249s
[TIMER]{MODULES}: 117s
[TIMER]{INSTALL}: 36s
[TIMER]{TOTAL} 3442s
Rebooting in 10 seconds
```

## Boots and runs:
```
[g.v.rose@lts86-base shell]$ uname -a
Linux lts86-base 4.18.0-debug-branch+ #1 SMP Fri Nov 15 14:41:28 EST 2024 x86_64 x86_64 x86_64 GNU/Linux
```
## Test Logs:

Before and after kernel selftest logs:
[kernel-selftest-before.log](https://github.com/user-attachments/files/17781929/kernel-selftest-before.log)
[kernel-selftest-after.log](https://github.com/user-attachments/files/17781942/kernel-selftest-after.log)

Kernel selftests were run with lockdep and kmemleak enabled and with stress running in the background - some of the usual  anomalies popped up but nothing exraordinary.

No changes to the netfilter tables test results which were also run with lockdep, kmemleak and stress running.
[nftables-test.log](https://github.com/user-attachments/files/17781962/nftables-test.log)

