### PR TITLE
github actions: Fix accidental exposure of key

### DIFF
--- a/.github/workflows/process-git-request.rb
+++ b/.github/workflows/process-git-request.rb
@@ -1,6 +1,6 @@
 require 'open3'
 
-requestors = { "gvrose8192" => "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" }
+requestors = { "gvrose8192" => "" }
 
 def file_prepend(file, str)
   new_contents = ""


### PR DESCRIPTION
A key was exposed in the PR processing ruby script - it was obsolete anyway, but not good form to have it there.
