### PR TITLE
CVE-2023-5178 - VULN-3190

### DIFF
--- a/drivers/nvme/target/tcp.c
+++ b/drivers/nvme/target/tcp.c
@@ -363,6 +363,7 @@ static void nvmet_tcp_fatal_error(struct nvmet_tcp_queue *queue)
 
 static void nvmet_tcp_socket_error(struct nvmet_tcp_queue *queue, int status)
 {
+	queue->rcv_state = NVMET_TCP_RECV_ERR;
 	if (status == -EPIPE || status == -ECONNRESET)
 		kernel_sock_shutdown(queue->sock, SHUT_RDWR);
 	else
@@ -906,15 +907,11 @@ static int nvmet_tcp_handle_icreq(struct nvmet_tcp_queue *queue)
 	iov.iov_len = sizeof(*icresp);
 	ret = kernel_sendmsg(queue->sock, &msg, &iov, 1, iov.iov_len);
 	if (ret < 0)
-		goto free_crypto;
+		return ret; /* queue removal will cleanup */
 
 	queue->state = NVMET_TCP_Q_LIVE;
 	nvmet_prepare_receive_pdu(queue);
 	return 0;
-free_crypto:
-	if (queue->hdr_digest || queue->data_digest)
-		nvmet_tcp_free_crypto(queue);
-	return ret;
 }
 
 static void nvmet_tcp_handle_req_failure(struct nvmet_tcp_queue *queue,


### PR DESCRIPTION
jira VULN-3190
cve CVE-2023-5178
commit-author Sagi Grimberg <sagi@grimberg.me>
commit d920abd1e7c4884f9ecd0749d1921b7ab19ddfbd

From Alon:
"Due to a logical bug in the NVMe-oF/TCP subsystem in the Linux kernel, a malicious user can cause a UAF and a double free, which may lead to RCE (may also lead to an LPE in case the attacker already has local privileges)."

Hence, when a queue initialization fails after the ahash requests are allocated, it is guaranteed that the queue removal async work will be called, hence leave the deallocation to the queue removal.

Also, be extra careful not to continue processing the socket, so set queue rcv_state to NVMET_TCP_RECV_ERR upon a socket error.

	Cc: stable@vger.kernel.org
	Reported-by: Alon Zahavi <zahavi.alon@gmail.com>
	Tested-by: Alon Zahavi <zahavi.alon@gmail.com>
	Signed-off-by: Sagi Grimberg <sagi@grimberg.me>
	Reviewed-by: Christoph Hellwig <hch@lst.de>
	Reviewed-by: Chaitanya Kulkarni <kch@nvidia.com>
	Signed-off-by: Keith Busch <kbusch@kernel.org>
(cherry picked from commit d920abd1e7c4884f9ecd0749d1921b7ab19ddfbd)
	Signed-off-by: Greg Rose <g.v.rose@ciq.com>

Builds:
`kABI check will be skipped
/home/g.v.rose/prj/kernel-build-tmp
  CLEAN   .
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   certs
  CLEAN   security/selinux
  CLEAN   usr
  CLEAN   arch/x86/tools
  CLEAN    resolve_btfids
  CLEAN   .tmp_versions
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated
  CLEAN   .config .config.old
[TIMER]{MRPROPER}: 5s
x86_64 architecture detected, copying config
'configs/kernel-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-debug-branch"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h

[SNIP]

  INSTALL sound/usb/misc/snd-ua101.ko
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-debug-branch+
[TIMER]{MODULES}: 43s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-debug-branch+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 14s
Checking kABI
kABI check skipped
Setting Default Kernel to /boot/vmlinuz-4.18.0-debug-branch+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 2049s
[TIMER]{MODULES}: 43s
[TIMER]{INSTALL}: 14s
[TIMER]{TOTAL} 2115s
Rebooting in 10 seconds
`
Boots:
[g.v.rose@rocky8_8_base-lts-rt ~]$ uname -a
Linux rocky8_8_base-lts-rt 4.18.0-debug-branch+ #1 SMP PREEMPT_RT Tue Nov 26 16:15:32 EST 2024 x86_64 x86_64 x86_64 GNU/Linux

The RT kernel does not have a kABI stability list due to the still in-development nature of RT at pre-9.4/6.12 integration into the main code base so the kABI check skipped.

The kernel selftests from before and after the change show no issues:
[kernel-selftests-before.log](https://github.com/user-attachments/files/17926225/kernel-selftests-before.log)
[kernel-selftests-after.log](https://github.com/user-attachments/files/17926230/kernel-selftests-after.log)

I ran the kernel selftests with lockdep and kmemleak on and found no reported issues - a couple of tests fail with lockdep / kmemleak enabled that do not seem related to our change.  We don't have time to investigate test failures not related to our changes.
[kernel-selftests-ldpon.log](https://github.com/user-attachments/files/17926241/kernel-selftests-ldpon.log)

It's a fairly straightforward patch in the same vein of others in the CVE-2023-5178 series.