### PR TITLE
Fix for CVE-2023-5178 kernel-rt lts-9.2 VULN-6746

### DIFF
--- a/.github/workflows/process-git-request.rb
+++ b/.github/workflows/process-git-request.rb
@@ -1,6 +1,6 @@
 require 'open3'
 
-requestors = { "gvrose8192" => "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" }
+requestors = { "gvrose8192" => "" }
 
 def file_prepend(file, str)
   new_contents = ""

--- a/drivers/nvme/target/tcp.c
+++ b/drivers/nvme/target/tcp.c
@@ -346,6 +346,7 @@ static void nvmet_tcp_fatal_error(struct nvmet_tcp_queue *queue)
 
 static void nvmet_tcp_socket_error(struct nvmet_tcp_queue *queue, int status)
 {
+	queue->rcv_state = NVMET_TCP_RECV_ERR;
 	if (status == -EPIPE || status == -ECONNRESET)
 		kernel_sock_shutdown(queue->sock, SHUT_RDWR);
 	else
@@ -872,15 +873,11 @@ static int nvmet_tcp_handle_icreq(struct nvmet_tcp_queue *queue)
 	iov.iov_len = sizeof(*icresp);
 	ret = kernel_sendmsg(queue->sock, &msg, &iov, 1, iov.iov_len);
 	if (ret < 0)
-		goto free_crypto;
+		return ret; /* queue removal will cleanup */
 
 	queue->state = NVMET_TCP_Q_LIVE;
 	nvmet_prepare_receive_pdu(queue);
 	return 0;
-free_crypto:
-	if (queue->hdr_digest || queue->data_digest)
-		nvmet_tcp_free_crypto(queue);
-	return ret;
 }
 
 static void nvmet_tcp_handle_req_failure(struct nvmet_tcp_queue *queue,


### PR DESCRIPTION
This patch fixes CVE-2023-5178 kernel-rt lts-9.2.

## Commit
```
nvmet-tcp: Fix a possible UAF in queue intialization setup
jira VULN-6746
cve https://github.com/advisories/GHSA-xr9j-c7v6-7542
commit-author Sagi Grimberg <sagi@grimberg.me>
commit https://github.com/ctrliq/kernel-src-tree/commit/d920abd1e7c4884f9ecd0749d1921b7ab19ddfbd

From Alon:
"Due to a logical bug in the NVMe-oF/TCP subsystem in the Linux kernel,
a malicious user can cause a UAF and a double free, which may lead to
RCE (may also lead to an LPE in case the attacker already has local
privileges)."

Hence, when a queue initialization fails after the ahash requests are
allocated, it is guaranteed that the queue removal async work will be
called, hence leave the deallocation to the queue removal.

Also, be extra careful not to continue processing the socket, so set
queue rcv_state to NVMET_TCP_RECV_ERR upon a socket error.
```

## Builds and installs:

kABI check will be skipped

```
/home/g.v.rose/prj/kernel-build-tmp
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr/include
  CLEAN   usr
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/tools
  CLEAN   vmlinux.symvers modules-only.symvers modules.builtin modules.builtin.modinfo
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 15s
x86_64 architecture detected, copying config
'configs/kernel-5.14.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-debug-branch"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  
[SNIP]

  STRIP   /lib/modules/5.14.0-debug-branch+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-debug-branch+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-debug-branch+
[TIMER]{MODULES}: 72s
Making Install
sh ./arch/x86/boot/install.sh \
        5.14.0-debug-branch+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 22s
Checking kABI
kABI check skipped
Setting Default Kernel to /boot/vmlinuz-5.14.0-debug-branch+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 15s
[TIMER]{BUILD}: 993s
[TIMER]{MODULES}: 72s
[TIMER]{INSTALL}: 22s
[TIMER]{TOTAL} 1112s
Rebooting in 10 seconds
```

Note that the kABI check is skipped for this RT kernel.  The RT kernel does not have a stable kABI and so we skip the check in this case.

## boots:
```
[g.v.rose@rocky92-lts-rt kernel-build-tmp]$ uname -a
Linux rocky92-lts-rt 5.14.0-debug-branch+ #1 SMP PREEMPT_RT Mon Dec 2 15:27:11 PST 2024 x86_64 x86_64 x86_64 GNU/Linux
```

## Before and after kernel selftest logs:
[kernel-selftests-before.log](https://github.com/user-attachments/files/17985280/kernel-selftests-before.log)
[kernel-selftests-after.log](https://github.com/user-attachments/files/17985281/kernel-selftests-after.log)

```
Interestingly - the after change tests consistently showed this improvement:
 ok 2 selftests: breakpoints: breakpoint_test
 ok 1 selftests: capabilities: test_execve
 ok 3 selftests: cgroup: test_core
+ok 4 selftests: cgroup: test_freezer
 ok 5 selftests: cgroup: test_kill
 ok 6 selftests: cgroup: test_stress.sh
 ok 7 selftests: cgroup: test_cpuset_prs.sh
@@ -54,6 +55,7 @@ ok 23 selftests: kvm: svm_int_ctl_test # SKIP
 ok 24 selftests: kvm: svm_nested_soft_inject_test # SKIP
 ok 25 selftests: kvm: tsc_scaling_sync # SKIP
 ok 26 selftests: kvm: sync_regs_test
+ok 27 selftests: kvm: ucna_injection_test
 ok 28 selftests: kvm: userspace_io_test
 ok 29 selftests: kvm: userspace_msr_exit_test
 ok 30 selftests: kvm: vmx_apic_access_test
```
I have no way to show that the change we made has contributed to two extra tests succeeding and do not have the time to track down why that may be the case, nevertheless the after change tests show a consistent improvement in two kernel selftest cases.

The kernel selftests were run with lockdep and kmemleak debugging enabled.  No significant issues result, a few tests fail because lockdep / kmemleak / RT enabled.  They fail either way with or without this change.

[kernel-selftests-ldpon.log](https://github.com/user-attachments/files/17985354/kernel-selftests-ldpon.log)

In general, this patch is comparable to others in the series of patches to lts and rt kernels for CVE-2023-5178.