### PR TITLE
CVE-2023-2163 kernel lts-9.2 fix

### DIFF
--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -2645,6 +2645,21 @@ static int backtrack_insn(struct bpf_verifier_env *env, int idx,
 			}
 		} else if (opcode == BPF_EXIT) {
 			return -ENOTSUPP;
+		} else if (BPF_SRC(insn->code) == BPF_X) {
+			if (!(*reg_mask & (dreg | sreg)))
+				return 0;
+			/* dreg <cond> sreg
+			 * Both dreg and sreg need precision before
+			 * this insn. If only sreg was marked precise
+			 * before it would be equally necessary to
+			 * propagate it to dreg.
+			 */
+			*reg_mask |= (sreg | dreg);
+			 /* else dreg <cond> K
+			  * Only dreg still needs precision before
+			  * this insn, so for the K-based conditional
+			  * there is nothing new to be marked.
+			  */
 		}
 	} else if (class == BPF_LD) {
 		if (!(*reg_mask & dreg))


### PR DESCRIPTION
jira VULN-6350
cve CVE-2023-2163

The commit description is too long to practically fit into this PR description.  See the attached original commit for the full commit description.

Builds and installs:
```
/home/g.v.rose/prj/kernel-build-tmp
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-5.14.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-gvrose_ciqlts9_2"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h

[SNIP]

  INSTALL /lib/modules/5.14.0-gvrose_ciqlts9_2+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-gvrose_ciqlts9_2+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-gvrose_ciqlts9_2+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-gvrose_ciqlts9_2+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-gvrose_ciqlts9_2+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-gvrose_ciqlts9_2+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-gvrose_ciqlts9_2+
[TIMER]{MODULES}: 119s
Making Install
sh ./arch/x86/boot/install.sh \
        5.14.0-gvrose_ciqlts9_2+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 23s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-gvrose_ciqlts9_2+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1130s
[TIMER]{MODULES}: 119s
[TIMER]{INSTALL}: 23s
[TIMER]{TOTAL} 1282s
Rebooting in 10 seconds
```
The standard kernel selftests - before and after logs show no problems.
[kernel-selftests-before.log](https://github.com/user-attachments/files/18030620/kernel-selftests-before.log)
[kernel-selftests-after.log](https://github.com/user-attachments/files/18030624/kernel-selftests-after.log)

During the kernel selftests I noticed that the bpf tests were not run and since this change hits the bpf verifier it is important that we get that code coverage.  TBH I'm not sure why the bpf tests don't run from the root kernel directory like most, but probably some issue with the 9.2 kernel selftests that has since been fixed.  I was able to get the kernel bpf selftests to run by changing to the bpf selftest directory and running the tests manually from there.  The before and after bpf test logs are attached here, there is no difference.

[bpf-selftest-before.log](https://github.com/user-attachments/files/18030650/bpf-selftest-before.log)
[bpf-selftest-after.log](https://github.com/user-attachments/files/18030654/bpf-selftest-after.log)

An error occurs during both of the bpf before and after tests.
[bpf-error.log](https://github.com/user-attachments/files/18031010/bpf-error.log)


Since this issue exists previously we will  not spend  time debugging it due to limited resources and scope.

The kernel selftests run with lockdep and kmemleak showed no unusual results - lockdep always seems to introduce a few failures into the kernel selftests.

[Uploading kernel-selftests-ldpon.log…]()


This fix is already introduced by our old friend Ronnie into fips 8 here: https://ciqinc.atlassian.net/browse/VULN-6349
It should be pretty safe.