### PR TITLE
Fix CVE-2023-2163 for VULN-3181 and enable github workflows

### DIFF
--- a/.github/workflows/diffdiff.py
+++ b/.github/workflows/diffdiff.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# coding: utf-8
+#
+
+import argparse
+import copy
+import difflib
+import io
+import git
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+verbose = False
+
+
+def get_upstream_commit(upstream, c):
+    for l in c.message.splitlines():
+        try:
+            sha = re.match('\s*commit\s+(?P<sha>\S+)', l).groups()[0].upper()
+            return upstream.commit(sha)
+        except:
+            True
+
+def get_diff(d):
+    dif = ''
+    df = False
+    for l in d.splitlines():
+        if l[:10] == 'diff --git':
+            df = True
+        if not df:
+            continue
+        dif = dif + l + '\n'
+    return dif
+
+
+def trim_unchanged_files(lines):
+    dl = []
+    ld = 0       # Last line with a 'diff --git' we saw
+    hd = False   # Have we seen a changed line since ld?
+    i = 0
+    for i, l in enumerate(lines):
+        if l[:4] == '+++ ' or l[:4] == '--- ' :
+            continue
+        if l[0] == '+' or l[0] == '-':
+            hd = True
+        if l[:11] == ' diff --git':
+            if ld:   # We are at a new diff now, last one started at 'ld'
+                if not hd:
+                    dl.insert(0, (ld, i+1),)
+            ld = i
+            hd = False # Reset hasdiff to False as we start a new section
+    # and check the tail
+    if not hd:
+        dl.insert(0, (ld, i+1),)
+    # delete the unchanged file sections
+    for d in dl:
+        del lines[d[0]:d[1]]
+    return lines
+
+            
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', action='store_true', help='Verbose')
+    parser.add_argument('--colour', action='store_true', help='Colorize the diff. Green for additions, red for deletions')
+    parser.add_argument('--commit', help='Commit in current tree to diffdiff. Default is the most recent commit.')
+    parser.add_argument('--upstream', help='A directory that contains the current upstream of linus kernel tree where we can find the commits we reference. Default is the current repo')
+    args = parser.parse_args()
+
+
+    if args.v:
+        verbose = True
+
+    srcgit = git.Repo.init('.')
+    upstream = git.Repo.init(args.upstream)
+    c = srcgit.head.commit if not args.commit else srcgit.commit(args.commit)
+    uc = get_upstream_commit(upstream, c)
+
+    dc = get_diff(srcgit.git.show(c))
+    duc = get_diff(upstream.git.show(uc))
+
+    with open('c.diff', 'w') as f:
+        f.write(dc)
+    with open('u.diff', 'w') as f:
+        f.write(duc)
+        
+    res = subprocess.run(['diff', '-u', 'u.diff', 'c.diff'],
+                         check=False, stdout=subprocess.PIPE)
+    lines = res.stdout.splitlines()
+    dd = []
+    for l in lines:
+        l = str(l)[2:-1]
+        if l[:6] == '-index':
+            continue
+        if l[:6] == '+index':
+            continue
+        if l[:3] == '-@@':
+            continue
+        if l[:3] == '+@@':
+            dd.append(' ' + l[1:])
+            continue
+        dd.append(l)
+
+    # trim diffs for files that did not change
+    lines = trim_unchanged_files(dd)
+
+    # colorize the diff
+    diffs = 0
+    if args.colour:
+        dd = []
+        for l in lines:
+            if l[0:4] != '+++ ' and l[0:4] != '--- ':
+                if l[0] == '+':
+                    l = '\033[42m' + l + '\033[0m'
+                    diffs = diffs + 1
+                if l[0] == '-':
+                    l = '\033[41m' + l + '\033[0m'
+                    diffs = diffs + 1
+            dd.append(l)
+        lines = dd
+
+
+    if diffs:
+        for l in lines:
+            print(l)
+
+    sys.exit(diffs)

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Sanity Check
+run-name: ${{ github.actor }} is running actions - this runs as a sanity check 🚀
+on:
+  push:
+    branches:
+      - '**'
+      - '!mainline'
+
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code        
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+          df .
+          df /
+          pwd
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/process-git-request.rb
+++ b/.github/workflows/process-git-request.rb
@@ -1,0 +1,140 @@
+require 'open3'
+
+requestors = { "gvrose8192" => "" }
+
+def file_prepend(file, str)
+  new_contents = ""
+  File.open(file, 'r') do |fd|
+    contents = fd.read
+    new_contents = str << contents
+  end
+  # Overwrite file but now with prepended string on it
+  File.open(file, 'w') do |fd| 
+    fd.write(new_contents)
+  end
+end
+
+def process_git_request(fname, target_branch, source_branch, prj_dir)
+  retcode = 200 #presume success
+#  puts "Opening file " + fname
+  file = File.new(fname, "w")
+  working_dir = prj_dir
+#  puts "Working Dir : " + working_dir
+  Dir.chdir working_dir
+#  puts "pwd : " + Dir.pwd
+  git_cmd = "git log --oneline --no-abbrev-commit origin/" + target_branch + ".." + "origin/" + source_branch
+#  puts git_cmd
+  out, err, status = Open3.capture3(git_cmd)
+  if status.exitstatus != 0
+    puts "Command error output is " + err
+    file.write("Command error output is " + err)
+    file.close
+    retcode = 201
+    return retcode
+  end
+  output_lines = out.split(' ')
+# we just want the commit sha IDs
+  output_lines.each { |x|
+#    puts "This is output_lines " + x
+    upstream_diff = false
+    if !x[/\H/]
+      if x.length < 40
+        next
+      end
+      git_cmd = "git show " + x
+      gitlog_out, gitlog_err, gitlog_status = Open3.capture3(git_cmd)
+      if gitlog_status.exitstatus != 0
+        file.write("git show command error output is " + gitlog_err)
+        retcode = 201
+      end
+      loglines = gitlog_out.lines.map(&:chomp)
+      lines_counted = 0
+      local_diffdiff_sha = ""
+      upstream_diffdiff_sha = ""
+      loglines.each { |logline|
+        lines_counted = lines_counted + 1
+        if lines_counted == 1
+            local_commit_sha = logline.match("[0-9a-f]\{40\}")
+            local_diffdiff_sha = local_commit_sha.to_s
+#            puts "Local : " + local_diffdiff_sha
+            file.write("Merge Request sha: " + local_diffdiff_sha)
+            file.write("\n")
+        end
+        if lines_counted == 2 #email address
+          if !logline.downcase.include? "ciq.com"
+            # Bad Author
+            s = "error:\nBad " + logline + "\n"
+            puts s
+            file.write(s)
+            retcode = 201
+          else
+            file.write("\t" + logline + "\n")
+          end
+        end
+        if lines_counted > 1
+          if logline.downcase.include? "jira"
+            file.write("\t" + logline + "\n")
+          end
+          if logline.downcase.include? "upstream-diff"
+            upstream_diff = true
+          end
+          if logline.downcase.include? "commit"
+            commit_sha = logline.match("[0-9a-f]\{40\}")
+            upstream_diffdiff_sha = commit_sha.to_s
+#            puts "Upstream : " + upstream_diffdiff_sha
+            if (!upstream_diffdiff_sha.empty?)
+              file.write("\tUpstream sha: " + upstream_diffdiff_sha)
+              file.write("\n")
+            end
+          end
+        end
+        if lines_counted > 8 #Everything we need should be in the first 8 lines
+          break
+        end
+      }
+      if !local_diffdiff_sha.empty? &&  !upstream_diffdiff_sha.empty?
+        diff_cmd = Dir.pwd + "/.github/workflows/diffdiff.py --colour --commit " + local_diffdiff_sha
+        puts "diffdiff: " + diff_cmd
+        diff_out, diff_err, diff_status = Open3.capture3(diff_cmd)
+        if diff_status.exitstatus != 0 && !upstream_diff
+          puts "diffdiff out: " + diff_out
+          puts "diffdiff err: " + diff_err
+          retcode = 201
+          file.write("error:\nCommit: " + local_diffdiff_sha + " differs with no upstream tag in commit message\n")
+        end
+      end
+    end
+  }
+  file.close
+  return retcode
+end
+
+first_arg,  *argv_in = ARGV
+if argv_in.length < 5
+  puts "Not enough arguments: fname, target_branch, source_branch, prj_dir, pull_request, requestor"
+  exit
+end
+fname = first_arg.to_s
+fname = "tmp-" + fname
+# puts "filename is " + fname
+target_branch  = argv_in[0].to_s
+# puts "target branch is " + target_branch
+source_branch = argv_in[1].to_s
+# puts "source branch is " + source_branch
+prj_dir = argv_in[2].to_s
+# puts "project dir is "  + prj_dir
+pullreq = argv_in[3].to_s
+# puts "pull request is " + pullreq
+requestor = argv_in[4].to_s
+retcode = process_git_request(fname, target_branch, source_branch, prj_dir)
+if retcode != 200
+  File.open(fname, 'r') do |fd|
+    contents = fd.read
+    puts contents
+  end
+  exit(1)
+else
+  puts "Done"
+end
+exit(0)
+

--- a/.github/workflows/process-pull-request.yml
+++ b/.github/workflows/process-pull-request.yml
@@ -1,0 +1,54 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Pull Request Checker
+
+on:
+  pull_request:
+    branches:
+      - '**'
+      - '!mainline'    
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.0']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+    # uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Set up Python
+      uses: actions/setup-python@v5
+    - name: Run tests
+      run: |
+        /usr/bin/pip3 install gitPython
+        python -c "import sys; import git; print(sys.version)"
+        git fetch origin ${{ github.base_ref }}
+        git fetch origin ${{ github.head_ref }}
+        git remote add linux https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+        git fetch --shallow-since="3 years ago" linux
+        echo "Will run process-git-request.rb with:"
+        echo "fname = ${{ github.run_id }}"
+        echo "target_branch = ${{ github.base_ref }}"
+        echo "source_branch = ${{ github.head_ref }}"
+        echo "prj_dir = ${{ github.workspace }}"
+        echo "pull_request = ${{ github.ref }}"
+        echo "requestor = ${{ github.actor }}"
+        cd ${{ github.workspace }}
+        /usr/bin/ruby .github/workflows/process-git-request.rb ${{ github.run_id }} ${{ github.base_ref }} \
+        ${{ github.head_ref }} ${{ github.workspace }} ${{ github.ref }} ${{ github.actor }} 

--- a/.github/workflows/push-check_x86_64.yml
+++ b/.github/workflows/push-check_x86_64.yml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  push:
+    branches:
+      - '**'
+      - '!mainline'
+
+jobs:
+  kernel-build-job:
+    runs-on:
+      labels: kernel-build
+    container:
+      image: rockylinux:8
+      env:
+        ROCKY_ENV: rocky8
+      ports:
+        - 80
+      options: --cpus 8
+    steps:
+      - name: Install tools and Libraries
+        run: |
+          dnf groupinstall 'Development Tools' -y
+          dnf install --enablerepo=devel bc dwarves kernel-devel openssl-devel elfutils-libelf-devel -y
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build the Kernel
+        run: |
+          git config --global --add safe.directory /__w/kernel-src-git/kernel-src-git
+          cp configs/kernel-4.18.0-x86_64.config .config
+          make olddefconfig
+          make -j8

--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -2224,6 +2224,21 @@ static int backtrack_insn(struct bpf_verifier_env *env, int idx,
 			}
 		} else if (opcode == BPF_EXIT) {
 			return -ENOTSUPP;
+		} else if (BPF_SRC(insn->code) == BPF_X) {
+			if (!(*reg_mask & (dreg | sreg)))
+				return 0;
+			/* dreg <cond> sreg
+			 * Both dreg and sreg need precision before
+			 * this insn. If only sreg was marked precise
+			 * before it would be equally necessary to
+			 * propagate it to dreg.
+			 */
+			*reg_mask |= (sreg | dreg);
+			 /* else dreg <cond> K
+			  * Only dreg still needs precision before
+			  * this insn, so for the K-based conditional
+			  * there is nothing new to be marked.
+			  */
 		}
 	} else if (class == BPF_LD) {
 		if (!(*reg_mask & dreg))


### PR DESCRIPTION
A) Install and enable the standard set of github workflows that we use for our other lts branches - pretty straightforward.

B) Address the fix for CVE-2023-2163

Builds and installs:
```
`/home/g.v.rose/prj/kernel-build-tmp
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-gvrose_ciqlts8_8"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h`

[SNIP]

`  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-gvrose_ciqlts8_8+
[TIMER]{MODULES}: 145s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-gvrose_ciqlts8_8+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 20s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-gvrose_ciqlts8_8+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1069s
[TIMER]{MODULES}: 145s
[TIMER]{INSTALL}: 20s
[TIMER]{TOTAL} 1243s
Rebooting in 10 seconds
```

Boots:
```
`[g.v.rose@rocky8-8-lts-VULN-3181 ~]$ uname -a
Linux rocky8-8-lts-VULN-3181 4.18.0-debug-branch+ #3 SMP Mon Dec 9 12:39:27 EST 2024 x86_64 x86_64 x86_64 GNU/Linux
```

Before and after kernel selftest logs show nothing interesting:
[kernel-selftests-before.log](https://github.com/user-attachments/files/18068141/kernel-selftests-before.log)
[kernel-selftests-after.log](https://github.com/user-attachments/files/18068142/kernel-selftests-after.log)

No additional erros in the lockdep and kmemleak enabled testing:
[kernel-selftests-ldpon.log](https://github.com/user-attachments/files/18068155/kernel-selftests-ldpon.log)

The LTS 8.8 branch needs the same fix for bpf kernel selftest as 9.2 - I let Brett know.
