### PR TITLE
[lts8.8] selftests/bpf: Fix pyperf180 compilation failure with clang18

### DIFF
--- a/tools/testing/selftests/bpf/progs/pyperf180.c
+++ b/tools/testing/selftests/bpf/progs/pyperf180.c
@@ -1,4 +1,26 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2019 Facebook
 #define STACK_MAX_LEN 180
+
+/* llvm upstream commit at clang18
+ *   https://github.com/llvm/llvm-project/commit/1a2e77cf9e11dbf56b5720c607313a566eebb16e
+ * changed inlining behavior and caused compilation failure as some branch
+ * target distance exceeded 16bit representation which is the maximum for
+ * cpu v1/v2/v3. Macro __BPF_CPU_VERSION__ is later implemented in clang18
+ * to specify which cpu version is used for compilation. So a smaller
+ * unroll_count can be set if __BPF_CPU_VERSION__ is less than 4, which
+ * reduced some branch target distances and resolved the compilation failure.
+ *
+ * To capture the case where a developer/ci uses clang18 but the corresponding
+ * repo checkpoint does not have __BPF_CPU_VERSION__, a smaller unroll_count
+ * will be set as well to prevent potential compilation failures.
+ */
+#ifdef __BPF_CPU_VERSION__
+#if __BPF_CPU_VERSION__ < 4
+#define UNROLL_COUNT 90
+#endif
+#elif __clang_major__ == 18
+#define UNROLL_COUNT 90
+#endif
+
 #include "pyperf.h"


### PR DESCRIPTION
jira LE-2125

Running bpf selftests can result in the fatal error below with certain CPU and LLVM version combinations:

```
CLNG-BPF [test_maps] pyperf180.o
fatal error: error in backend: Branch target out of insn range
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.      Program arguments: clang -g -Werror -D__TARGET_ARCH_x86 -mlittle-endian -I/home/g.v.rose/prj/kernel-build-tmp/tools/testing/selftests/bpf/tools/include -I/home/g.v.rose/prj/kernel-build-tmp/tools/testing/selftests/bpf -I/home/g.v.rose/prj/kernel-build-tmp/tools/include/uapi -I/home/g.v.rose/prj/kernel-build-tmp/tools/testing/selftests/usr/include -idirafter /usr/bin/../lib/clang/18/include -idirafter /usr/local/include -idirafter /usr/include -Wno-compare-distinct-pointer-types -DENABLE_ATOMICS_TESTS -O2 -target bpf -c progs/pyperf180.c -mcpu=v3 -o /home/g.v.rose/prj/kernel-build-tmp/tools/testing/selftests/bpf/pyperf180.o
1.      <eof> parser at end of file
2.      Code generation
 #0 0x00007ff275cfdcba llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/lib64/libLLVM.so.18.1+0x8fdcba)
 #1 0x00007ff275cfb464 llvm::sys::RunSignalHandlers() (/lib64/libLLVM.so.18.1+0x8fb464)
 #2 0x00007ff275c2d2a2 (/lib64/libLLVM.so.18.1+0x82d2a2)
 #3 0x00007ff275c2d25f (/lib64/libLLVM.so.18.1+0x82d25f)
 #4 0x00007ff275cf792d (/lib64/libLLVM.so.18.1+0x8f792d)
 #5 0x0000000000213717 (/usr/bin/clang-18+0x213717)
 #6 0x00007ff275c3ebd7 llvm::report_fatal_error(llvm::Twine const&, bool) (/lib64/libLLVM.so.18.1+0x83ebd7)
 #7 0x00007ff275c3ea9a (/lib64/libLLVM.so.18.1+0x83ea9a)
 #8 0x00007ff278e95ca1 (/lib64/libLLVM.so.18.1+0x3a95ca1)
 #9 0x00007ff2776c1ab1 llvm::MCAssembler::layout(llvm::MCAsmLayout&) (/lib64/libLLVM.so.18.1+0x22c1ab1)
#10 0x00007ff2776c1d4b llvm::MCAssembler::Finish() (/lib64/libLLVM.so.18.1+0x22c1d4b)
#11 0x00007ff2776e4bda llvm::MCELFStreamer::finishImpl() (/lib64/libLLVM.so.18.1+0x22e4bda)
#12 0x00007ff276727dab llvm::AsmPrinter::doFinalization(llvm::Module&) (/lib64/libLLVM.so.18.1+0x1327dab)
#13 0x00007ff275e8a4c1 llvm::FPPassManager::doFinalization(llvm::Module&) (/lib64/libLLVM.so.18.1+0xa8a4c1)
#14 0x00007ff275e83e11 llvm::legacy::PassManagerImpl::run(llvm::Module&) (/lib64/libLLVM.so.18.1+0xa83e11)
#15 0x00007ff27e19520b clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::StringRef, llvm::Module*, clang::BackendAction, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>, std::unique_ptr<llvm::raw_pwrite_stream, std::default_delete<llvm::raw_pwrite_stream>>, clang::BackendConsumer*) (/lib64/libclang-cpp.so.18.1+0x279520b)
#16 0x00007ff27e593680 clang::BackendConsumer::HandleTranslationUnit(clang::ASTContext&) (/lib64/libclang-cpp.so.18.1+0x2b93680)
#17 0x00007ff27ced4cd6 clang::ParseAST(clang::Sema&, bool, bool) (/lib64/libclang-cpp.so.18.1+0x14d4cd6)
#18 0x00007ff27f15ade6 clang::FrontendAction::Execute() (/lib64/libclang-cpp.so.18.1+0x375ade6)
#19 0x00007ff27f0d2210 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/lib64/libclang-cpp.so.18.1+0x36d2210)
#20 0x00007ff27f1d938e clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/lib64/libclang-cpp.so.18.1+0x37d938e)
#21 0x0000000000213486 cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/usr/bin/clang-18+0x213486)
#22 0x00000000002100d4 (/usr/bin/clang-18+0x2100d4)
#23 0x00007ff27ecff5dd (/lib64/libclang-cpp.so.18.1+0x32ff5dd)
#24 0x00007ff275c2d234 llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) (/lib64/libLLVM.so.18.1+0x82d234)
#25 0x00007ff27ecff197 clang::driver::CC1Command::Execute(llvm::ArrayRef<std::optional<llvm::StringRef>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>*, bool*) const (/lib64/libclang-cpp.so.18.1+0x32ff197)
#26 0x00007ff27ecc4b97 clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&, bool) const (/lib64/libclang-cpp.so.18.1+0x32c4b97)
#27 0x00007ff27ecc4df7 clang::driver::Compilation::ExecuteJobs(clang::driver::JobList const&, llvm::SmallVectorImpl<std::pair<int, clang::driver::Command const*>>&, bool) const (/lib64/libclang-cpp.so.18.1+0x32c4df7)
#28 0x00007ff27ece2eae clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::pair<int, clang::driver::Command const*>>&) (/lib64/libclang-cpp.so.18.1+0x32e2eae)
#29 0x000000000020f930 clang_main(int, char**, llvm::ToolContext const&) (/usr/bin/clang-18+0x20f930)
#30 0x000000000021d76a main (/usr/bin/clang-18+0x21d76a)
#31 0x00007ff274c295d0 __libc_start_call_main (/lib64/libc.so.6+0x295d0)
#32 0x00007ff274c29680 __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x29680)
#33 0x000000000020c835 _start (/usr/bin/clang-18+0x20c835)
clang: error: clang frontend command failed with exit code 70 (use -v to see invocation)
clang version 18.1.8 (RESF 18.1.8-3.el9)
Target: bpf
Thread model: posix
InstalledDir: /bin
clang: note: diagnostic msg:
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang: note: diagnostic msg: /tmp/pyperf180-99665f.c
clang: note: diagnostic msg: /tmp/pyperf180-99665f.sh
clang: note: diagnostic msg:

********************
make: *** [Makefile:526: /home/g.v.rose/prj/kernel-build-tmp/tools/testing/selftests/bpf/pyperf180.o] Error 1
```

This PR backports the following upstream fix for this situation:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/tools/testing/selftests/bpf/progs/pyperf180.c?h=v6.13-rc1&id=100888fb6d8a185866b1520031ee7e3182b173de

Below are logs from running bpf selftests before and after the fix:
[bpf_selftests_88-before.log](https://github.com/user-attachments/files/18130153/bpf_selftests_88-before.log)
[bpf_selftests_88-after.log](https://github.com/user-attachments/files/18130157/bpf_selftests_88-after.log)
