### PR TITLE
[sig-cloud-9] 5.14.0-503.19.1.el9_5 update Customer Patches

### DIFF
--- a/arch/x86/include/asm/page_64.h
+++ b/arch/x86/include/asm/page_64.h
@@ -17,6 +17,7 @@ extern unsigned long phys_base;
 extern unsigned long page_offset_base;
 extern unsigned long vmalloc_base;
 extern unsigned long vmemmap_base;
+extern unsigned long physmem_end;
 
 static __always_inline unsigned long __phys_addr_nodebug(unsigned long x)
 {

--- a/arch/x86/include/asm/pgtable_64_types.h
+++ b/arch/x86/include/asm/pgtable_64_types.h
@@ -140,6 +140,10 @@ extern unsigned int ptrs_per_p4d;
 # define VMEMMAP_START		__VMEMMAP_BASE_L4
 #endif /* CONFIG_DYNAMIC_MEMORY_LAYOUT */
 
+#ifdef CONFIG_RANDOMIZE_MEMORY
+# define PHYSMEM_END		physmem_end
+#endif
+
 /*
  * End of the region for which vmalloc page tables are pre-allocated.
  * For non-KMSAN builds, this is the same as VMALLOC_END.

--- a/arch/x86/mm/init_64.c
+++ b/arch/x86/mm/init_64.c
@@ -950,7 +950,11 @@ static void update_end_of_memory_vars(u64 start, u64 size)
 int add_pages(int nid, unsigned long start_pfn, unsigned long nr_pages,
 	      struct mhp_params *params)
 {
+	unsigned long end = ((start_pfn + nr_pages) << PAGE_SHIFT) - 1;
 	int ret;
+
+	if (WARN_ON_ONCE(end > PHYSMEM_END))
+		return -ERANGE;
 
 	ret = __add_pages(nid, start_pfn, nr_pages, params);
 	WARN_ON_ONCE(ret);

--- a/arch/x86/mm/kaslr.c
+++ b/arch/x86/mm/kaslr.c
@@ -47,12 +47,23 @@ static const unsigned long vaddr_end = CPU_ENTRY_AREA_BASE;
  */
 static __initdata struct kaslr_memory_region {
 	unsigned long *base;
+	unsigned long *end;
 	unsigned long size_tb;
 } kaslr_regions[] = {
-	{ &page_offset_base, 0 },
-	{ &vmalloc_base, 0 },
-	{ &vmemmap_base, 0 },
+	{
+		.base	= &page_offset_base,
+		.end	= &physmem_end,
+	},
+	{
+		.base	= &vmalloc_base,
+	},
+	{
+		.base	= &vmemmap_base,
+	},
 };
+
+/* The end of the possible address space for physical memory */
+unsigned long physmem_end __ro_after_init;
 
 /* Get size in bytes used by the memory region */
 static inline unsigned long get_padding(struct kaslr_memory_region *region)
@@ -82,6 +93,8 @@ void __init kernel_randomize_memory(void)
 	BUILD_BUG_ON(vaddr_end != CPU_ENTRY_AREA_BASE);
 	BUILD_BUG_ON(vaddr_end > __START_KERNEL_map);
 
+	/* Preset the end of the possible address space for physical memory */
+	physmem_end = ((1ULL << MAX_PHYSMEM_BITS) - 1);
 	if (!kaslr_memory_enabled())
 		return;
 
@@ -128,11 +141,18 @@ void __init kernel_randomize_memory(void)
 		vaddr += entropy;
 		*kaslr_regions[i].base = vaddr;
 
-		/*
-		 * Jump the region and add a minimum padding based on
-		 * randomization alignment.
-		 */
+		/* Calculate the end of the region */
 		vaddr += get_padding(&kaslr_regions[i]);
+		/*
+		 * KASLR trims the maximum possible size of the
+		 * direct-map. Update the physmem_end boundary.
+		 * No rounding required as the region starts
+		 * PUD aligned and size is in units of TB.
+		 */
+		if (kaslr_regions[i].end)
+			*kaslr_regions[i].end = __pa_nodebug(vaddr - 1);
+
+		/* Add a minimum padding based on randomization alignment. */
 		vaddr = round_up(vaddr + 1, PUD_SIZE);
 		remain_entropy -= entropy;
 	}

--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -95,6 +95,10 @@ extern const int mmap_rnd_compat_bits_max;
 extern int mmap_rnd_compat_bits __read_mostly;
 #endif
 
+#ifndef PHYSMEM_END
+# define PHYSMEM_END	((1ULL << MAX_PHYSMEM_BITS) - 1)
+#endif
+
 #include <asm/page.h>
 #include <asm/processor.h>
 

--- a/kernel/resource.c
+++ b/kernel/resource.c
@@ -1806,8 +1806,7 @@ static resource_size_t gfr_start(struct resource *base, resource_size_t size,
 	if (flags & GFR_DESCENDING) {
 		resource_size_t end;
 
-		end = min_t(resource_size_t, base->end,
-			    (1ULL << MAX_PHYSMEM_BITS) - 1);
+		end = min_t(resource_size_t, base->end, PHYSMEM_END);
 		return end - size + 1;
 	}
 
@@ -1824,8 +1823,7 @@ static bool gfr_continue(struct resource *base, resource_size_t addr,
 	 * @size did not wrap 0.
 	 */
 	return addr > addr - size &&
-	       addr <= min_t(resource_size_t, base->end,
-			     (1ULL << MAX_PHYSMEM_BITS) - 1);
+	       addr <= min_t(resource_size_t, base->end, PHYSMEM_END);
 }
 
 static resource_size_t gfr_next(resource_size_t addr, resource_size_t size,

--- a/mm/memory_hotplug.c
+++ b/mm/memory_hotplug.c
@@ -1706,7 +1706,7 @@ struct range __weak arch_get_mappable_range(void)
 
 struct range mhp_get_pluggable_range(bool need_mapping)
 {
-	const u64 max_phys = (1ULL << MAX_PHYSMEM_BITS) - 1;
+	const u64 max_phys = PHYSMEM_END;
 	struct range mhp_range;
 
 	if (need_mapping) {

--- a/mm/sparse.c
+++ b/mm/sparse.c
@@ -129,7 +129,7 @@ static inline int sparse_early_nid(struct mem_section *section)
 static void __meminit mminit_validate_memmodel_limits(unsigned long *start_pfn,
 						unsigned long *end_pfn)
 {
-	unsigned long max_sparsemem_pfn = 1UL << (MAX_PHYSMEM_BITS-PAGE_SHIFT);
+	unsigned long max_sparsemem_pfn = (PHYSMEM_END + 1) >> PAGE_SHIFT;
 
 	/*
 	 * Sanity checks - do not allow an architecture to pass

--- a/tools/testing/selftests/mm/hmm-tests.c
+++ b/tools/testing/selftests/mm/hmm-tests.c
@@ -159,6 +159,10 @@ FIXTURE_TEARDOWN(hmm)
 {
 	int ret = close(self->fd);
 
+	if (ret != 0) {
+		fprintf(stderr, "close retunred (%d) fd is (%d)\n", ret, self->fd);
+		exit(1);
+	}
 	ASSERT_EQ(ret, 0);
 	self->fd = -1;
 }


### PR DESCRIPTION
## Upgrade process
* Branch from `centos-stream-9` for the appropriate build `5.14.0-503`
* Kernel History Rebuild Process for all `src.rpm`s hosted by RESF, https://dl.rockylinux.org/vault/rocky/9.5/BaseOS/source/tree/Packages/k/
* Create `sig-cloud-9/5.14.0-503.19.1el9_5` branch
* Check if any maintained code is included in the new `el` release.
* Cherry-pick all code from pervious branch into new branch (skipping unneeded code) 
  * Fix conflicts as they arise 
* Build and Test

## Removed Patches (included in base code from Rocky) since 9.4 `5.14.0-427.42.1`
* x86/sev-es: Allow copy_from_kernel_nofault() in earlier boot
  * Kernel.org[f79936545fb122856bd78b189d3c7ee59928c751](https://github.com/ctrliq/kernel-src-tree/commit/f79936545fb122856bd78b189d3c7ee59928c751)
  * CentOS9: kernel-5.14.0-434 https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9/-/commit/e638b8e4449ed42a5dcbce015a6b25d069969cf2

## Build (with srpmproc)
Due to some issues discovered during testing I the original `kernel-src-tree` build and test data.
I instead integrated these patches into a new `srpmproc` build to get full rpms to help deal with some of what I thought were build issues with the tests.
```
[jmaple@devbox kernel-5.14.0-503.19.1.el9_5]$ time mock -r /etc/mock/rocky+epel-9-x86_64.cfg --resultdir=RPMS --spec=SPECS/kernel.spec --sources=SOURCES/
INFO: mock.py version 5.9 starting (python version = 3.9.19, NVR = mock-5.9-1.el9), args: /usr/libexec/mock/mock -r /etc/mock/rocky+epel-9-x86_64.cfg --resultdir=RPMS --spec=SPECS/kernel.spec --sources=SOURCES/
Start(bootstrap): init plugins
INFO: selinux enabled

[SNIP]

Wrote: /builddir/build/RPMS/kernel-rt-modules-5.14.0-503.19.1.el9.x86_64.rpm
Wrote: /builddir/build/RPMS/kernel-rt-debuginfo-5.14.0-503.19.1.el9.x86_64.rpm
Wrote: /builddir/build/RPMS/kernel-debuginfo-5.14.0-503.19.1.el9.x86_64.rpm
Wrote: /builddir/build/RPMS/kernel-rt-debug-debuginfo-5.14.0-503.19.1.el9.x86_64.rpm
Wrote: /builddir/build/RPMS/kernel-debug-debuginfo-5.14.0-503.19.1.el9.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.lKlya2
+ umask 022
+ cd /builddir/build/BUILD
+ cd kernel-5.14.0-503.19.1.el9_5
+ /usr/bin/rm -rf /builddir/build/BUILDROOT/kernel-5.14.0-503.19.1.el9.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
Finish: rpmbuild kernel-5.14.0-503.19.1.el9.src.rpm
Finish: build phase for kernel-5.14.0-503.19.1.el9.src.rpm
INFO: Done(RPMS/kernel-5.14.0-503.19.1.el9.src.rpm) Config(rocky+epel-9-x86_64) 74 minutes 2 seconds
INFO: Results and/or logs in: RPMS
INFO: Cleaning up build root ('cleanup_on_success=True')
Start: clean chroot
Finish: clean chroot
Finish: run

real	74m21.353s
user	935m12.266s
sys	116m58.504s
```

## Testing (with limited HMM)
NOTE Test using the following command after making the `TARGET="m,m"` or with `kselftest` here `/usr/libexec/kselftests/mm/run_vmtests.sh -t hmm`
`./run_vmtests.sh -t hmm`
### 9.4 HMM testing
These results were consistent in the previous 9.4 release of the HMM testing
https://github.com/ctrliq/kernel-src-tree/pull/4
```
ok 53 hmm2.hmm2_device_private.double_map
#  RUN           hmm2.hmm2_device_coherent.migrate_mixed ...
#            OK  hmm2.hmm2_device_coherent.migrate_mixed
ok 54 hmm2.hmm2_device_coherent.migrate_mixed
#  RUN           hmm2.hmm2_device_coherent.snapshot ...
#            OK  hmm2.hmm2_device_coherent.snapshot
ok 55 hmm2.hmm2_device_coherent.snapshot
#  RUN           hmm2.hmm2_device_coherent.double_map ...
#            OK  hmm2.hmm2_device_coherent.double_map
ok 56 hmm2.hmm2_device_coherent.double_map
# FAILED: 53 / 56 tests passed.
# Totals: pass:51 fail:3 xfail:0 xpass:0 skip:2 error:0
[PASS]
```
### 9.5 HMM Infinite loop Testing
This requires a patch to do the testing as 3 of the tests cause infinite loops see this change: https://github.com/ctrliq/kernel-src-tree/commit/782e0aa98bc5bb9de0568d1d370024f12536e09a
```
# could not open hmm dmirror driver (/dev/hmm_dmirror2)
# #      SKIP      DEVICE_COHERENT not available
# #            OK  hmm2.hmm2_device_coherent.snapshot
# ok 55 # SKIP DEVICE_COHERENT not available
# #  RUN           hmm2.hmm2_device_coherent.double_map ...
# could not open hmm dmirror driver (/dev/hmm_dmirror2)
# #      SKIP      DEVICE_COHERENT not available
# #            OK  hmm2.hmm2_device_coherent.double_map
# ok 56 # SKIP DEVICE_COHERENT not available
# # FAILED: 53 / 56 tests passed.
# # Totals: pass:23 fail:3 xfail:0 xpass:0 skip:30 error:0
# [PASS]
```

### 9.5 SIG CLOUD BUILD (seen above)
```
could not open hmm dmirror driver (/dev/hmm_dmirror2)
#      SKIP      DEVICE_COHERENT not available
#            OK  hmm2.hmm2_device_coherent.snapshot
ok 55 # SKIP DEVICE_COHERENT not available
#  RUN           hmm2.hmm2_device_coherent.double_map ...
could not open hmm dmirror driver (/dev/hmm_dmirror2)
#      SKIP      DEVICE_COHERENT not available
#            OK  hmm2.hmm2_device_coherent.double_map
ok 56 # SKIP DEVICE_COHERENT not available
# FAILED: 53 / 56 tests passed.
# Totals: pass:23 fail:3 xfail:0 xpass:0 skip:30 error:0
[maple@r9-sigcloud-builder ~]$ uname -a
Linux r9-sigcloud-builder 5.14.0-503.19.1.el9.1.0.x86_64 #1 SMP PREEMPT_DYNAMIC Mon Dec 23 15:23:23 EST 2024 x86_64 x86_64 x86_64 GNU/Linux
```

## Reason for the tests going from 53/56 tests passed but from `skip: 2` -> `skip 30`
This is related to selftest changes not anything else
https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9/-/commit/b401f30926f83f13521a3a6f7658da8fceea0382

> Note that for hmm-tests this actually changes the result
> from pass to skip. Which seems fair, the test is skipped,
> after all.