### PR TITLE
[LTS 8.8] Bluetooth: L2CAP: Fix l2cap_global_chan_by_psm

### DIFF
--- a/net/bluetooth/l2cap_core.c
+++ b/net/bluetooth/l2cap_core.c
@@ -1960,7 +1960,7 @@ static struct l2cap_chan *l2cap_global_chan_by_psm(int state, __le16 psm,
 		if (link_type == LE_LINK && c->src_type == BDADDR_BREDR)
 			continue;
 
-		if (c->psm == psm) {
+		if (c->chan_type != L2CAP_CHAN_FIXED && c->psm == psm) {
 			int src_match, dst_match;
 			int src_any, dst_any;
 


### PR DESCRIPTION
jira VULN-206
cve CVE-2022-42896
commit-author Marcin Wcisło <marcin.wcislo@conclusive.pl>
commit f937b758a188d6fd328a81367087eddbb2fce50f


# Solution

The bug fix in the mainline is provided in two commits:

-   `f937b758a188d6fd328a81367087eddbb2fce50f`
-   `711f8c3fb3db61897080468586b970c87c61d9e4`

Of these the `711f8c3` is already applied on `ciqlts8_8`.


# Build

Kernel built on Rocky 9 machine with

    CVE=CVE-2022-42896 ./ninja.sh _compile_ciqlts8_8-CVE-2022-42896

from the <https://gitlab.conclusive.pl/devices/rocky-patching> project. This translates to the environment of [Rocky-8-GenericCloud-Base-8.8-20230518.0.x86_64.qcow2](https://download.rockylinux.org/vault/rocky/8.8/images/x86_64/Rocky-8-GenericCloud-Base-8.8-20230518.0.x86_64.qcow2) base image ran with [install_build_machine.sh](https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/master/jinja/ninja-back/install_build_machine.sh?ref_type=heads) script and customized with cloud-init user data file [user-data-ciqlts8_8.yml](https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/master/jinja/cloud-init/user-data-ciqlts8_8.yml?ref_type=heads), with the compilation itself done with [compile-kernel.sh](https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/master/src/compile-kernel.sh?ref_type=heads), [install-kernel.sh](https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/master/src/install-kernel.sh?ref_type=heads), [set-default-kernel.sh](https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/master/src/set-default-kernel.sh?ref_type=heads) scripts run in succession.


# kABI check: passed

kABI ran with

    python3 /mnt/code/kernel-dist-git/SOURCES/check-kabi \
            -k /mnt/code/kernel-dist-git/SOURCES/Module.kabi_$(uname -m) \
            -s /mnt/build_files/kernel-src-tree-ciqlts8_8-CVE-2022-42896/Module.symvers

For `/mnt/code/kernel-dist-git` repo on `el-8.8` branch (`3120f78031909f15cb48295d2de8d020fd9ec1d7`)


# Boot test: passed

[boot-test.log](https://github.com/user-attachments/files/18322053/boot-test.log)


# Kselftests (partial): passed

Kselftests ran with

    modprobe bluetooth
    /usr/libexec/kselftests/run_kselftest.sh --summary $($(echo sed $(for t in net:xfrm_policy.sh net:ip_defrag.sh net:gro.sh net/mptcp:simult_flows.sh vm:run_vmtests.sh; do echo ${t}; done | sed -e 's|/|\\/|g' | awk '{print "-e /^" $1 "$/d"}')) /usr/libexec/kselftests/kselftest-list.txt | awk '{print "--test " $1}') 2>&1 | tee summary.log

(This runs all selftests provided by `kernel-selftests-internal` package as they would be ran by 

    /usr/libexec/kselftests/run_kselftest.sh --summary

except `net:xfrm_policy.sh`, `net:ip_defrag.sh`, `net:gro.sh`, `net/mptcp:simult_flows.sh`, `vm:run_vmtests.sh`. The baseline for these tests could not have been established as the results were indeterministic. To be done)

Results:

[kselftests-ciqlts8_8-CVE-2022-42896.summary.log](https://github.com/user-attachments/files/18322099/kselftest-after-with-bluetooth-4.18.0-ciqlts8_8-CVE-2022-42896.1.summary.clean.log)
[kselftests-ciqlts8_8-CVE-2022-42896.full.log](https://github.com/user-attachments/files/18322129/kselftest-after-with-bluetooth-4.18.0-ciqlts8_8-CVE-2022-42896.1.full.log)

Reference results for the `ciqlts8_8` (`369d0f6e5`) version:

[kselftests-ciqlts8_8.summary.log](https://github.com/user-attachments/files/18322452/kselftest-before-with-bluetooth-4.18.0-ciqlts8_8.4.summary.clean.log)
[kselftests-ciqlts8_8.full.log](https://github.com/user-attachments/files/18322408/kselftest-before-with-bluetooth-4.18.0-ciqlts8_8.4.full.log)


# Additional tests: to be added on request

A proof of concept is given in <https://github.com/google/security-research/security/advisories/GHSA-pf87-6c9q-jvm4>. It was not replicated.

