### PR TITLE
[LTS 9.2] Bluetooth: L2CAP: Fix l2cap_global_chan_by_psm

### DIFF
--- a/net/bluetooth/l2cap_core.c
+++ b/net/bluetooth/l2cap_core.c
@@ -1984,7 +1984,7 @@ static struct l2cap_chan *l2cap_global_chan_by_psm(int state, __le16 psm,
 		if (link_type == LE_LINK && c->src_type == BDADDR_BREDR)
 			continue;
 
-		if (c->psm == psm) {
+		if (c->chan_type != L2CAP_CHAN_FIXED && c->psm == psm) {
 			int src_match, dst_match;
 			int src_any, dst_any;
 


### PR DESCRIPTION

# CVE-2022-42896, VULN-210


## Solution

The bug fix in the mainline is provided in two commits:

-   `f937b758a188d6fd328a81367087eddbb2fce50f`
-   `711f8c3fb3db61897080468586b970c87c61d9e4`

Of these the `711f8c3` is already applied on `ciqlts9_2`.

(Same situation as in <https://github.com/ctrliq/kernel-src-tree/pull/41>)


## Build

Kernel built on Rocky 9 machine with

    CVE=CVE-2022-42896 ./ninja.sh _compile_ciqlts9_2-CVE-2022-42896

from the <https://gitlab.conclusive.pl/devices/rocky-patching> project.


## kABI check: passed

kABI ran on the build machine with

    python3 /mnt/code/kernel-dist-git/SOURCES/check-kabi \
            -k /mnt/code/kernel-dist-git/SOURCES/Module.kabi_$(uname -m) \
            -s /mnt/build_files/kernel-src-tree-ciqlts9_2-CVE-2022-42896/Module.symvers

for the `/mnt/code/kernel-dist-git` repo in the state of

    On branch el-9.2
    Your branch is up to date with 'origin/el-9.2'.

commit hash `d55abe03912e1cf92944e3aaaefc89402923eda3`.


## Boot test: passed

Logs [boot-test.log](https://github.com/user-attachments/files/18355445/boot-test.log) for the kernel booted with

    CVE=CVE-2022-42896 ./ninja.sh _boot_kernel-ciqlts9_2-CVE-2022-42896

from within the `rocky-patching` project.


## Kselftests: passed

Kselftests ran with

    MACHINE=test-ciqlts9_2-CVE-2022-42896 CVE=CVE-2022-42896 ./ninja.sh kselftests

and prepared with

    modprobe bluetooth

Results:

[kselftests-patch&#x2013;ciqlts9_2-CVE-2022-42896.zip](https://github.com/user-attachments/files/18355522/kselftests-patch--ciqlts9_2-CVE-2022-42896.zip)
Flat text file form:
[kselftests-patch&#x2013;ciqlts9_2-CVE-2022-42896.log](https://github.com/user-attachments/files/18355537/kselftests-patch--ciqlts9_2-CVE-2022-42896.log)

Reference results of the tests ran on `ciqlts9_2` (`c566432b9c6923174f979ee0811749d1b4045d9f`):

[kselftests-reference&#x2013;ciqlts9_2.zip](https://github.com/user-attachments/files/18355580/kselftests-reference--ciqlts9_2.zip)
Flat text file form:
[kselftests-reference&#x2013;ciqlts9_2.log](https://github.com/user-attachments/files/18355610/kselftests-reference--ciqlts9_2.log)

Comparison:

[comparison-patch-reference.csv](https://github.com/user-attachments/files/18355667/comparison-patch-reference.csv)

Summary: all test cases have the same results as the reference. Tests `bpf:test_progs`, `bpf:test_progs-no_alu32`, `net:fib_tests.sh`, `net:rps_default_mask.sh`, `netfilter:conntrack_tcp_unreplied.sh`, `netfilter:nft_flowtable.sh`, `netfilter:nft_nat.sh`, `tc-testing:tdc.sh` fail in both reference and patched kernel version. To be investigated on demand.


## Additional tests: none

Following the guidelines from the precedent <https://github.com/ctrliq/kernel-src-tree/pull/41>.

