### PR TITLE
netfilter: nft_set_pipapo: skip inactive elements during set walk

### DIFF
--- a/net/netfilter/nft_set_pipapo.c
+++ b/net/netfilter/nft_set_pipapo.c
@@ -1981,6 +1981,10 @@ static void nft_pipapo_walk(const struct nft_ctx *ctx, struct nft_set *set,
 			goto cont;
 
 		e = f->mt[r].e;
+
+		if (!nft_set_elem_active(&e->ext, iter->genmask))
+			goto cont;
+
 		if (nft_set_elem_expired(&e->ext))
 			goto cont;
 


### PR DESCRIPTION
jira VULN-8904
cve CVE-2023-6817

```
commit-author Florian Westphal <fw@strlen.de>
commit 317eb9685095678f2c9f5a8189de698c5354316a
upstream-diff Additional newline because this kernel has not removed
              the nft_set_elem_expired call yet

Otherwise set elements can be deactivated twice which will cause a crash.

	Reported-by: Xingyuan Mo <hdthky0@gmail.com>
Fixes: 3c4287f62044 ("nf_tables: Add set type for arbitrary concatenation of ranges")
	Signed-off-by: Florian Westphal <fw@strlen.de>
	Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
(cherry picked from commit 317eb9685095678f2c9f5a8189de698c5354316a)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

Netfilter selftests were run because this is a netfilter change:
[netfilter-selftest-before.log](https://github.com/user-attachments/files/18378700/netfilter-selftest-before.log)
[netfilter-selftest-after.log](https://github.com/user-attachments/files/18378730/netfilter-selftest-after.log)

```
brett@lycia ~/ciq/vuln-8904 % grep ^ok netfilter-selftest-before.log | wc -l
12
brett@lycia ~/ciq/vuln-8904 % grep ^ok netfilter-selftest-after.log | wc -l
12
brett@lycia ~/ciq/vuln-8904 %
```

Full selftests were also run:
[selftests-before.log](https://github.com/user-attachments/files/18378720/selftests-before.log)
[selftests-after.log](https://github.com/user-attachments/files/18378703/selftests-after.log)

```
brett@lycia ~/ciq/vuln-8904 % grep ^ok selftests-before.log | wc -l
309
brett@lycia ~/ciq/vuln-8904 % grep ^ok selftests-after.log | wc -l
311
brett@lycia ~/ciq/vuln-8904 %
```
