### PR TITLE
github actions Add Build x86_64 action

### DIFF
--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -1,0 +1,34 @@
+name: CI
+on:
+  pull_request_target:
+    branches:
+      - '**'
+      - '!mainline'
+
+jobs:
+  kernel-build-job:
+    runs-on:
+      labels: kernel-build
+    container:
+      image: rockylinux:9
+      env:
+        ROCKY_ENV: rocky9
+      ports:
+        - 80
+      options: --cpus 8
+    steps:
+      - name: Install tools and Libraries
+        run: |
+          dnf groupinstall 'Development Tools' -y
+          dnf install --enablerepo=crb bc dwarves kernel-devel openssl-devel elfutils-libelf-devel -y
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.head }}"
+          fetch-depth: 0
+      - name: Build the Kernel
+        run: |
+          git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
+          cp configs/kernel-5.14.0-x86_64.config .config
+          make olddefconfig
+          make -j8


### PR DESCRIPTION
Introducing a basic build check github action to the PR Checks for the Certified Branch of FIPS-9

Testing that Pull Request builds work is here:
https://github.com/ctrliq/kernel-src-tree/pull/62

Note these are intentionally broken since to test they're pulling my code from my personal fork of `kernel-src-tree`