### PR TITLE
[LTS 9.2-RT] Bluetooth: L2CAP: Fix l2cap_global_chan_by_psm

### DIFF
--- a/net/bluetooth/l2cap_core.c
+++ b/net/bluetooth/l2cap_core.c
@@ -1984,7 +1984,7 @@ static struct l2cap_chan *l2cap_global_chan_by_psm(int state, __le16 psm,
 		if (link_type == LE_LINK && c->src_type == BDADDR_BREDR)
 			continue;
 
-		if (c->psm == psm) {
+		if (c->chan_type != L2CAP_CHAN_FIXED && c->psm == psm) {
 			int src_match, dst_match;
 			int src_any, dst_any;
 


### PR DESCRIPTION


# CVE-2022-42896, VULN-210 (RT variant)


## Solution

The bug fix in the mainline is provided in two commits:

-   `f937b758a188d6fd328a81367087eddbb2fce50f`
-   `711f8c3fb3db61897080468586b970c87c61d9e4`

Of these the `711f8c3` is already applied on `ciqlts9_2-rt` (commit `af424ab54ea3c8a9acce353dd51faf68075c1ce1`).

(Same situation as in <https://github.com/ctrliq/kernel-src-tree/pull/41>)


## Build

Kernel built on virtual machine instantiated on physical Rocky 9 machine with

    ./ninja.sh _run_build-ciqlts9_2

from the <https://gitlab.conclusive.pl/devices/rocky-patching> project. Installed on a testing machine created with

    CVE=CVE-2022-42896 ./ninja.sh _run_test-ciqlts9_2-rt-CVE-2022-42896

Logs: [build.log](https://github.com/user-attachments/files/18417205/build.log)


## kABI check: failed (passed relative)

kABI check ran on the build machine with

    python3 /mnt/code/kernel-dist-git/SOURCES/check-kabi \
            -k /mnt/code/kernel-dist-git/SOURCES/Module.kabi_$(uname -m) \
            -s /mnt/build_files/kernel-src-tree-ciqlts9_2-rt-CVE-2022-42896/Module.symvers

for the `/mnt/code/kernel-dist-git` repo in the state of

    On branch el-9.2
    Your branch is up to date with 'origin/el-9.2'.

commit hash `d55abe03912e1cf92944e3aaaefc89402923eda3`.

Logs: [kabi-patch.log](https://github.com/user-attachments/files/18417210/kabi-patch.log)

The same check ran for the reference version `ciqlts9_2-rt` (`da2d199f93545e2d9b8c355c9d4dadc7c7aef1e6`) with

    python3 /mnt/code/kernel-dist-git/SOURCES/check-kabi \
            -k /mnt/code/kernel-dist-git/SOURCES/Module.kabi_$(uname -m) \
            -s /mnt/build_files/kernel-src-tree-ciqlts9_2-rt/Module.symvers

Logs: [kabi-reference.log](https://github.com/user-attachments/files/18417217/kabi-reference.log)

The patched and reference ABI breakage are identical.


## Boot test: passed

[boot-test.log](https://github.com/user-attachments/files/18417222/boot-test.log)


## Kselftests: passed relative

Kselftests ran using `kernel-rt-selftests-internal` package on a test machine prepared with

    modprobe bluetooth

Results:
[kselftests-patch.zip](https://github.com/user-attachments/files/18417230/kselftests-patch.zip)
Flat text file form:
[kselftests-patch.log](https://github.com/user-attachments/files/18417234/kselftests-patch.log)

Reference results of the tests ran on `ciqlts9_2-rt` (`da2d199f93545e2d9b8c355c9d4dadc7c7aef1e6`):

[kselftests-reference.zip](https://github.com/user-attachments/files/18417237/kselftests-reference.zip)
Flat text file form:
[kselftests-reference.log](https://github.com/user-attachments/files/18417244/kselftests-reference.log)

Comparison:
[comparison-patch-reference.csv](https://github.com/user-attachments/files/18417245/comparison-patch-reference.csv)

Summary: all test cases for the patched version have the same result as the reference. Tests

-   `bpf:test_kmod.sh`
-   `bpf:test_verifier`
-   `net:fib_nexthops.sh`
-   `net:fib_tests.sh`
-   `net:icmp.sh`
-   `net:rps_default_mask.sh`
-   `net:test_blackhole_dev.sh`
-   `net:vrf_route_leaking.sh`
-   `netfilter:conntrack_tcp_unreplied.sh`
-   `netfilter:conntrack_vrf.sh`
-   `netfilter:nft_concat_range.sh`
-   `netfilter:nft_flowtable.sh`
-   `netfilter:nft_nat.sh`
-   `tc-testing:tdc.sh`

fail in both reference and patched kernel version. Tests

-   `bpf:test_tcpnotify_user`
-   `net/mptcp:mptcp_join.sh`

were "flappy" and needed to be re-run one time. Tests

-   `bpf:test_progs`
-   `bpf:test_progs-no_alu32`

were omitted due to them hanging the testing machine on the reference `ciqlts9_2-rt` version (patched version not tested). To investigate and re-run on request.


## Additional tests: none

Following the guidelines from the precedent <https://github.com/ctrliq/kernel-src-tree/pull/41>.

