### PR TITLE
[LTS 8.8] github actions: Reduce Pull Request openness

### DIFF
--- a/.github/workflows/build-check_aarch64.yml
+++ b/.github/workflows/build-check_aarch64.yml
@@ -1,6 +1,6 @@
 name: aarch64 CI
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - '**'
       - '!mainline'

--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -1,6 +1,6 @@
 name: x86_64 CI
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - '**'
       - '!mainline'


### PR DESCRIPTION
Since the kernel builds are very expensive we only want to run the workflows associated with them is by approval of staff / maintainers of the kernel.  There was a miss understanding initially that pull_request_target was required to get access to the code.