### PR TITLE
[LTS 8.8-rt] github actions: Make builds on Merge Request

### DIFF
--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -1,0 +1,34 @@
+name: x86_64 CI
+on:
+  pull_request:
+    branches:
+      - '**'
+      - '!mainline'
+
+jobs:
+  kernel-build-job:
+    runs-on:
+      labels: kernel-build
+    container:
+      image: rockylinux:8
+      env:
+        ROCKY_ENV: rocky8
+      ports:
+        - 80
+      options: --cpus 8
+    steps:
+      - name: Install tools and Libraries
+        run: |
+          dnf groupinstall 'Development Tools' -y
+          dnf install --enablerepo=devel bc dwarves kernel-devel openssl-devel elfutils-libelf-devel -y
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.head.sha }}"
+          fetch-depth: 0
+      - name: Build the Kernel
+        run: |
+          git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
+          cp configs/kernel-rt-4.18.0-x86_64.config .config
+          make olddefconfig
+          make -j8


### PR DESCRIPTION
Since we need to make sure external contributors code actually compiles prior to merging. To get access to the forked repos merge request we need to switch over our push to pull_request. In addition we're fixing up some Naming Conventions, adding aarch64 to this branch and fixing the naming so that we can quickly identify if the CI is for x86_64 or aarch64.

Reference builds:
https://github.com/ctrliq/kernel-src-tree/pull/85