### PR TITLE
[LTS 8.6 RT] Bluetooth: L2CAP: Fix l2cap_global_chan_by_psm

### DIFF
--- a/net/bluetooth/l2cap_core.c
+++ b/net/bluetooth/l2cap_core.c
@@ -1960,7 +1960,7 @@ static struct l2cap_chan *l2cap_global_chan_by_psm(int state, __le16 psm,
 		if (link_type == LE_LINK && c->src_type == BDADDR_BREDR)
 			continue;
 
-		if (c->psm == psm) {
+		if (c->chan_type != L2CAP_CHAN_FIXED && c->psm == psm) {
 			int src_match, dst_match;
 			int src_any, dst_any;
 


### PR DESCRIPTION
CVE-2022-42896
VULN-205


# Solution

The bug fix in the mainline is provided<sup><a id="fnr.1" class="footref" href="#fn.1">1</a></sup> in two commits:

-   `f937b758a188d6fd328a81367087eddbb2fce50f`
-   `711f8c3fb3db61897080468586b970c87c61d9e4`

Of these the `711f8c3` is already applied on `ciqlts8_6-rt` (commit `0c319402e3cb34e46cad6ed4299faffa7916b670`).

(Same situation as in <https://github.com/ctrliq/kernel-src-tree/pull/41>)


# kABI check: omitted


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/18566023/boot-test.log>)


# Kselftests: passed relative


## Methodology

All kselftests used were compiled from the kernel source code, branch `ciqlts8_6-rt` (`5d362bf39d935ad7de47fa83661d2965e54ae013`). The `kernel-rt-selftests-internal` package is not available for Rocky LTS 8.6 RT.

Additionally the tests were ran using the installed kselftests, as with

    make -C tools/testing/selftests install

in order to evaluate the usefulness of this feature. (The installed selftests use the same `run_kselftest.sh` -defined interface as those from `kernel-selftests-internal`, `kernel-rt-selftests-internal` packages, providing high granularity of tests selection and potentially streamlining testing across different rocky versions.)


## Covered test groups (including those skipped during execution)

`android`, `bpf`, `breakpoints`, `capabilities`, `core`, `cpu-hotplug`, `cpufreq`, `efivarfs`, `exec`, `filesystems`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `net`, `net/forwarding`, `net/mptcp`, `netfilter`, `nsfs`, `pstore`, `ptrace`, `rseq`, `rtc`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `sysctl`, `tc-testing`, `timens`, `timers`, `tpm2`, `user`, `vm`, `x86`, `zram`


## Compiled selftests


### Tests stability analysis on a reference kernel

A series of 5 test runs were conducted on the reference LTS 8.6 RT kernel `ciqlts8_6-rt` (`5d362bf39d935ad7de47fa83661d2965e54ae013`) of which 2 finished without issues.

[kselftests&#x2013;source&#x2013;ciqlts8\_6-rt&#x2013;run1.log](<https://github.com/user-attachments/files/18566249/kselftests--source--ciqlts8_6-rt--run1.log>)
[kselftests&#x2013;source&#x2013;ciqlts8\_6-rt&#x2013;run2.log](<https://github.com/user-attachments/files/18566260/kselftests--source--ciqlts8_6-rt--run2.log>)

It was found that

-   Two tests are dysfunctional
    -   **`bpf:test_sockmap`:** Sometimes hangs the machine by blocking the kworker
    -   **`bpf:test_progs`:** Sometimes causes the machine to spontaneously reboot, interrupting the tests run. Potentially this also applies to the `bpf:test_progs-no_alu32` test as is the case on other Rocky versions, but on these test runs it behaved properly.
-   Two tests are "flappy", their results differing depending on the run
    -   `ipc:msgque`
    -   `net:gro.sh`

For the full picture of unit tests stability state refer to the column <https://docs.google.com/spreadsheets/d/1tUwJ2rV57cYZXh7momPtraSjZcHDjMYHLeHA3DYWrUU/edit?pli=1&gid=0#gid=0&range=D:D>


### Patched kernel

A single test run was conducted on the patched kernel.
[kselftests&#x2013;source&#x2013;ciqlts8\_6-rt-CVE-2022-42896.log](<https://github.com/user-attachments/files/18566352/kselftests--source--ciqlts8_6-rt-CVE-2022-42896.log>)


### Comparison

Compared to the reference kernel and omitting the unstable and flappy tests the results are identical except for the `net:reuseport_addr_any.sh` test, which the reference kernel was failing while the patched kernel was passing. An additional series of `net` tests were conducted on the reference kernel in hope of obtaining the passing result, without success.

[kselftests&#x2013;source&#x2013;ciqlts8\_6-rt&#x2013;net&#x2013;run1.log](<https://github.com/user-attachments/files/18566811/kselftests--source--ciqlts8_6-rt--net--run1.log>)
[kselftests&#x2013;source&#x2013;ciqlts8\_6-rt&#x2013;net&#x2013;run2.log](<https://github.com/user-attachments/files/18566814/kselftests--source--ciqlts8_6-rt--net--run2.log>)
[kselftests&#x2013;source&#x2013;ciqlts8\_6-rt&#x2013;net&#x2013;run3.log](<https://github.com/user-attachments/files/18566817/kselftests--source--ciqlts8_6-rt--net--run3.log>)

Full comparison give below

    xonsh ktests.xsh table \
          kselftests--source--ciqlts8_6-rt--run1.log \
          kselftests--source--ciqlts8_6-rt--run2.log \
          kselftests--source--ciqlts8_6-rt--net--run1.log \
          kselftests--source--ciqlts8_6-rt--net--run2.log \
          kselftests--source--ciqlts8_6-rt--net--run3.log \
          kselftests--source--ciqlts8_6-rt-CVE-2022-42896.log

    Column    File
    --------  ---------------------------------------------------
    Status0   kselftests--source--ciqlts8_6-rt--run1.log
    Status1   kselftests--source--ciqlts8_6-rt--run2.log
    Status2   kselftests--source--ciqlts8_6-rt--net--run1.log
    Status3   kselftests--source--ciqlts8_6-rt--net--run2.log
    Status4   kselftests--source--ciqlts8_6-rt--net--run3.log
    Status5   kselftests--source--ciqlts8_6-rt-CVE-2022-42896.log
    
    TestCase                                     Status0  Status1  Status2  Status3  Status4  Status5  Summary
    android:run.sh                               skip     skip                                skip     same
    bpf:get_cgroup_id_user                       pass     pass                                pass     same
    bpf:test_bpftool.sh                          fail     fail                                fail     same
    bpf:test_bpftool_build.sh                    pass     pass                                pass     same
    bpf:test_bpftool_metadata.sh                 skip     skip                                skip     same
    bpf:test_cgroup_storage                      pass     pass                                pass     same
    bpf:test_dev_cgroup                          pass     pass                                pass     same
    bpf:test_doc_build.sh                        pass     pass                                pass     same
    bpf:test_flow_dissector.sh                   fail     fail                                fail     same
    bpf:test_kmod.sh                             pass     pass                                pass     same
    bpf:test_lirc_mode2.sh                       pass     pass                                pass     same
    bpf:test_lpm_map                             pass     pass                                pass     same
    bpf:test_lru_map                             pass     pass                                pass     same
    bpf:test_lwt_ip_encap.sh                     pass     pass                                pass     same
    bpf:test_lwt_seg6local.sh                    pass     pass                                pass     same
    bpf:test_maps                                pass     pass                                pass     same
    bpf:test_netcnt                              pass     pass                                pass     same
    bpf:test_offload.py                          pass     pass                                pass     same
    bpf:test_progs                               fail     fail                                fail     same
    bpf:test_progs-no_alu32                      fail     fail                                fail     same
    bpf:test_skb_cgroup_id.sh                    fail     fail                                fail     same
    bpf:test_sock                                pass     pass                                pass     same
    bpf:test_sock_addr.sh                        pass     pass                                pass     same
    bpf:test_sockmap                             pass     pass                                pass     same
    bpf:test_sysctl                              pass     pass                                pass     same
    bpf:test_tag                                 pass     pass                                pass     same
    bpf:test_tc_edt.sh                           fail     fail                                fail     same
    bpf:test_tc_tunnel.sh                        fail     fail                                fail     same
    bpf:test_tcp_check_syncookie.sh              fail     fail                                fail     same
    bpf:test_tcpnotify_user                      fail     fail                                fail     same
    bpf:test_tunnel.sh                           fail     fail                                fail     same
    bpf:test_verifier                            fail     fail                                fail     same
    bpf:test_verifier_log                        pass     pass                                pass     same
    bpf:test_xdp_meta.sh                         fail     fail                                fail     same
    bpf:test_xdp_redirect.sh                     pass     pass                                pass     same
    bpf:test_xdp_veth.sh                         skip     skip                                skip     same
    bpf:test_xdp_vlan_mode_generic.sh            fail     fail                                fail     same
    bpf:test_xdp_vlan_mode_native.sh             fail     fail                                fail     same
    bpf:test_xdping.sh                           pass     pass                                pass     same
    bpf:test_xsk.sh                              fail     fail                                fail     same
    bpf:urandom_read                             pass     pass                                pass     same
    breakpoints:step_after_suspend_test          fail     fail                                fail     same
    capabilities:test_execve                     pass     pass                                pass     same
    core:close_range_test                        pass     pass                                pass     same
    cpu-hotplug:cpu-on-off-test.sh               pass     pass                                pass     same
    cpufreq:main.sh                              fail     fail                                fail     same
    efivarfs:efivarfs.sh                         skip     skip                                skip     same
    exec:execveat                                pass     pass                                pass     same
    filesystems:devpts_pts                       pass     pass                                pass     same
    firmware:fw_run_tests.sh                     skip     skip                                skip     same
    fpu:run_test_fpu.sh                          skip     skip                                skip     same
    fpu:test_fpu                                 pass     pass                                pass     same
    ftrace:ftracetest                            fail     fail                                fail     same
    futex:run.sh                                 pass     pass                                pass     same
    gpio:gpio-mockup.sh                          fail     fail                                fail     same
    intel_pstate:run.sh                          pass     pass                                pass     same
    ipc:msgque                                   pass     fail                                pass     diff
    kcmp:kcmp_test                               pass     pass                                pass     same
    kvm:access_tracking_perf_test                fail     fail                                fail     same
    kvm:amx_test                                 skip     skip                                skip     same
    kvm:cr4_cpuid_sync_test                      pass     pass                                pass     same
    kvm:debug_regs                               pass     pass                                pass     same
    kvm:demand_paging_test                       pass     pass                                pass     same
    kvm:dirty_log_perf_test                      pass     pass                                pass     same
    kvm:dirty_log_test                           fail     fail                                fail     same
    kvm:emulator_error_test                      pass     pass                                pass     same
    kvm:evmcs_test                               pass     pass                                pass     same
    kvm:get_cpuid_test                           pass     pass                                pass     same
    kvm:get_msr_index_features                   pass     pass                                pass     same
    kvm:hardware_disable_test                    pass     pass                                pass     same
    kvm:hyperv_clock                             fail     fail                                fail     same
    kvm:hyperv_cpuid                             pass     pass                                pass     same
    kvm:hyperv_features                          pass     pass                                pass     same
    kvm:kvm_binary_stats_test                    pass     pass                                pass     same
    kvm:kvm_create_max_vcpus                     skip     skip                                skip     same
    kvm:kvm_page_table_test                      pass     pass                                pass     same
    kvm:kvm_pv_test                              pass     pass                                pass     same
    kvm:memslot_modification_stress_test         pass     pass                                pass     same
    kvm:memslot_perf_test                        fail     fail                                fail     same
    kvm:mmio_warning_test                        skip     skip                                skip     same
    kvm:mmu_role_test                            pass     pass                                pass     same
    kvm:platform_info_test                       pass     pass                                pass     same
    kvm:rseq_test                                fail     fail                                fail     same
    kvm:set_boot_cpu_id                          pass     pass                                pass     same
    kvm:set_memory_region_test                   fail     fail                                fail     same
    kvm:set_sregs_test                           pass     pass                                pass     same
    kvm:smm_test                                 pass     pass                                pass     same
    kvm:state_test                               pass     pass                                pass     same
    kvm:steal_time                               pass     pass                                pass     same
    kvm:svm_int_ctl_test                         skip     skip                                skip     same
    kvm:svm_vmcall_test                          skip     skip                                skip     same
    kvm:sync_regs_test                           pass     pass                                pass     same
    kvm:tsc_msrs_test                            pass     pass                                pass     same
    kvm:userspace_msr_exit_test                  pass     pass                                pass     same
    kvm:vmx_apic_access_test                     pass     pass                                pass     same
    kvm:vmx_close_while_nested_test              pass     pass                                pass     same
    kvm:vmx_dirty_log_test                       pass     pass                                pass     same
    kvm:vmx_nested_tsc_scaling_test              skip     skip                                skip     same
    kvm:vmx_pmu_msrs_test                        pass     pass                                pass     same
    kvm:vmx_preemption_timer_test                fail     fail                                fail     same
    kvm:vmx_set_nested_state_test                pass     pass                                pass     same
    kvm:vmx_tsc_adjust_test                      pass     pass                                pass     same
    kvm:xapic_ipi_test                           pass     pass                                pass     same
    kvm:xen_shinfo_test                          skip     skip                                skip     same
    kvm:xen_vmcall_test                          skip     skip                                skip     same
    kvm:xss_msr_test                             pass     pass                                pass     same
    lib:bitmap.sh                                skip     skip                                skip     same
    lib:prime_numbers.sh                         skip     skip                                skip     same
    lib:printf.sh                                skip     skip                                skip     same
    lib:scanf.sh                                 fail     fail                                fail     same
    livepatch:test-callbacks.sh                  pass     pass                                pass     same
    livepatch:test-ftrace.sh                     pass     pass                                pass     same
    livepatch:test-livepatch.sh                  pass     pass                                pass     same
    livepatch:test-shadow-vars.sh                pass     pass                                pass     same
    livepatch:test-state.sh                      pass     pass                                pass     same
    membarrier:membarrier_test_multi_thread      pass     pass                                pass     same
    membarrier:membarrier_test_single_thread     pass     pass                                pass     same
    memfd:memfd_test                             pass     pass                                pass     same
    memfd:run_fuse_test.sh                       fail     fail                                fail     same
    memfd:run_hugetlbfs_test.sh                  pass     pass                                pass     same
    memory-hotplug:mem-on-off-test.sh            pass     pass                                pass     same
    mount:run_tests.sh                           pass     pass                                pass     same
    net/forwarding:bridge_igmp.sh                fail     fail                                fail     same
    net/forwarding:bridge_port_isolation.sh      fail     fail                                fail     same
    net/forwarding:bridge_sticky_fdb.sh          fail     fail                                fail     same
    net/forwarding:bridge_vlan_aware.sh          fail     fail                                fail     same
    net/forwarding:bridge_vlan_unaware.sh        fail     fail                                fail     same
    net/forwarding:ethtool.sh                    fail     fail                                fail     same
    net/forwarding:gre_multipath.sh              fail     fail                                fail     same
    net/forwarding:ip6_forward_instats_vrf.sh    fail     fail                                fail     same
    net/forwarding:ipip_flat_gre.sh              fail     fail                                fail     same
    net/forwarding:ipip_flat_gre_key.sh          fail     fail                                fail     same
    net/forwarding:ipip_flat_gre_keys.sh         fail     fail                                fail     same
    net/forwarding:ipip_hier_gre.sh              fail     fail                                fail     same
    net/forwarding:ipip_hier_gre_key.sh          fail     fail                                fail     same
    net/forwarding:ipip_hier_gre_keys.sh         fail     fail                                fail     same
    net/forwarding:loopback.sh                   fail     fail                                fail     same
    net/forwarding:mirror_gre.sh                 fail     fail                                fail     same
    net/forwarding:mirror_gre_bound.sh           fail     fail                                fail     same
    net/forwarding:mirror_gre_bridge_1d.sh       fail     fail                                fail     same
    net/forwarding:mirror_gre_bridge_1d_vlan.sh  fail     fail                                fail     same
    net/forwarding:mirror_gre_bridge_1q.sh       fail     fail                                fail     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh   fail     fail                                fail     same
    net/forwarding:mirror_gre_changes.sh         fail     fail                                fail     same
    net/forwarding:mirror_gre_flower.sh          fail     fail                                fail     same
    net/forwarding:mirror_gre_lag_lacp.sh        fail     fail                                fail     same
    net/forwarding:mirror_gre_neigh.sh           fail     fail                                fail     same
    net/forwarding:mirror_gre_nh.sh              fail     fail                                fail     same
    net/forwarding:mirror_gre_vlan.sh            fail     fail                                fail     same
    net/forwarding:mirror_gre_vlan_bridge_1q.sh  fail     fail                                fail     same
    net/forwarding:mirror_vlan.sh                fail     fail                                fail     same
    net/forwarding:router.sh                     fail     fail                                fail     same
    net/forwarding:router_bridge.sh              fail     fail                                fail     same
    net/forwarding:router_bridge_vlan.sh         fail     fail                                fail     same
    net/forwarding:router_broadcast.sh           fail     fail                                fail     same
    net/forwarding:router_multicast.sh           fail     fail                                fail     same
    net/forwarding:router_multipath.sh           fail     fail                                fail     same
    net/forwarding:router_vid_1.sh               fail     fail                                fail     same
    net/forwarding:sch_ets.sh                    fail     fail                                fail     same
    net/forwarding:sch_tbf_ets.sh                fail     fail                                fail     same
    net/forwarding:sch_tbf_prio.sh               fail     fail                                fail     same
    net/forwarding:sch_tbf_root.sh               fail     fail                                fail     same
    net/forwarding:tc_actions.sh                 fail     fail                                fail     same
    net/forwarding:tc_chains.sh                  fail     fail                                fail     same
    net/forwarding:tc_flower.sh                  fail     fail                                fail     same
    net/forwarding:tc_flower_router.sh           fail     fail                                fail     same
    net/forwarding:tc_mpls_l2vpn.sh              fail     fail                                fail     same
    net/forwarding:tc_shblocks.sh                fail     fail                                fail     same
    net/forwarding:tc_vlan_modify.sh             fail     fail                                fail     same
    net/forwarding:vxlan_asymmetric.sh           fail     fail                                fail     same
    net/forwarding:vxlan_bridge_1d.sh            fail     fail                                fail     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh  fail     fail                                fail     same
    net/forwarding:vxlan_bridge_1q.sh            fail     fail                                fail     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh  fail     fail                                fail     same
    net/forwarding:vxlan_symmetric.sh            fail     fail                                fail     same
    net/mptcp:diag.sh                            pass     pass                                pass     same
    net/mptcp:mptcp_connect.sh                   pass     pass                                pass     same
    net/mptcp:mptcp_join.sh                      skip     skip                                skip     same
    net/mptcp:mptcp_sockopt.sh                   skip     skip                                skip     same
    net/mptcp:pm_netlink.sh                      pass     pass                                pass     same
    net/mptcp:simult_flows.sh                    pass     pass                                pass     same
    net:bareudp.sh                               skip     skip     skip     skip     skip     skip     same
    net:devlink_port_split.py                    skip     skip     skip     skip     skip     skip     same
    net:drop_monitor_tests.sh                    skip     skip     skip     skip     skip     skip     same
    net:fcnal-test.sh                            pass     pass     pass     pass     pass     pass     same
    net:fib-onlink-tests.sh                      pass     pass     pass     pass     pass     pass     same
    net:fib_rule_tests.sh                        fail     fail     fail     fail     fail     fail     same
    net:fib_tests.sh                             pass     pass     pass     pass     pass     pass     same
    net:gre_gso.sh                               skip     skip     skip     skip     skip     skip     same
    net:gro.sh                                   fail     pass     pass     pass     pass     pass     diff
    net:icmp_redirect.sh                         pass     pass     pass     pass     pass     pass     same
    net:ip6_gre_headroom.sh                      pass     pass     pass     pass     pass     pass     same
    net:ip_defrag.sh                             fail     fail     fail     fail     fail     fail     same
    net:ipv6_flowlabel.sh                        pass     pass     pass     pass     pass     pass     same
    net:l2tp.sh                                  pass     pass     pass     pass     pass     pass     same
    net:msg_zerocopy.sh                          fail     fail     fail     fail     fail     fail     same
    net:netdevice.sh                             pass     pass     pass     pass     pass     pass     same
    net:pmtu.sh                                  pass     pass     pass     pass     pass     pass     same
    net:psock_snd.sh                             fail     fail     fail     fail     fail     fail     same
    net:reuseaddr_conflict                       pass     pass     pass     pass     pass     pass     same
    net:reuseport_addr_any.sh                    fail     fail     fail     fail     fail     pass     diff
    net:reuseport_bpf                            pass     pass     pass     pass     pass     pass     same
    net:reuseport_bpf_cpu                        pass     pass     pass     pass     pass     pass     same
    net:reuseport_bpf_numa                       fail     fail     fail     fail     fail     fail     same
    net:reuseport_dualstack                      pass     pass     pass     pass     pass     pass     same
    net:rtnetlink.sh                             skip     skip     skip     skip     skip     skip     same
    net:run_afpackettests                        pass     pass     pass     pass     pass     pass     same
    net:run_netsocktests                         pass     pass     pass     pass     pass     pass     same
    net:rxtimestamp.sh                           pass     pass     pass     pass     pass     pass     same
    net:so_txtime.sh                             fail     fail     fail     fail     fail     fail     same
    net:test_bpf.sh                              pass     pass     pass     pass     pass     pass     same
    net:test_vxlan_fdb_changelink.sh             pass     pass     pass     pass     pass     pass     same
    net:tls                                      pass     pass     pass     pass     pass     pass     same
    net:traceroute.sh                            pass     pass     pass     pass     pass     pass     same
    net:txtimestamp.sh                           fail     fail     fail     fail     fail     fail     same
    net:udpgro.sh                                pass     pass     pass     pass     pass     pass     same
    net:udpgro_bench.sh                          pass     pass     pass     pass     pass     pass     same
    net:udpgro_fwd.sh                            fail     fail     fail     fail     fail     fail     same
    net:udpgso.sh                                pass     pass     pass     pass     pass     pass     same
    net:udpgso_bench.sh                          skip     skip     skip     skip     skip     skip     same
    net:veth.sh                                  pass     pass     pass     pass     pass     pass     same
    net:vrf-xfrm-tests.sh                        pass     pass     pass     pass     pass     pass     same
    net:xfrm_policy.sh                           skip     skip     skip     skip     skip     skip     same
    netfilter:conntrack_icmp_related.sh          skip     skip                                skip     same
    netfilter:conntrack_tcp_unreplied.sh         skip     skip                                skip     same
    netfilter:ipvs.sh                            skip     skip                                skip     same
    netfilter:nft_flowtable.sh                   skip     skip                                skip     same
    netfilter:nft_meta.sh                        skip     skip                                skip     same
    netfilter:nft_nat.sh                         skip     skip                                skip     same
    netfilter:nft_queue.sh                       skip     skip                                skip     same
    netfilter:nft_trans_stress.sh                skip     skip                                skip     same
    nsfs:owner                                   pass     pass                                pass     same
    nsfs:pidns                                   pass     pass                                pass     same
    pstore:pstore_post_reboot_tests              skip     skip                                skip     same
    pstore:pstore_tests                          fail     fail                                fail     same
    ptrace:peeksiginfo                           pass     pass                                pass     same
    ptrace:vmaccess                              fail     fail                                fail     same
    rseq:basic_percpu_ops_test                   pass     pass                                pass     same
    rseq:basic_test                              pass     pass                                pass     same
    rseq:param_test                              pass     pass                                pass     same
    rseq:param_test_benchmark                    pass     pass                                pass     same
    rseq:param_test_compare_twice                pass     pass                                pass     same
    rseq:run_param_test.sh                       fail     fail                                fail     same
    rtc:rtctest                                  pass     pass                                pass     same
    sgx:test_sgx                                 fail     fail                                fail     same
    sigaltstack:sas                              pass     pass                                pass     same
    size:get_size                                pass     pass                                pass     same
    splice:default_file_splice_read.sh           pass     pass                                pass     same
    static_keys:test_static_keys.sh              skip     skip                                skip     same
    sync:sync_test                               skip     skip                                skip     same
    sysctl:sysctl.sh                             skip     skip                                skip     same
    tc-testing:tdc.sh                            fail     fail                                fail     same
    timens:clock_nanosleep                       pass     pass                                pass     same
    timens:exec                                  pass     pass                                pass     same
    timens:procfs                                pass     pass                                pass     same
    timens:timens                                pass     pass                                pass     same
    timens:timer                                 pass     pass                                pass     same
    timens:timerfd                               pass     pass                                pass     same
    timers:inconsistency-check                   fail     fail                                fail     same
    timers:mqueue-lat                            pass     pass                                pass     same
    timers:nanosleep                             pass     pass                                pass     same
    timers:nsleep-lat                            fail     fail                                fail     same
    timers:posix_timers                          pass     pass                                pass     same
    timers:raw_skew                              fail     fail                                fail     same
    timers:rtcpie                                pass     pass                                pass     same
    timers:set-timer-lat                         fail     fail                                fail     same
    timers:threadtest                            pass     pass                                pass     same
    tpm2:test_smoke.sh                           fail     fail                                fail     same
    tpm2:test_space.sh                           fail     fail                                fail     same
    user:test_user_copy.sh                       skip     skip                                skip     same
    vm:run_vmtests                               fail     fail                                fail     same
    x86:amx_64                                   fail     fail                                fail     same
    x86:check_initial_reg_state_64               pass     pass                                pass     same
    x86:corrupt_xstate_header_64                 pass     pass                                pass     same
    x86:fsgsbase_64                              pass     pass                                pass     same
    x86:fsgsbase_restore_64                      pass     pass                                pass     same
    x86:ioperm_64                                pass     pass                                pass     same
    x86:iopl_64                                  pass     pass                                pass     same
    x86:mov_ss_trap_64                           pass     pass                                pass     same
    x86:mpx-mini-test_64                         fail     fail                                fail     same
    x86:protection_keys_64                       pass     pass                                pass     same
    x86:sigaltstack_64                           pass     pass                                pass     same
    x86:sigreturn_64                             pass     pass                                pass     same
    x86:single_step_syscall_64                   pass     pass                                pass     same
    x86:syscall_nt_64                            pass     pass                                pass     same
    x86:sysret_rip_64                            pass     pass                                pass     same
    x86:sysret_ss_attrs_64                       pass     pass                                pass     same
    x86:test_mremap_vdso_64                      pass     pass                                pass     same
    x86:test_vdso_64                             pass     pass                                pass     same
    x86:test_vsyscall_64                         pass     pass                                pass     same
    zram:zram.sh                                 pass     pass                                pass     same

However, the passing `net:reuseport_addr_any.sh` test on the reference kernel when used in the installed form (see section below) suggests that the passing result for the patched kernel is not related to the change in any way.


## Installed selftests

A series of 2 test runs were conducted on the reference LTS 8.6 RT kernel `ciqlts8_6-rt` (`5d362bf39d935ad7de47fa83661d2965e54ae013`) with the tests proven to be unstable before omitted: `bpf:test_progs`, `bpf:test_sockmap`.

[kselftests&#x2013;source-installed&#x2013;ciqlts8\_6-rt&#x2013;run1.log](<https://github.com/user-attachments/files/18566533/kselftests--source-installed--ciqlts8_6-rt--run1.log>)
[kselftests&#x2013;source-installed&#x2013;ciqlts8\_6-rt&#x2013;run2.log](<https://github.com/user-attachments/files/18566547/kselftests--source-installed--ciqlts8_6-rt--run2.log>)

It was found that the `kvm:hardware_disable_test` was flappy. Additionally, multiple tests behaved differently when run in this mode compared to the tests run with `make`.

    xonsh ktests.xsh table \
          kselftests--source--ciqlts8_6-rt--run1.log \
          kselftests--source--ciqlts8_6-rt--run2.log \
          kselftests--source-installed--ciqlts8_6-rt--run2.log \
          kselftests--source-installed--ciqlts8_6-rt--run1.log \
          --where "Summary = 'diff'" \
          --omit-tests ipc:msgque net:gro.sh bpf:test_progs bpf:test_sockmap kvm:hardware_disable_test

    Column    File
    --------  ----------------------------------------------------
    Status0   kselftests--source--ciqlts8_6-rt--run1.log
    Status1   kselftests--source--ciqlts8_6-rt--run2.log
    Status2   kselftests--source-installed--ciqlts8_6-rt--run2.log
    Status3   kselftests--source-installed--ciqlts8_6-rt--run1.log
    
    TestCase                       Status0  Status1  Status2  Status3  Summary
    bpf:test_doc_build.sh          pass     pass     fail     fail     diff
    bpf:test_lwt_ip_encap.sh       pass     pass     fail     fail     diff
    bpf:test_lwt_seg6local.sh      pass     pass     fail     fail     diff
    bpf:test_xdping.sh             pass     pass     fail     fail     diff
    firmware:fw_run_tests.sh       skip     skip     fail     fail     diff
    net:reuseport_addr_any.sh      fail     fail     fail     pass     diff
    rseq:basic_percpu_ops_test     pass     pass     fail     fail     diff
    rseq:basic_test                pass     pass     fail     fail     diff
    rseq:param_test                pass     pass     fail     fail     diff
    rseq:param_test_benchmark      pass     pass     fail     fail     diff
    rseq:param_test_compare_twice  pass     pass     fail     fail     diff

The reasons were investigated cursorily and they ranged from conditional "skipping" of some tests (eg. `bpf:test_lwt_seg6local.sh`) which showed as passing when invoked with `make` to what seems like an erroneous installation (`rseq`).

The full picture is provided at <https://docs.google.com/spreadsheets/d/1tUwJ2rV57cYZXh7momPtraSjZcHDjMYHLeHA3DYWrUU/edit?pli=1&gid=0#gid=0&range=E:E>.

These results show that the tests ran directly from kernel source and the tests ran with `run_kselftest.sh` after installation are **not** interchangable in a straightforward manner.


# Additional tests: none

Following the guidelines from the precedent <https://github.com/ctrliq/kernel-src-tree/pull/41>.


# Footnotes

<sup><a id="fn.1" href="#fnr.1">1</a></sup> <https://github.com/google/security-research/security/advisories/GHSA-pf87-6c9q-jvm4>
