### PR TITLE
[LTS RT 8.6] bpf: Fix incorrect verifier pruning due to missing register precision…

### DIFF
--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -2220,6 +2220,21 @@ static int backtrack_insn(struct bpf_verifier_env *env, int idx,
 			}
 		} else if (opcode == BPF_EXIT) {
 			return -ENOTSUPP;
+		} else if (BPF_SRC(insn->code) == BPF_X) {
+			if (!(*reg_mask & (dreg | sreg)))
+				return 0;
+			/* dreg <cond> sreg
+			 * Both dreg and sreg need precision before
+			 * this insn. If only sreg was marked precise
+			 * before it would be equally necessary to
+			 * propagate it to dreg.
+			 */
+			*reg_mask |= (sreg | dreg);
+			 /* else dreg <cond> K
+			  * Only dreg still needs precision before
+			  * this insn, so for the K-based conditional
+			  * there is nothing new to be marked.
+			  */
 		}
 	} else if (class == BPF_LD) {
 		if (!(*reg_mask & dreg))


### PR DESCRIPTION
VULN-3188
CVE-2023-2163

**Builds and Loads**
We skip the kABI check for 8.* RT kernels since there is no stable kABI for them.

```
skipkabi is true
/home/g.v.rose/prj/ramdisk/kernel-build-ciqlts8_6-rt
  CLEAN   .
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr
  CLEAN   arch/x86/tools
  CLEAN    resolve_btfids
  CLEAN   .tmp_versions
[TIMER]{MRPROPER}: 12s
x86_64 architecture detected, copying config
'configs/kernel-rt-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-gvrose_ciqlts8_6-rt"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/basic/bin2c
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  DESCEND objtool
  DESCEND bpf/resolve_btfids

[SNIP]

  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-gvrose_ciqlts8_6-rt+
[TIMER]{MODULES}: 89s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-gvrose_ciqlts8_6-rt+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 24s
Checking kABI
kABI check skipped
Setting Default Kernel to /boot/vmlinuz-4.18.0-gvrose_ciqlts8_6-rt+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 12s
[TIMER]{BUILD}: 2437s
[TIMER]{MODULES}: 89s
[TIMER]{INSTALL}: 24s
[TIMER]{TOTAL} 2569s
Rebooting in 10 seconds
```
```
[g.v.rose@rocky8_6-base-rt ~]$ uname -a
Linux rocky8_6-base-rt 4.18.0-gvrose_ciqlts8_6-rt+ #3 SMP PREEMPT_RT Thu Jan 30 21:21:37 EST 2025 x86_64 x86_64 x86_64 GNU/Linux
```

**Kernel Selftests**

No difference between two runs
[kernel-selftests-before.log](https://github.com/user-attachments/files/18625521/kernel-selftests-before.log)
[kernel-selftests-after.log](https://github.com/user-attachments/files/18625522/kernel-selftests-after.log)

The kernel selftests show the BPF verifier tests are successful and this is a well known fix from previous patches for CVE-2023-2163.
