### PR TITLE
[LTS RT 8.8] bpf: Fix incorrect verifier pruning due to missing register precision…

### DIFF
--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -2224,6 +2224,21 @@ static int backtrack_insn(struct bpf_verifier_env *env, int idx,
 			}
 		} else if (opcode == BPF_EXIT) {
 			return -ENOTSUPP;
+		} else if (BPF_SRC(insn->code) == BPF_X) {
+			if (!(*reg_mask & (dreg | sreg)))
+				return 0;
+			/* dreg <cond> sreg
+			 * Both dreg and sreg need precision before
+			 * this insn. If only sreg was marked precise
+			 * before it would be equally necessary to
+			 * propagate it to dreg.
+			 */
+			*reg_mask |= (sreg | dreg);
+			 /* else dreg <cond> K
+			  * Only dreg still needs precision before
+			  * this insn, so for the K-based conditional
+			  * there is nothing new to be marked.
+			  */
 		}
 	} else if (class == BPF_LD) {
 		if (!(*reg_mask & dreg))


### PR DESCRIPTION
VULN-3188
CVE-2023-2163

**Builds and Loads**
[ciqlts8_8-rt-build.log](https://github.com/user-attachments/files/18625876/ciqlts8_8-rt-build.log)

The kABI check is skipped for 8.x RT kernels because there is no stable kABI.

```
skipkabi is true
/home/g.v.rose/prj/ramdisk/kernel-build-ciqlts8_8-rt
  CLEAN   .
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   security/selinux
  CLEAN   usr
  CLEAN   samples/hidraw
  CLEAN   arch/x86/tools
  CLEAN    resolve_btfids
  CLEAN   .tmp_versions
[TIMER]{MRPROPER}: 13s
x86_64 architecture detected, copying config
'configs/kernel-rt-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-gvrose_ciqlts8_8-rt"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  DESCEND objtool
  DESCEND bpf/resolve_btfids
  MKDIR     /mnt/ramdisk/kernel-build-ciqlts8_8-rt/tools/bpf/resolve_btfids//libbpf
  MKDIR     /mnt/ramdisk/kernel-build-ciqlts8_8-rt/tools/bpf/resolve_btfids//libsubcmd
```
[SNIP]

```
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-gvrose_ciqlts8_8-rt+
[TIMER]{MODULES}: 75s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-gvrose_ciqlts8_8-rt+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 23s
Checking kABI
kABI check skipped
Setting Default Kernel to /boot/vmlinuz-4.18.0-gvrose_ciqlts8_8-rt+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 13s
[TIMER]{BUILD}: 2403s
[TIMER]{MODULES}: 75s
[TIMER]{INSTALL}: 23s
[TIMER]{TOTAL} 2523s
Rebooting in 10 seconds
```
```
[g.v.rose@rocky8_8-base-rt ~]$ uname -a
Linux rocky8_8-base-rt 4.18.0-gvrose_ciqlts8_8-rt+ #2 SMP PREEMPT_RT Thu Jan 30 21:22:42 EST 2025 x86_64 x86_64 x86_64 GNU/Linux
```
There was some flap in the kernel selftest runs - I've uploaded several
[kernel-selftests-before.log](https://github.com/user-attachments/files/18625891/kernel-selftests-before.log)
[kernel-selftests-after.log](https://github.com/user-attachments/files/18625892/kernel-selftests-after.log)
[kernel-selftests-after_try2.log](https://github.com/user-attachments/files/18625894/kernel-selftests-after_try2.log)
[kernel-selftests-after_try3.log](https://github.com/user-attachments/files/18625895/kernel-selftests-after_try3.log)

In all of the logs the bpf tests, which this patch address, are all passing and no issue or change is detected.  The flap in test results is not due to our change and is ignored.
