### PR TITLE
[SIG CLOUD 9] rebase custom changes to 5.14.0-503.22.1.el9_5

### DIFF
--- a/arch/x86/include/asm/page_64.h
+++ b/arch/x86/include/asm/page_64.h
@@ -17,6 +17,7 @@ extern unsigned long phys_base;
 extern unsigned long page_offset_base;
 extern unsigned long vmalloc_base;
 extern unsigned long vmemmap_base;
+extern unsigned long physmem_end;
 
 static __always_inline unsigned long __phys_addr_nodebug(unsigned long x)
 {

--- a/arch/x86/include/asm/pgtable_64_types.h
+++ b/arch/x86/include/asm/pgtable_64_types.h
@@ -140,6 +140,10 @@ extern unsigned int ptrs_per_p4d;
 # define VMEMMAP_START		__VMEMMAP_BASE_L4
 #endif /* CONFIG_DYNAMIC_MEMORY_LAYOUT */
 
+#ifdef CONFIG_RANDOMIZE_MEMORY
+# define PHYSMEM_END		physmem_end
+#endif
+
 /*
  * End of the region for which vmalloc page tables are pre-allocated.
  * For non-KMSAN builds, this is the same as VMALLOC_END.

--- a/arch/x86/mm/init_64.c
+++ b/arch/x86/mm/init_64.c
@@ -950,7 +950,11 @@ static void update_end_of_memory_vars(u64 start, u64 size)
 int add_pages(int nid, unsigned long start_pfn, unsigned long nr_pages,
 	      struct mhp_params *params)
 {
+	unsigned long end = ((start_pfn + nr_pages) << PAGE_SHIFT) - 1;
 	int ret;
+
+	if (WARN_ON_ONCE(end > PHYSMEM_END))
+		return -ERANGE;
 
 	ret = __add_pages(nid, start_pfn, nr_pages, params);
 	WARN_ON_ONCE(ret);

--- a/arch/x86/mm/kaslr.c
+++ b/arch/x86/mm/kaslr.c
@@ -47,12 +47,23 @@ static const unsigned long vaddr_end = CPU_ENTRY_AREA_BASE;
  */
 static __initdata struct kaslr_memory_region {
 	unsigned long *base;
+	unsigned long *end;
 	unsigned long size_tb;
 } kaslr_regions[] = {
-	{ &page_offset_base, 0 },
-	{ &vmalloc_base, 0 },
-	{ &vmemmap_base, 0 },
+	{
+		.base	= &page_offset_base,
+		.end	= &physmem_end,
+	},
+	{
+		.base	= &vmalloc_base,
+	},
+	{
+		.base	= &vmemmap_base,
+	},
 };
+
+/* The end of the possible address space for physical memory */
+unsigned long physmem_end __ro_after_init;
 
 /* Get size in bytes used by the memory region */
 static inline unsigned long get_padding(struct kaslr_memory_region *region)
@@ -82,6 +93,8 @@ void __init kernel_randomize_memory(void)
 	BUILD_BUG_ON(vaddr_end != CPU_ENTRY_AREA_BASE);
 	BUILD_BUG_ON(vaddr_end > __START_KERNEL_map);
 
+	/* Preset the end of the possible address space for physical memory */
+	physmem_end = ((1ULL << MAX_PHYSMEM_BITS) - 1);
 	if (!kaslr_memory_enabled())
 		return;
 
@@ -128,11 +141,18 @@ void __init kernel_randomize_memory(void)
 		vaddr += entropy;
 		*kaslr_regions[i].base = vaddr;
 
-		/*
-		 * Jump the region and add a minimum padding based on
-		 * randomization alignment.
-		 */
+		/* Calculate the end of the region */
 		vaddr += get_padding(&kaslr_regions[i]);
+		/*
+		 * KASLR trims the maximum possible size of the
+		 * direct-map. Update the physmem_end boundary.
+		 * No rounding required as the region starts
+		 * PUD aligned and size is in units of TB.
+		 */
+		if (kaslr_regions[i].end)
+			*kaslr_regions[i].end = __pa_nodebug(vaddr - 1);
+
+		/* Add a minimum padding based on randomization alignment. */
 		vaddr = round_up(vaddr + 1, PUD_SIZE);
 		remain_entropy -= entropy;
 	}

--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -95,6 +95,10 @@ extern const int mmap_rnd_compat_bits_max;
 extern int mmap_rnd_compat_bits __read_mostly;
 #endif
 
+#ifndef PHYSMEM_END
+# define PHYSMEM_END	((1ULL << MAX_PHYSMEM_BITS) - 1)
+#endif
+
 #include <asm/page.h>
 #include <asm/processor.h>
 

--- a/kernel/resource.c
+++ b/kernel/resource.c
@@ -1806,8 +1806,7 @@ static resource_size_t gfr_start(struct resource *base, resource_size_t size,
 	if (flags & GFR_DESCENDING) {
 		resource_size_t end;
 
-		end = min_t(resource_size_t, base->end,
-			    (1ULL << MAX_PHYSMEM_BITS) - 1);
+		end = min_t(resource_size_t, base->end, PHYSMEM_END);
 		return end - size + 1;
 	}
 
@@ -1824,8 +1823,7 @@ static bool gfr_continue(struct resource *base, resource_size_t addr,
 	 * @size did not wrap 0.
 	 */
 	return addr > addr - size &&
-	       addr <= min_t(resource_size_t, base->end,
-			     (1ULL << MAX_PHYSMEM_BITS) - 1);
+	       addr <= min_t(resource_size_t, base->end, PHYSMEM_END);
 }
 
 static resource_size_t gfr_next(resource_size_t addr, resource_size_t size,

--- a/mm/memory_hotplug.c
+++ b/mm/memory_hotplug.c
@@ -1706,7 +1706,7 @@ struct range __weak arch_get_mappable_range(void)
 
 struct range mhp_get_pluggable_range(bool need_mapping)
 {
-	const u64 max_phys = (1ULL << MAX_PHYSMEM_BITS) - 1;
+	const u64 max_phys = PHYSMEM_END;
 	struct range mhp_range;
 
 	if (need_mapping) {

--- a/mm/sparse.c
+++ b/mm/sparse.c
@@ -129,7 +129,7 @@ static inline int sparse_early_nid(struct mem_section *section)
 static void __meminit mminit_validate_memmodel_limits(unsigned long *start_pfn,
 						unsigned long *end_pfn)
 {
-	unsigned long max_sparsemem_pfn = 1UL << (MAX_PHYSMEM_BITS-PAGE_SHIFT);
+	unsigned long max_sparsemem_pfn = (PHYSMEM_END + 1) >> PAGE_SHIFT;
 
 	/*
 	 * Sanity checks - do not allow an architecture to pass

--- a/tools/testing/selftests/mm/hmm-tests.c
+++ b/tools/testing/selftests/mm/hmm-tests.c
@@ -159,6 +159,10 @@ FIXTURE_TEARDOWN(hmm)
 {
 	int ret = close(self->fd);
 
+	if (ret != 0) {
+		fprintf(stderr, "close returned (%d) fd is (%d)\n", ret, self->fd);
+		exit(1);
+	}
 	ASSERT_EQ(ret, 0);
 	self->fd = -1;
 }


### PR DESCRIPTION
## Update process (This kernel CentOS base for `5.14.0-503`)
* Kernel History Rebuild Process for all `src.rpm`s hosted by RESF
* Create `sig-cloud-9/ 5.14.0-503.22.1.el9_5` branch
* Check if any maintained code is included in the new `el` release.
* Cherry-pick all code from previous branch into new branch (skipping unneeded code) 
  * Fix conflicts as they arise 
* Build and Test

## Removed Patches
* None

## BUILD
```
[maple@r9-sigcloud-builder kernel-src-tree]$ ../kernel-src-tree-tools/kernel_build.sh
/mnt/code/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h

[SNIP]

  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  BTF [M] sound/xen/snd_xen_front.ko
[TIMER]{BUILD}: 1659s
Making Modules
  INSTALL /lib/modules/5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  STRIP   /lib/modules/5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  SIGN    /lib/modules/5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+/kernel/arch/x86/crypto/blake2s-x86_64.ko

[SNIP]

  SIGN    /lib/modules/5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+
[TIMER]{MODULES}: 44s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 22s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+ and Index to 0
The default is /boot/loader/entries/5782692e02ef46cfa05ffa287f90171c-5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+
The default is /boot/loader/entries/5782692e02ef46cfa05ffa287f90171c-5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1659s
[TIMER]{MODULES}: 44s
[TIMER]{INSTALL}: 22s
[TIMER]{TOTAL} 1731s
Rebooting in 10 seconds
[maple@r9-sigcloud-builder kernel-src-tree]$ Connection to 192.168.122.155 closed by remote host.
Connection to 192.168.122.155 closed.
```

## Testing
Well this is less than usual but the two seem to be trading what works and what doesn't. 
And this is consistent ... we'll see if there is a difference after the build via `mock` for the SIG-CLOUD-9 as this might be related to the local `make` build.
```
kernel_5.14.0-503.22.1.el9_5.x86_64_iteration_* vs kernel_5.14.0-_jmaple__sig-cloud-9_5.14.0-503.22.1.el9_5+_iteration_*
5 ok 3 selftests: bpf: test_maps                vs 5 not ok 3 selftests: bpf: test_maps # exit=255
18 ok 16 selftests: bpf: test_kmod.sh           vs 18 not ok 16 selftests: bpf: test_kmod.sh # exit=1
23 ok 21 selftests: bpf: test_offload.py        vs 23 not ok 21 selftests: bpf: test_offload.py # exit=1
All Live Patches failed                         vs All Live Patches Succeeded
74 not ok 10 selftests: net: test_bpf.sh # exit=1.       vs 74 ok 10 selftests: net: test_bpf.sh
97 not ok 33 selftests: net: l2tp.sh # exit=1.           vs 97 ok 33 selftests: net: l2tp.sh
56 not ok 3 selftests: net/mptcp: mptcp_join.sh # exit=1 vs 256 ok 3 selftests: net/mptcp: mptcp_join.sh
```
![Screenshot 2025-02-04 at 1 17 32 PM](https://github.com/user-attachments/assets/1be94156-5283-4f1e-a718-afba60524fa0)
