### PR TITLE
[fips-9] media: uvcvideo: Skip parsing frames of type UVC_VS_UNDEFINED in uvc_parse_format

### DIFF
--- a/drivers/media/usb/uvc/uvc_driver.c
+++ b/drivers/media/usb/uvc/uvc_driver.c
@@ -672,7 +672,7 @@ static int uvc_parse_format(struct uvc_device *dev,
 	 * Parse the frame descriptors. Only uncompressed, MJPEG and frame
 	 * based formats have frame descriptors.
 	 */
-	while (buflen > 2 && buffer[1] == USB_DT_CS_INTERFACE &&
+	while (ftype && buflen > 2 && buffer[1] == USB_DT_CS_INTERFACE &&
 	       buffer[2] == ftype) {
 		frame = &format->frame[format->nframes];
 		if (ftype != UVC_VS_FRAME_FRAME_BASED)


### PR DESCRIPTION


jira VULN-9674
cve CVE-2024-53104

```
commit-author Benoit Sevens <bsevens@google.com>
commit ecf2b43018da9579842c774b7f35dbe11b5c38dd

This can lead to out of bounds writes since frames of this type were not taken into account when calculating the size of the frames buffer in uvc_parse_streaming.

Fixes: c0efd232929c ("V4L/DVB (8145a): USB Video Class driver")
	Signed-off-by: Benoit Sevens <bsevens@google.com>
	Cc: stable@vger.kernel.org
	Acked-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
	Reviewed-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
	Signed-off-by: Hans Verkuil <hverkuil@xs4all.nl>
(cherry picked from commit ecf2b43018da9579842c774b7f35dbe11b5c38dd)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

Same as https://github.com/ctrliq/kernel-src-tree/pull/108

[build.log](https://github.com/user-attachments/files/18756679/build.log)

kselftests were run before and after:
[selftests-before.log](https://github.com/user-attachments/files/18756685/selftests-before.log)
[selftests-after.log](https://github.com/user-attachments/files/18756691/selftests-after.log)

```
brett@lycia ~/ciq/vuln-9674 % grep ^ok selftests-before.log | wc -l
304
brett@lycia ~/ciq/vuln-9674 % grep ^ok selftests-after.log | wc -l
305
brett@lycia ~/ciq/vuln-9674 %

```