### PR TITLE
[LTS 8.8 RT] media: uvcvideo: Skip parsing frames of type UVC_VS_UNDEFINED in uvc_…

### DIFF
--- a/drivers/media/usb/uvc/uvc_driver.c
+++ b/drivers/media/usb/uvc/uvc_driver.c
@@ -645,7 +645,7 @@ static int uvc_parse_format(struct uvc_device *dev,
 	/* Parse the frame descriptors. Only uncompressed, MJPEG and frame
 	 * based formats have frame descriptors.
 	 */
-	while (buflen > 2 && buffer[1] == USB_DT_CS_INTERFACE &&
+	while (ftype && buflen > 2 && buffer[1] == USB_DT_CS_INTERFACE &&
 	       buffer[2] == ftype) {
 		frame = &format->frame[format->nframes];
 		if (ftype != UVC_VS_FRAME_FRAME_BASED)


### PR DESCRIPTION
jira VULN-9664
cve CVE-2024-53104
commit-author Benoit Sevens <bsevens@google.com>
commit ecf2b43018da9579842c774b7f35dbe11b5c38dd

This can lead to out of bounds writes since frames of this type were not taken into account when calculating the size of the frames buffer in uvc_parse_streaming.

Fixes: c0efd232929c ("V4L/DVB (8145a): USB Video Class driver")
	Signed-off-by: Benoit Sevens <bsevens@google.com>
	Cc: stable@vger.kernel.org
	Acked-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
	Reviewed-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
	Signed-off-by: Hans Verkuil <hverkuil@xs4all.nl>
(cherry picked from commit ecf2b43018da9579842c774b7f35dbe11b5c38dd)
	Signed-off-by: Greg Rose <g.v.rose@ciq.com>

**Builds and Loads**
`Already up to date.
configs/kernel-rt-4.18.0-x86_64.config:CONFIG_PREEMPT_RT=y
configs/kernel-rt-4.18.0-x86_64-debug.config:CONFIG_PREEMPT_RT=y
configs/kernel-rt-x86_64.config:# CONFIG_PREEMPT_RTB is not set
configs/kernel-rt-x86_64.config:CONFIG_PREEMPT_RT=y
configs/kernel-rt-x86_64-debug.config:# CONFIG_PREEMPT_RTB is not set
configs/kernel-rt-x86_64-debug.config:CONFIG_PREEMPT_RT=y
skipkabi is true
/home/gvrose8192/prj/kernel-build-gvrose_ciqlts8_8-rt
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-rt-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-gvrose_ciqlts8_8-rt"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
`
kABI check is skipped due to RT kernel ABI instability

[SNIP]

` INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-gvrose_ciqlts8_8-rt+
[TIMER]{MODULES}: 81s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-gvrose_ciqlts8_8-rt+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 32s
Checking kABI
kABI check skipped
Setting Default Kernel to /boot/vmlinuz-4.18.0-gvrose_ciqlts8_8-rt+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 4870s
[TIMER]{MODULES}: 81s
[TIMER]{INSTALL}: 32s
[TIMER]{TOTAL} 5004s
Rebooting in 10 seconds
`
`[gvrose8192@auto-kernel-test-88lts-rt ~]$ uname -a
Linux auto-kernel-test-88lts-rt 4.18.0-gvrose_ciqlts8_8-rt+ #1 SMP PREEMPT_RT Wed Feb 12 20:24:38 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux`

Note that this PR is using the newer kernel automation tests available in kernel-tools under the 'gvrose_more_automation' branch.

Full command and build logs attached.
[lts-8_8-rt-commands.log](https://github.com/user-attachments/files/18775927/lts-8_8-rt-commands.log)
[lts-8_8-rt-build.log](https://github.com/user-attachments/files/18775928/lts-8_8-rt-build.log)
