### PR TITLE
[LTS 9.2-RT] media: uvcvideo: Skip parsing frames of type UVC_VS_UNDEFINED in uvc_…

### DIFF
--- a/drivers/media/usb/uvc/uvc_driver.c
+++ b/drivers/media/usb/uvc/uvc_driver.c
@@ -672,7 +672,7 @@ static int uvc_parse_format(struct uvc_device *dev,
 	 * Parse the frame descriptors. Only uncompressed, MJPEG and frame
 	 * based formats have frame descriptors.
 	 */
-	while (buflen > 2 && buffer[1] == USB_DT_CS_INTERFACE &&
+	while (ftype && buflen > 2 && buffer[1] == USB_DT_CS_INTERFACE &&
 	       buffer[2] == ftype) {
 		frame = &format->frame[format->nframes];
 		if (ftype != UVC_VS_FRAME_FRAME_BASED)


### PR DESCRIPTION
jira VULN-9666
cve CVE-2024-53104
commit-author Benoit Sevens <bsevens@google.com>
commit ecf2b43018da9579842c774b7f35dbe11b5c38dd

This can lead to out of bounds writes since frames of this type were not taken into account when calculating the size of the frames buffer in uvc_parse_streaming.

Fixes: c0efd232929c ("V4L/DVB (8145a): USB Video Class driver")
	Signed-off-by: Benoit Sevens <bsevens@google.com>
	Cc: stable@vger.kernel.org
	Acked-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
	Reviewed-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
	Signed-off-by: Hans Verkuil <hverkuil@xs4all.nl>
(cherry picked from commit ecf2b43018da9579842c774b7f35dbe11b5c38dd)
	Signed-off-by: Greg Rose <g.v.rose@ciq.com>

**Builds and Loads**
```executing command /home/gvrose8192/prj/kernel-tools/build.sh gvrose_ciqlts9_2-rt /home/gvrose8192/prj
Your branch is up to date with 'origin/main'.
branch 'gvrose_ciqlts9_2-rt' set up to track 'origin/gvrose_ciqlts9_2-rt'.
Already up to date.
configs/kernel-rt-5.14.0-x86_64.config:CONFIG_PREEMPT_RT=y
configs/kernel-rt-5.14.0-x86_64-debug.config:CONFIG_PREEMPT_RT=y
skipkabi is true
/home/gvrose8192/prj/kernel-build-gvrose_ciqlts9_2-rt
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-rt-5.14.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-gvrose_ciqlts9_2-rt"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
                                                                                                                  6,1           Top
`
The kABI check is skipped for RT kernels since up to this time there has not been a stable kernel ABI for RT kernels.

[SNIP]
`  SIGN    /lib/modules/5.14.0-gvrose_ciqlts9_2-rt+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-gvrose_ciqlts9_2-rt+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-gvrose_ciqlts9_2-rt+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-gvrose_ciqlts9_2-rt+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-gvrose_ciqlts9_2-rt+
[TIMER]{MODULES}: 147s
Making Install
sh ./arch/x86/boot/install.sh \
        5.14.0-gvrose_ciqlts9_2-rt+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 34s
Checking kABI
kABI check skipped
Setting Default Kernel to /boot/vmlinuz-5.14.0-gvrose_ciqlts9_2-rt+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 4797s
[TIMER]{MODULES}: 147s
[TIMER]{INSTALL}: 34s
[TIMER]{TOTAL} 4998s
Rebooting in 10 seconds
```
```[gvrose8192@auto-kernel-test-92lts-rt ~]$ uname -a
Linux auto-kernel-test-92lts-rt 5.14.0-gvrose_ciqlts9_2-rt+ #1 SMP PREEMPT_RT Wed Feb 12 20:37:00 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
```
Full auto kernel test run commands and logs:
[lts-9_2-rt-commands.log](https://github.com/user-attachments/files/18776191/lts-9_2-rt-commands.log)
[lts-9_2-rt-build.log](https://github.com/user-attachments/files/18776193/lts-9_2-rt-build.log)

Nothing remarkable about the kernel selftest logs.