### PR TITLE
[LTS 9.4] tipc: Fix use-after-free of kernel socket in cleanup_bearer().

### DIFF
--- a/net/tipc/udp_media.c
+++ b/net/tipc/udp_media.c
@@ -818,10 +818,10 @@ static void cleanup_bearer(struct work_struct *work)
 		kfree_rcu(rcast, rcu);
 	}
 
-	atomic_dec(&tipc_net(sock_net(ub->ubsock->sk))->wq_count);
 	dst_cache_destroy(&ub->rcast.dst_cache);
 	udp_tunnel_sock_release(ub->ubsock);
 	synchronize_net();
+	atomic_dec(&tipc_net(sock_net(ub->ubsock->sk))->wq_count);
 	kfree(ub);
 }
 


### PR DESCRIPTION
jira VULN-8674
cve CVE-2024-56642
commit-author Kuniyuki Iwashima <kuniyu@amazon.com>
commit 6a2fa13312e51a621f652d522d7e2df7066330b6

```
syzkaller reported a use-after-free of UDP kernel socket in cleanup_bearer() without repro. [0][1]

When bearer_disable() calls tipc_udp_disable(), cleanup of the UDP kernel socket is deferred by work calling cleanup_bearer().

tipc_net_stop() waits for such works to finish by checking tipc_net(net)->wq_count.  However, the work decrements the count too early before releasing the kernel socket, unblocking cleanup_net() and resulting in use-after-free.

Let's move the decrement after releasing the socket in cleanup_bearer().

[0]:
ref_tracker: net notrefcnt@000000009b3d1faf has 1/1 users at
     sk_alloc+0x438/0x608
     inet_create+0x4c8/0xcb0
     __sock_create+0x350/0x6b8
     sock_create_kern+0x58/0x78
     udp_sock_create4+0x68/0x398
     udp_sock_create+0x88/0xc8
     tipc_udp_enable+0x5e8/0x848
     __tipc_nl_bearer_enable+0x84c/0xed8
     tipc_nl_bearer_enable+0x38/0x60
     genl_family_rcv_msg_doit+0x170/0x248
     genl_rcv_msg+0x400/0x5b0
     netlink_rcv_skb+0x1dc/0x398
     genl_rcv+0x44/0x68
     netlink_unicast+0x678/0x8b0
     netlink_sendmsg+0x5e4/0x898
     ____sys_sendmsg+0x500/0x830

[1]:
BUG: KMSAN: use-after-free in udp_hashslot include/net/udp.h:85 [inline] BUG: KMSAN: use-after-free in udp_lib_unhash+0x3b8/0x930 net/ipv4/udp.c:1979
 udp_hashslot include/net/udp.h:85 [inline]
 udp_lib_unhash+0x3b8/0x930 net/ipv4/udp.c:1979
 sk_common_release+0xaf/0x3f0 net/core/sock.c:3820
 inet_release+0x1e0/0x260 net/ipv4/af_inet.c:437
 inet6_release+0x6f/0xd0 net/ipv6/af_inet6.c:489
 __sock_release net/socket.c:658 [inline]
 sock_release+0xa0/0x210 net/socket.c:686
 cleanup_bearer+0x42d/0x4c0 net/tipc/udp_media.c:819
 process_one_work kernel/workqueue.c:3229 [inline]
 process_scheduled_works+0xcaf/0x1c90 kernel/workqueue.c:3310
 worker_thread+0xf6c/0x1510 kernel/workqueue.c:3391
 kthread+0x531/0x6b0 kernel/kthread.c:389
 ret_from_fork+0x60/0x80 arch/x86/kernel/process.c:147
 ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:244

Uninit was created at:
 slab_free_hook mm/slub.c:2269 [inline]
 slab_free mm/slub.c:4580 [inline]
 kmem_cache_free+0x207/0xc40 mm/slub.c:4682
 net_free net/core/net_namespace.c:454 [inline]
 cleanup_net+0x16f2/0x19d0 net/core/net_namespace.c:647
 process_one_work kernel/workqueue.c:3229 [inline]
 process_scheduled_works+0xcaf/0x1c90 kernel/workqueue.c:3310
 worker_thread+0xf6c/0x1510 kernel/workqueue.c:3391
 kthread+0x531/0x6b0 kernel/kthread.c:389
 ret_from_fork+0x60/0x80 arch/x86/kernel/process.c:147
 ret_from_fork_asm+0x11/0x20 arch/x86/entry/entry_64.S:244

CPU: 0 UID: 0 PID: 54 Comm: kworker/0:2 Not tainted 6.12.0-rc1-00131-gf66ebf37d69c #7 91723d6f74857f70725e1583cba3cf4adc716cfa
Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS rel-1.16.3-0-ga6ed6b701f0a-prebuilt.qemu.org 04/01/2014
Workqueue: events cleanup_bearer

Fixes: 26abe14379f8 ("net: Modify sk_alloc to not reference count the netns of kernel sockets.")
	Reported-by: syzkaller <syzkaller@googlegroups.com>
	Signed-off-by: Kuniyuki Iwashima <kuniyu@amazon.com>
Link: https://patch.msgid.link/20241127050512.28438-1-kuniyu@amazon.com
	Signed-off-by: Paolo Abeni <pabeni@redhat.com>

(cherry picked from commit 6a2fa13312e51a621f652d522d7e2df7066330b6)
	Signed-off-by: David Gomez <dgomez@ciq.com>
```

Build.log
```
INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+
[TIMER]{MODULES}: 39s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 25s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+ and Index to 0
The default is /boot/loader/entries/7554588dbe7f45cbbd9e84245a2afeb6-5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+
The default is /boot/loader/entries/7554588dbe7f45cbbd9e84245a2afeb6-5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 7s
[TIMER]{BUILD}: 2355s
[TIMER]{MODULES}: 39s
[TIMER]{INSTALL}: 25s
[TIMER]{TOTAL} 2431s
```
Kernel selftest logs:
With kernel 5.14.0-ciqlts9_4+
[kernel-selftest_before.log](https://github.com/user-attachments/files/18804880/kernel-selftest_before.log)
With kernel (change applied to lts9.4 branch) 5.14.0-dgomez_ciqlts9_4_CVE-2024-56642+
[kernel-selftest_after.log](https://github.com/user-attachments/files/18804879/kernel-selftest_after.log)
```
[dgomez@r94 kernel-src-tree]$ grep '^ok' kernel-selftest_before.log | wc -l
344
[dgomez@r94 kernel-src-tree]$ grep '^ok' kernel-selftest_after.log | wc -l
345
[dgomez@r94 kernel-src-tree]$ grep 'not ok' kernel-selftest_before.log | wc -l
194
[dgomez@r94 kernel-src-tree]$ grep 'not ok' kernel-selftest_after.log | wc -l
193
```