### PR TITLE
[LTS 8.10 FIPS] CVE-2024-53104 kernel fips-8.10

### DIFF
--- a/.github/workflows/build-check_aarch64.yml
+++ b/.github/workflows/build-check_aarch64.yml
@@ -1,0 +1,34 @@
+name: aarch64 CI
+on:
+  pull_request:
+    branches:
+      - '**'
+      - '!mainline'
+
+jobs:
+  kernel-build-job:
+    runs-on:
+      labels: kernel-build-arm64
+    container:
+      image: rockylinux:8
+      env:
+        ROCKY_ENV: rocky8
+      ports:
+        - 80
+      options: --cpus 8
+    steps:
+      - name: Install tools and Libraries
+        run: |
+          dnf groupinstall 'Development Tools' -y
+          dnf install --enablerepo=devel bc dwarves kernel-devel openssl-devel elfutils-libelf-devel -y
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.head.sha }}"
+          fetch-depth: 0
+      - name: Build the Kernel
+        run: |
+          git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
+          cp configs/kernel-4.18.0-aarch64.config .config
+          make olddefconfig
+          make -j8

--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -1,0 +1,34 @@
+name: x86_64 CI
+on:
+  pull_request:
+    branches:
+      - '**'
+      - '!mainline'
+
+jobs:
+  kernel-build-job:
+    runs-on:
+      labels: kernel-build
+    container:
+      image: rockylinux:8
+      env:
+        ROCKY_ENV: rocky8
+      ports:
+        - 80
+      options: --cpus 8
+    steps:
+      - name: Install tools and Libraries
+        run: |
+          dnf groupinstall 'Development Tools' -y
+          dnf install --enablerepo=devel bc dwarves kernel-devel openssl-devel elfutils-libelf-devel -y
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.head.sha }}"
+          fetch-depth: 0
+      - name: Build the Kernel
+        run: |
+          git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
+          cp configs/kernel-4.18.0-x86_64.config .config
+          make olddefconfig
+          make -j8

--- a/drivers/media/usb/uvc/uvc_driver.c
+++ b/drivers/media/usb/uvc/uvc_driver.c
@@ -368,7 +368,7 @@ static int uvc_parse_format(struct uvc_device *dev,
 	 * Parse the frame descriptors. Only uncompressed, MJPEG and frame
 	 * based formats have frame descriptors.
 	 */
-	while (buflen > 2 && buffer[1] == USB_DT_CS_INTERFACE &&
+	while (ftype && buflen > 2 && buffer[1] == USB_DT_CS_INTERFACE &&
 	       buffer[2] == ftype) {
 		frame = &format->frame[format->nframes];
 		if (ftype != UVC_VS_FRAME_FRAME_BASED)


### PR DESCRIPTION
**Builds and Loads**

```
our branch is up to date with 'origin/main'.
branch 'gvrose_fips-8-complaint/4.18.0-553.16.1' set up to track 'origin/gvrose_fips-8-complaint/4.18.0-553.16.1'.
Already up to date.
/home/gvrose8192/prj/kernel-build-gvrose_fips-8-complaint/4.18.0-553.16.1
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-gvrose_fips-8-complaint_4.18.0-553.16.1"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
```
[SNIP]
```
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-gvrose_fips-8-complaint_4.18.0-553.16.1+
[TIMER]{MODULES}: 83s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-gvrose_fips-8-complaint_4.18.0-553.16.1+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 35s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-gvrose_fips-8-complaint_4.18.0-553.16.1+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 5177s
[TIMER]{MODULES}: 83s
[TIMER]{INSTALL}: 35s
[TIMER]{TOTAL} 5317s
Rebooting in 10 seconds
[gvrose8192@auto-kernel-test-fips810 ~]$ uname -a
Linux auto-kernel-test-fips810 4.18.0-gvrose_fips-8-complaint_4.18.0-553.16.1+ #1 SMP Fri Feb 14 20:59:34 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
```
**Commands and Build logs**
[lts-8_10-commands-pass3.log](https://github.com/user-attachments/files/18805627/lts-8_10-commands-pass3.log)
[lts-8_10-build-pass3.log](https://github.com/user-attachments/files/18805639/lts-8_10-build-pass3.log)

There's no reason to think this patch would cause any issues.