### PR TITLE
[LTS 8.8] CVE-2023-4623, VULN-6709

### DIFF
--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -1012,6 +1012,10 @@ hfsc_change_class(struct Qdisc *sch, u32 classid, u32 parentid,
 		if (parent == NULL)
 			return -ENOENT;
 	}
+	if (!(parent->cl_flags & HFSC_FSC) && parent != &q->root) {
+		NL_SET_ERR_MSG(extack, "Invalid parent - parent class must have FSC");
+		return -EINVAL;
+	}
 
 	if (classid == 0 || TC_H_MAJ(classid ^ sch->handle) != 0)
 		return -EINVAL;


### PR DESCRIPTION
[LTS 8.8]
CVE-2023-4623
VULN-6709


# Problem

<https://www.cve.org/CVERecord?id=CVE-2023-4623>

> A use-after-free vulnerability in the Linux kernel's net/sched: sch\_hfsc (HFSC qdisc traffic control) component can be exploited to achieve local privilege escalation. If a class with a link-sharing curve (i.e. with the HFSC\_FSC flag set) has a parent without a link-sharing curve, then init\_vf() will call vttree\_insert() on the parent, but vttree\_remove() will be skipped in update\_vf(). This leaves a dangling pointer that can cause a use-after-free.


# Analysis and solution

A single commit was identified as a fix for this issue: [b3d26c5702c7d6c45456326e56d2ccf3f103e60f](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=b3d26c5702c7d6c45456326e56d2ccf3f103e60f) *net/sched: sch\_hfsc: Ensure inner classes have fsc curve*.

The solution consisted of rejecting the addition of a class with a link-sharing curve to the class without it (see [Specific tests](#org45c124b) for details):

    [root@ciqlts8_8 pvts]# (
        tc qdisc add dev lo root handle 1: hfsc default 10
        tc class add dev lo parent 1: classid 1:1 hfsc rt m2 100kbps
        tc class add dev lo parent 1:1 classid 1:10 hfsc ls m2 50kbps
        echo $?
    )

    Error: Invalid parent - parent class must have FSC.
    2

The fix introduced a problem with existing network setup scripts for some users <https://lore.kernel.org/all/297D84E3-736E-4AB4-B825-264279E2043C@flyingcircus.io/>:

> I upgraded from 6.1.38 to 6.1.55 this morning and it broke my traffic shaping script, leaving me with a non-functional uplink on a remote router.

It was decided to fix the problem without breaking backwards compatibility <https://lore.kernel.org/all/20231013151057.2611860-1-pctammela@mojatatu.com/>:

> > Setting 'rt' as a parent is incorrect and the man page is explicit about 
> > it as it doesn't make sense 'qdisc wise'. Being able to set it has 
> > always been wrong unfortunately&#x2026;
> 
> Sure but unfortunately "we don't break backward compat" means
> we can't really argue. It will take us more time to debate this
> than to fix it (assuming we understand the initial problem).
> 
> Frankly one can even argue whether "exploitable by root / userns"
> is more important than single user's init scripts breaking.
> The "security" issues for root are dime a dozen.

The solution was to change the erroneous qdisc hierarchy to a correct one when the possible UAF condition was detected <https://lore.kernel.org/all/20231013151057.2611860-1-pctammela@mojatatu.com/>:

> As reported [1] disallowing 'rt' inner curves breaks already existing
> scripts. Even though it doesn't make sense 'qdisc wise' users have been
> relying on this behaviour since the qdisc inception.
> 
> We need users to update the scripts/applications to use 'sc' or 'ls'
> as a inner curve instead of 'rt', but also avoid the UAF found by
> Budimir, which was present since the qdisc inception.

The fix of the fix is given in the commit [a13b67c9a015c4e21601ef9aa4ec9c5d972df1b4](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a13b67c9a015c4e21601ef9aa4ec9c5d972df1b4) *net/sched: sch\_hfsc: upgrade 'rt' to 'sc' when it becomes a inner curve*

While the changes could be squashed into a single commit it was decided to retain the sequence of two commits for more straightforward LTS 8.8 - mainline patches correspondence.

The same solution was used already in other "version 8" branches `centos8`, `fips-8-complaint/4.18.0-553.16.1`, `fips-8/4.18.0-553.16.1`, `rocky8_10`, `sig-cloud-8/4.18.0-553.22.1.el8_10`, `sig-cloud-8/4.18.0-553.33.1.el8_10`, `sig-cloud-8/4.18.0-553.36.1.el8_10`:

    git --no-pager log --decorate  --format="%h %cd %d %s" --date=short -n 2 ae71642ce

    ae71642ce 2024-09-11  net/sched: sch_hfsc: upgrade 'rt' to 'sc' when it becomes a inner curve
    1a61f0a5d 2024-09-11  net/sched: sch_hfsc: Ensure inner classes have fsc curve


# kABI check: passed

    CVE=CVE-2023-4623 ./ninja.sh _kabi_checked_ciqlts8_8-CVE-2023-4623

    ninja: Entering directory `/data/build/rocky-patching'
    [0/2] Create worktree for branch 'el-8.8': '/data/src/ctrliq-github/kernel-dist-git-el-8.8' (main repo: '/data/src/ctrliq-github/kernel-dist-git')
    + rm -rf /data/src/ctrliq-github/kernel-dist-git-el-8.8
    + git -C /data/src/ctrliq-github/kernel-dist-git worktree prune
    + git -C /data/src/ctrliq-github/kernel-dist-git worktree add /data/src/ctrliq-github/kernel-dist-git-el-8.8 el-8.8
    Preparing worktree (checking out 'el-8.8')
    HEAD is now at 3120f78 import kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1
    [1/2] Check ABI of kernel [ciqlts8_8-CVE-2023-4623]	_kabi_checked_ciqlts8_8-CVE-2023-4623
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/Module.kabi_x86_64 -s vms/build-ciqlts8_8/build_files/kernel-src-tree-ciqlts8_8-CVE-2023-4623/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_8-CVE-2023-4623/kabi_checked


# Boot test: passed

Refer to [Specific tests](#org45c124b) for implicit boot test passing.


# Kselftests


## Methodology

A mix of `kernel-selftests-internal` and source-compiled tests were used:

-   **`kernel-selftests-internal`:** `bpf` tests, except:
    -   **`bpf:test_kmod.sh`:** takes very long time to finish and always fails anyway,
    -   **`bpf:test_progs`:** unstable, can crash the machine,
    -   **`bpf:test_progs-no_alu32`:** unstable, can crash the machine.
-   **source-compiled:** all the rest.


## Coverage (including tests skipped during execution)

`android`, `bpf`, `breakpoints`, `capabilities`, `cgroup`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/net/bonding`, `drivers/net/team`, `efivarfs`, `exec`, `filesystems`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `mqueue`, `net`, `net/forwarding`, `net/mptcp`, `netfilter`, `nsfs`, `proc`, `pstore`, `ptrace`, `rseq`, `rtc`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `sysctl`, `tc-testing`, `tdx`, `timens`, `timers`, `tpm2`, `user`, `vm`, `x86`, `zram`


## Reference `ciqlts8_8` (`6bfcdd41f5877d7326b3c3bf848f8f9c0c93465c`)

Two test runs were conducted on the reference kernel.
[kselftests&#x2013;mixed&#x2013;ciqlts8\_8&#x2013;run1.log](<https://github.com/user-attachments/files/18888966/kselftests--mixed--ciqlts8_8--run1.log>)
[kselftests&#x2013;mixed&#x2013;ciqlts8\_8&#x2013;run2.log](<https://github.com/user-attachments/files/18888964/kselftests--mixed--ciqlts8_8--run2.log>)


## Patch `ciqlts8_8-CVE-2023-4623` (`e35af37ed7bf4462a9c57844fcce23b19862df90`)

Two test runs were conducted on the patched kernel.
[kselftests&#x2013;mixed&#x2013;ciqlts8\_8-CVE-2023-4623&#x2013;run1.log](<https://github.com/user-attachments/files/18888960/kselftests--mixed--ciqlts8_8-CVE-2023-4623--run1.log>)
[kselftests&#x2013;mixed&#x2013;ciqlts8\_8-CVE-2023-4623&#x2013;run2.log](<https://github.com/user-attachments/files/18888956/kselftests--mixed--ciqlts8_8-CVE-2023-4623--run2.log>)


## Comparison

    ktests.xsh  table --where "Summary = 'diff'"  kselftests*.log

    Column    File
    --------  ----------------------------------------------------
    Status0   kselftests--mixed--ciqlts8_8--run1.log
    Status1   kselftests--mixed--ciqlts8_8--run2.log
    Status2   kselftests--mixed--ciqlts8_8-CVE-2023-4623--run1.log
    Status3   kselftests--mixed--ciqlts8_8-CVE-2023-4623--run2.log
    
    TestCase                   Status0  Status1  Status2  Status3  Summary
    net/mptcp:simult_flows.sh  pass     fail     pass     fail     diff
    net:gro.sh                 fail     pass     pass     pass     diff
    net:ip_defrag.sh           fail     pass     pass     pass     diff
    net:reuseport_addr_any.sh  pass     fail     fail     fail     diff

Tests `net/mptcp:simult_flows.sh`, `net:gro.sh` have already shown inconsistent behavior before <https://docs.google.com/spreadsheets/d/1tUwJ2rV57cYZXh7momPtraSjZcHDjMYHLeHA3DYWrUU/edit?pli=1&gid=0#gid=0&range=F:G>

The `net:ip_defrag.sh`, `net:reuseport_addr_any.sh` tests showed inconsistent behavior in the reference tests set itself. Added to the list of "flappy" tests for the `ciqlts8_8` platform.


<a id="org45c124b"></a>

# Specific tests: passed

The potential UAF condition was found to be reproducible with the following `tc` commands sequence:

    tc qdisc add dev lo root handle 1: hfsc default 10
    # Inner hfsc class constructed with 'rt' - realtime service
    tc class add dev lo parent 1: classid 1:1 hfsc rt m2 100kbps
    # Leaf hfsc class constructed with 'ls' - linksharing service
    tc class add dev lo parent 1:1 classid 1:10 hfsc ls m2 50kbps

The "100kbps", "50kbps" parts are arbitrary. What's important is the use of `rt` for the inner class and `ls` for the leaf class. While the exact UAF was not obtained the commands helped confirm the efficacy of the patch.


## Reference

The incorrect qdisc hierarchy can be created without any guardrails.

    [root@ciqlts8_8 pvts]# (
        tc qdisc add dev lo root handle 1: hfsc default 10
        tc class add dev lo parent 1: classid 1:1 hfsc rt m2 100kbps
        tc class add dev lo parent 1:1 classid 1:10 hfsc ls m2 50kbps
        echo $?
    )
    0
    [root@ciqlts8_8 pvts]# tc -g class show dev lo
    tc -g  class show dev lo
    +---(1:) hfsc 
         +---(1:1) hfsc rt m1 0bit d 0us m2 800Kbit 
              +---(1:10) hfsc ls m1 0bit d 0us m2 400Kbit 

Full logs:
[fix-replicate&#x2013;ciqlts8\_8.log](<https://github.com/user-attachments/files/18888970/fix-replicate--ciqlts8_8.log>)


## Patch

Creating the incorrect qdisc hierarchy raises a warning, but succeeds. Notice the type of inner class being `sc` instead of `rt` as shown by `tc -g class show dev lo` command.

    [root@ciqlts8_8 pvts]# (
        tc qdisc add dev lo root handle 1: hfsc default 10
        tc class add dev lo parent 1: classid 1:1 hfsc rt m2 100kbps
        tc class add dev lo parent 1:1 classid 1:10 hfsc ls m2 50kbps
        echo $?
    )
    Warning: Forced curve change on parent 'rt' to 'sc'.
    0
    [root@ciqlts8_8 pvts]# tc -g  class show dev lo
    tc -g  class show dev lo
    +---(1:) hfsc 
         +---(1:1) hfsc sc m1 0bit d 0us m2 800Kbit 
              +---(1:10) hfsc ls m1 0bit d 0us m2 400Kbit 

Full logs:
[fix-replicate&#x2013;ciqlts8\_8-CVE-2023-4623&#x2013;1.log](<https://github.com/user-attachments/files/18888972/fix-replicate--ciqlts8_8-CVE-2023-4623--1.log>)

