### PR TITLE
[LTS 9.2 RT] CVE-2023-4623, VULN-6713

### DIFF
--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -1012,6 +1012,10 @@ hfsc_change_class(struct Qdisc *sch, u32 classid, u32 parentid,
 		if (parent == NULL)
 			return -ENOENT;
 	}
+	if (!(parent->cl_flags & HFSC_FSC) && parent != &q->root) {
+		NL_SET_ERR_MSG(extack, "Invalid parent - parent class must have FSC");
+		return -EINVAL;
+	}
 
 	if (classid == 0 || TC_H_MAJ(classid ^ sch->handle) != 0)
 		return -EINVAL;


### PR DESCRIPTION
[LTS 9.2 RT]
CVE-2023-4623
VULN-6713


# Problem

<https://www.cve.org/CVERecord?id=CVE-2023-4623>

> A use-after-free vulnerability in the Linux kernel's net/sched: sch\_hfsc (HFSC qdisc traffic control) component can be exploited to achieve local privilege escalation. If a class with a link-sharing curve (i.e. with the HFSC\_FSC flag set) has a parent without a link-sharing curve, then init\_vf() will call vttree\_insert() on the parent, but vttree\_remove() will be skipped in update\_vf(). This leaves a dangling pointer that can cause a use-after-free.


# Analysis and solution

A single commit was identified as a fix for this issue: [b3d26c5702c7d6c45456326e56d2ccf3f103e60f](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=b3d26c5702c7d6c45456326e56d2ccf3f103e60f) *net/sched: sch\_hfsc: Ensure inner classes have fsc curve*.

The solution consisted of rejecting the addition of a class with a link-sharing curve to the class without it (see [Specific tests](#org61dd4e5) for details):

    [root@ciqlts9 pvts]# (
        tc qdisc add dev lo root handle 1: hfsc default 10
        tc class add dev lo parent 1: classid 1:1 hfsc rt m2 100kbps
        tc class add dev lo parent 1:1 classid 1:10 hfsc ls m2 50kbps
        echo $?
    )

    Error: Invalid parent - parent class must have FSC.
    2

The fix introduced a problem with existing network setup scripts for some users <https://lore.kernel.org/all/297D84E3-736E-4AB4-B825-264279E2043C@flyingcircus.io/>:

> I upgraded from 6.1.38 to 6.1.55 this morning and it broke my traffic shaping script, leaving me with a non-functional uplink on a remote router.

It was decided to fix the problem without breaking backwards compatibility <https://lore.kernel.org/all/20231013151057.2611860-1-pctammela@mojatatu.com/>:

> > Setting 'rt' as a parent is incorrect and the man page is explicit about 
> > it as it doesn't make sense 'qdisc wise'. Being able to set it has 
> > always been wrong unfortunately&#x2026;
> 
> Sure but unfortunately "we don't break backward compat" means
> we can't really argue. It will take us more time to debate this
> than to fix it (assuming we understand the initial problem).
> 
> Frankly one can even argue whether "exploitable by root / userns"
> is more important than single user's init scripts breaking.
> The "security" issues for root are dime a dozen.

The solution was to change the erroneous qdisc hierarchy to a correct one when the possible UAF condition was detected <https://lore.kernel.org/all/20231013151057.2611860-1-pctammela@mojatatu.com/>:

> As reported [1] disallowing 'rt' inner curves breaks already existing
> scripts. Even though it doesn't make sense 'qdisc wise' users have been
> relying on this behaviour since the qdisc inception.
> 
> We need users to update the scripts/applications to use 'sc' or 'ls'
> as a inner curve instead of 'rt', but also avoid the UAF found by
> Budimir, which was present since the qdisc inception.

The fix of the fix is given in the commit [a13b67c9a015c4e21601ef9aa4ec9c5d972df1b4](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a13b67c9a015c4e21601ef9aa4ec9c5d972df1b4) *net/sched: sch\_hfsc: upgrade 'rt' to 'sc' when it becomes a inner curve*

While the changes could be squashed into a single commit it was decided to retain the sequence of two commits for more straightforward LTS 9.2 RT - mainline patches correspondence.

The same solution was used already in other "version 9" branches `centos9`, `ciqlts9_4`, `rocky9_4`, `rocky9_5`, `sig-cloud-9/5.14.0-427.37.1.el9_4`, `sig-cloud-9/5.14.0-427.40.1.el9_4`, `sig-cloud-9/5.14.0-427.42.1.el9_4`, `sig-cloud-9/5.14.0-503.19.1.el9_5`, `sig-cloud-9/5.14.0-503.22.1.el9_5`:

    git --no-pager log --decorate  --format="%h %cd %d %s" --date=short -n 2 9950d4d93

    9950d4d93 2023-10-26  net/sched: sch_hfsc: upgrade 'rt' to 'sc' when it becomes a inner curve
    ff4452fb0 2023-10-26  net/sched: sch_hfsc: Ensure inner classes have fsc curve


# kABI check: omitted (unstable ABI of RT kernels)


# Boot test: passed

Refer to [Specific tests](#org61dd4e5) for implicit boot test passing.


# Kselftests: passed relative


## Methodology

A mix of `kernel-selftests-internal` and source-compiled tests were used:

-   **`kernel-selftests-internal`:** `bpf` tests, except:
    -   **`bpf:test_kmod.sh`:** takes very long time to finish and always fails anyway,
    -   **`bpf:test_progs`:** unstable, can crash the machine,
    -   **`bpf:test_progs-no_alu32`:** unstable, can crash the machine.
-   **source-compiled:** all the rest.


## Coverage (including tests skipped during execution)

`bpf`, `breakpoints`, `capabilities`, `clone3`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding`, `drivers/net/team`, `efivarfs`, `filesystems`, `filesystems/binderfs`, `filesystems/epoll`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `ir`, `kcmp`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net`, `net/forwarding`, `net/mptcp`, `netfilter`, `nsfs`, `openat2`, `pid_namespace`, `pidfd`, `pstore`, `ptrace`, `rlimits`, `rseq`, `rtc`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `syscall_user_dispatch`, `sysctl`, `tc-testing`, `tdx`, `timens`, `timers`, `tmpfs`, `tpm2`, `user`, `vDSO`, `vm`, `x86`, `zram`


## Reference `ciqlts9_2-rt` (`4c5f656231e024966e5df6be5a66e3adf36379fb`)

Three test runs were conducted on the reference kernel.
[kselftests&#x2013;mixed&#x2013;ciqlts9\_2-rt&#x2013;run1.log](<https://github.com/user-attachments/files/18892139/kselftests--mixed--ciqlts9_2-rt--run1.log>)
[kselftests&#x2013;mixed&#x2013;ciqlts9\_2-rt&#x2013;run2.log](<https://github.com/user-attachments/files/18892138/kselftests--mixed--ciqlts9_2-rt--run2.log>)
[kselftests&#x2013;mixed&#x2013;ciqlts9\_2-rt&#x2013;run3.log](<https://github.com/user-attachments/files/18892135/kselftests--mixed--ciqlts9_2-rt--run3.log>)


## Patch `ciqlts9_2-rt-CVE-2023-4623` (`752717727a98bd7e29840fc4c65f8721aaae6a10`)

A single test run was conducted on the patched kernel.
[kselftests&#x2013;mixed&#x2013;ciqlts9\_2-rt-CVE-2023-4623.log](<https://github.com/user-attachments/files/18892134/kselftests--mixed--ciqlts9_2-rt-CVE-2023-4623.log>)


## Comparison

    /home/pvts/gtd/projects/conclusive/ciq/rocky-patching/ktests.xsh  table --where "Summary = 'diff'"  kselftests*.log

    Column    File
    --------  -------------------------------------------------
    Status0   kselftests--mixed--ciqlts9_2-rt--run1.log
    Status1   kselftests--mixed--ciqlts9_2-rt--run2.log
    Status2   kselftests--mixed--ciqlts9_2-rt--run3.log
    Status3   kselftests--mixed--ciqlts9_2-rt-CVE-2023-4623.log
    
    TestCase                  Status0  Status1  Status2  Status3  Summary
    net/mptcp:mptcp_join.sh   fail     pass     pass     pass     diff
    net:gro.sh                fail     pass     pass     pass     diff
    net:txtimestamp.sh        pass     fail     fail     pass     diff
    net:udpgso_bench.sh       pass     fail     pass     pass     diff
    rtc:rtctest               fail     pass     fail     fail     diff
    x86:syscall_numbering_64  fail     fail     pass     pass     diff

All of the tests with different results in the tested patch showed inconsistent behavior in the reference tests set itself. The `net/mptcp:mptcp_join.sh` test have shown inconsistent behavior before. Likely `net:gro.sh`, `rtc:rtctest`, `net:txtimestamp.sh`, although not yet on the `ciqlts9_2-rt` platform. Added to the list of flappy tests.

The `net:udpgso_bench.sh` did show inconsistent behavior before across different platforms but not on a single one. The one failing test seems to be associated with resources depletion

    ...
    # udp gso zerocopy
    # ./udpgso_bench_tx: sendmsg: No buffer space available
    # udp gso timestamp
    ...

The `x86:syscall_numbering_64` shows inconsistent behavior for the first time. All problems are associated with associated `MODIFIED_BY_PTRACE` errno, and returning -38 by the system call instead (`ENOSYS 38 Function not implemented`):

    # [FAIL]              x32 syscall 0:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -1:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1073741823:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1073741824:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1073741823:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -1073741824:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 2147483647:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -2147483648:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -2147483647:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 0:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -1:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1073741823:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1073741824:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1073741823:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -1073741824:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 2147483647:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -2147483648:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -2147483647:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 0:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -1:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1073741823:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1073741824:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 1073741823:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -1073741824:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall 2147483647:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -2147483648:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]              x32 syscall -2147483647:-1 returned -38, but it should have returned MODIFIED_BY_PTRACE
    # [FAIL]  A total of 30 system calls had incorrect behavior

The details of this failure were not investigated further


<a id="org61dd4e5"></a>

# Specific tests: passed

The potential UAF condition was found to be reproducible with the following `tc` commands sequence:

    tc qdisc add dev lo root handle 1: hfsc default 10
    # Inner hfsc class constructed with 'rt' - realtime service
    tc class add dev lo parent 1: classid 1:1 hfsc rt m2 100kbps
    # Leaf hfsc class constructed with 'ls' - linksharing service
    tc class add dev lo parent 1:1 classid 1:10 hfsc ls m2 50kbps

The "100kbps", "50kbps" parts are arbitrary. What's important is the use of `rt` for the inner class and `ls` for the leaf class. While the exact UAF was not obtained the commands helped confirm the efficacy of the patch.


## Reference

The incorrect qdisc hierarchy can be created without any guardrails.

    [root@ciqlts9 pvts]# (
        tc qdisc add dev lo root handle 1: hfsc default 10
        tc class add dev lo parent 1: classid 1:1 hfsc rt m2 100kbps
        tc class add dev lo parent 1:1 classid 1:10 hfsc ls m2 50kbps
        echo $?
    )
    0
    [root@ciqlts9 pvts]# tc -g class show dev lo
    tc -g class show dev lo
    +---(1:) hfsc 
         +---(1:1) hfsc rt m1 0bit d 0us m2 800Kbit 
              +---(1:10) hfsc ls m1 0bit d 0us m2 400Kbit 

Full logs:
[fix-replicate&#x2013;ciqlts9\_2-rt.log](<https://github.com/user-attachments/files/18892140/fix-replicate--ciqlts9_2-rt.log>)


## Patch

Creating the incorrect qdisc hierarchy raises a warning, but succeeds. Notice the type of inner class being `sc` instead of `rt` as shown by `tc -g class show dev lo` command.

    [root@ciqlts9 pvts]# (
        tc qdisc add dev lo root handle 1: hfsc default 10
        tc class add dev lo parent 1: classid 1:1 hfsc rt m2 100kbps
        tc class add dev lo parent 1:1 classid 1:10 hfsc ls m2 50kbps
        echo $?
    )
    Warning: Forced curve change on parent 'rt' to 'sc'.
    0
    [root@ciqlts9 pvts]# tc -g class show dev lo
    tc -g class show dev lo
    +---(1:) hfsc 
         +---(1:1) hfsc sc m1 0bit d 0us m2 800Kbit 
              +---(1:10) hfsc ls m1 0bit d 0us m2 400Kbit 

Full logs:
[fix-replicate&#x2013;ciqlts9\_2-rt-CVE-2023-4623.log](<https://github.com/user-attachments/files/18892141/fix-replicate--ciqlts9_2-rt-CVE-2023-4623.log>)

