### PR TITLE
[ciqlts8_8] writeback: avoid use-after-free after removing device

### DIFF
--- a/fs/fs-writeback.c
+++ b/fs/fs-writeback.c
@@ -133,10 +133,10 @@ static bool inode_io_list_move_locked(struct inode *inode,
 
 static void wb_wakeup(struct bdi_writeback *wb)
 {
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 	if (test_bit(WB_registered, &wb->state))
 		mod_delayed_work(bdi_wq, &wb->dwork, 0);
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 }
 
 static void finish_writeback_work(struct bdi_writeback *wb,
@@ -163,7 +163,7 @@ static void wb_queue_work(struct bdi_writeback *wb,
 	if (work->done)
 		atomic_inc(&work->done->cnt);
 
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 
 	if (test_bit(WB_registered, &wb->state)) {
 		list_add_tail(&work->list, &wb->work_list);
@@ -171,7 +171,7 @@ static void wb_queue_work(struct bdi_writeback *wb,
 	} else
 		finish_writeback_work(wb, work);
 
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 }
 
 /**
@@ -2105,13 +2105,13 @@ static struct wb_writeback_work *get_next_work_item(struct bdi_writeback *wb)
 {
 	struct wb_writeback_work *work = NULL;
 
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 	if (!list_empty(&wb->work_list)) {
 		work = list_entry(wb->work_list.next,
 				  struct wb_writeback_work, list);
 		list_del_init(&work->list);
 	}
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 	return work;
 }
 

--- a/mm/backing-dev.c
+++ b/mm/backing-dev.c
@@ -273,10 +273,10 @@ void wb_wakeup_delayed(struct bdi_writeback *wb)
 	unsigned long timeout;
 
 	timeout = msecs_to_jiffies(dirty_writeback_interval * 10);
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 	if (test_bit(WB_registered, &wb->state))
 		queue_delayed_work(bdi_wq, &wb->dwork, timeout);
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 }
 
 static void wb_update_bandwidth_workfn(struct work_struct *work)
@@ -361,12 +361,12 @@ static void cgwb_remove_from_bdi_list(struct bdi_writeback *wb);
 static void wb_shutdown(struct bdi_writeback *wb)
 {
 	/* Make sure nobody queues further work */
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 	if (!test_and_clear_bit(WB_registered, &wb->state)) {
-		spin_unlock_bh(&wb->work_lock);
+		spin_unlock_irq(&wb->work_lock);
 		return;
 	}
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 
 	cgwb_remove_from_bdi_list(wb);
 	/*

--- a/mm/page-writeback.c
+++ b/mm/page-writeback.c
@@ -2769,6 +2769,7 @@ static void wb_inode_writeback_start(struct bdi_writeback *wb)
 
 static void wb_inode_writeback_end(struct bdi_writeback *wb)
 {
+	unsigned long flags;
 	atomic_dec(&wb->writeback_inodes);
 	/*
 	 * Make sure estimate of writeback throughput gets updated after
@@ -2777,7 +2778,10 @@ static void wb_inode_writeback_end(struct bdi_writeback *wb)
 	 * that if multiple inodes end writeback at a similar time, they get
 	 * batched into one bandwidth update.
 	 */
-	queue_delayed_work(bdi_wq, &wb->_rh->bw_dwork, BANDWIDTH_INTERVAL);
+	spin_lock_irqsave(&wb->work_lock, flags);
+	if (test_bit(WB_registered, &wb->state))
+		queue_delayed_work(bdi_wq, &wb->_rh->bw_dwork, BANDWIDTH_INTERVAL);
+	spin_unlock_irqrestore(&wb->work_lock, flags);
 }
 
 int test_clear_page_writeback(struct page *page)


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

#### Commit message

```
jira VULN-6836
cve CVE-2024-0562
commit-author Khazhismel Kumykov <khazhy@chromium.org> commit f87904c075515f3e1d8f4a7115869d3b914674fd

When a disk is removed, bdi_unregister gets called to stop further writeback and wait for associated delayed work to complete.  However, wb_inode_writeback_end() may schedule bandwidth estimation dwork after this has completed, which can result in the timer attempting to access the just freed bdi_writeback.

Fix this by checking if the bdi_writeback is alive, similar to when scheduling writeback work.

Since this requires wb->work_lock, and wb_inode_writeback_end() may get called from interrupt, switch wb->work_lock to an irqsafe lock.

Link: https://lkml.kernel.org/r/20220801155034.3772543-1-khazhy@google.com Fixes: 45a2966fd641 ("writeback: fix bandwidth estimate for spiky workload")
	Signed-off-by: Khazhismel Kumykov <khazhy@google.com>
	Reviewed-by: Jan Kara <jack@suse.cz>
	Cc: Michael Stapelberg <stapelberg+linux@google.com>
	Cc: Wu Fengguang <fengguang.wu@intel.com>
	Cc: Alexander Viro <viro@zeniv.linux.org.uk>
	Cc: <stable@vger.kernel.org>
	Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
(cherry picked from commit f87904c075515f3e1d8f4a7115869d3b914674fd)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

#### kABI check
```
[ciq@lts-8-8 kernel-src-tree]$ ../kernel-dist-git/SOURCES/check-kabi -k ../kernel-dist-git/SOURCES/Module.kabi_x86_64 -s Module.symvers
[ciq@lts-8-8 kernel-src-tree]$ echo $?
0
```

#### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l
     230

$ grep '^ok ' kselftest-after.log | wc -l
     230

$ grep '^not ok ' kselftest-before.log | wc -l
      62

$ grep '^not ok ' kselftest-after.log | wc -l
      62
```

[kselftest-after.log](https://github.com/user-attachments/files/18903593/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/18903595/kselftest-before.log)