### PR TITLE
[ciqlts8_6-rt] writeback: avoid use-after-free after removing device

### DIFF
--- a/fs/fs-writeback.c
+++ b/fs/fs-writeback.c
@@ -151,10 +151,10 @@ static void inode_io_list_del_locked(struct inode *inode,
 
 static void wb_wakeup(struct bdi_writeback *wb)
 {
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 	if (test_bit(WB_registered, &wb->state))
 		mod_delayed_work(bdi_wq, &wb->dwork, 0);
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 }
 
 static void finish_writeback_work(struct bdi_writeback *wb,
@@ -181,7 +181,7 @@ static void wb_queue_work(struct bdi_writeback *wb,
 	if (work->done)
 		atomic_inc(&work->done->cnt);
 
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 
 	if (test_bit(WB_registered, &wb->state)) {
 		list_add_tail(&work->list, &wb->work_list);
@@ -189,7 +189,7 @@ static void wb_queue_work(struct bdi_writeback *wb,
 	} else
 		finish_writeback_work(wb, work);
 
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 }
 
 /**
@@ -1938,13 +1938,13 @@ static struct wb_writeback_work *get_next_work_item(struct bdi_writeback *wb)
 {
 	struct wb_writeback_work *work = NULL;
 
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 	if (!list_empty(&wb->work_list)) {
 		work = list_entry(wb->work_list.next,
 				  struct wb_writeback_work, list);
 		list_del_init(&work->list);
 	}
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 	return work;
 }
 

--- a/mm/backing-dev.c
+++ b/mm/backing-dev.c
@@ -280,10 +280,10 @@ void wb_wakeup_delayed(struct bdi_writeback *wb)
 	unsigned long timeout;
 
 	timeout = msecs_to_jiffies(dirty_writeback_interval * 10);
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 	if (test_bit(WB_registered, &wb->state))
 		queue_delayed_work(bdi_wq, &wb->dwork, timeout);
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 }
 
 static void wb_update_bandwidth_workfn(struct work_struct *work)
@@ -376,12 +376,12 @@ static void cgwb_remove_from_bdi_list(struct bdi_writeback *wb);
 static void wb_shutdown(struct bdi_writeback *wb)
 {
 	/* Make sure nobody queues further work */
-	spin_lock_bh(&wb->work_lock);
+	spin_lock_irq(&wb->work_lock);
 	if (!test_and_clear_bit(WB_registered, &wb->state)) {
-		spin_unlock_bh(&wb->work_lock);
+		spin_unlock_irq(&wb->work_lock);
 		return;
 	}
-	spin_unlock_bh(&wb->work_lock);
+	spin_unlock_irq(&wb->work_lock);
 
 	cgwb_remove_from_bdi_list(wb);
 	/*

--- a/mm/page-writeback.c
+++ b/mm/page-writeback.c
@@ -2754,6 +2754,7 @@ static void wb_inode_writeback_start(struct bdi_writeback *wb)
 
 static void wb_inode_writeback_end(struct bdi_writeback *wb)
 {
+	unsigned long flags;
 	atomic_dec(&wb->writeback_inodes);
 	/*
 	 * Make sure estimate of writeback throughput gets updated after
@@ -2762,7 +2763,10 @@ static void wb_inode_writeback_end(struct bdi_writeback *wb)
 	 * that if multiple inodes end writeback at a similar time, they get
 	 * batched into one bandwidth update.
 	 */
-	queue_delayed_work(bdi_wq, wb->bw_dwork, BANDWIDTH_INTERVAL);
+	spin_lock_irqsave(&wb->work_lock, flags);
+	if (test_bit(WB_registered, &wb->state))
+		queue_delayed_work(bdi_wq, wb->bw_dwork, BANDWIDTH_INTERVAL);
+	spin_unlock_irqrestore(&wb->work_lock, flags);
 }
 
 int test_clear_page_writeback(struct page *page)


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [ ] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-9260
cve CVE-2024-0562
commit-author Khazhismel Kumykov <khazhy@chromium.org> commit f87904c075515f3e1d8f4a7115869d3b914674fd

When a disk is removed, bdi_unregister gets called to stop further writeback and wait for associated delayed work to complete.  However, wb_inode_writeback_end() may schedule bandwidth estimation dwork after this has completed, which can result in the timer attempting to access the just freed bdi_writeback.

Fix this by checking if the bdi_writeback is alive, similar to when scheduling writeback work.

Since this requires wb->work_lock, and wb_inode_writeback_end() may get called from interrupt, switch wb->work_lock to an irqsafe lock.

Link: https://lkml.kernel.org/r/20220801155034.3772543-1-khazhy@google.com Fixes: 45a2966fd641 ("writeback: fix bandwidth estimate for spiky workload")
	Signed-off-by: Khazhismel Kumykov <khazhy@google.com>
	Reviewed-by: Jan Kara <jack@suse.cz>
	Cc: Michael Stapelberg <stapelberg+linux@google.com>
	Cc: Wu Fengguang <fengguang.wu@intel.com>
	Cc: Alexander Viro <viro@zeniv.linux.org.uk>
	Cc: <stable@vger.kernel.org>
	Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
(cherry picked from commit f87904c075515f3e1d8f4a7115869d3b914674fd)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
  INSTALL sound/usb/line6/snd-usb-variax.ko
  INSTALL sound/usb/misc/snd-ua101.ko
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-_ppatel__ciqlts8_6-rt+
[TIMER]{MODULES}: 39s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-_ppatel__ciqlts8_6-rt+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 11s
Checking kABI
Error: kABI check failed
Setting Default Kernel to /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_6-rt+ and Index to 0
The default is /boot/loader/entries/74447cfd379141518e0d01ed1a411e3c-4.18.0-_ppatel__ciqlts8_6-rt+.conf with index 0 and kernel /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_6-rt+
The default is /boot/loader/entries/74447cfd379141518e0d01ed1a411e3c-4.18.0-_ppatel__ciqlts8_6-rt+.conf with index 0 and kernel /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_6-rt+
Generating grub configuration file ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 1027s
[TIMER]{MODULES}: 39s
[TIMER]{INSTALL}: 11s
[TIMER]{TOTAL} 1086s
Rebooting in 10 seconds
```
[kernel_build.log](https://github.com/user-attachments/files/19085214/kernel_build.log)


### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
214
215

$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
52
51

$ gdiff <(grep '^ok ' kselftest-before.log) <(grep '^ok ' kselftest-after.log)
diff --git a/dev/fd/63 b/dev/fd/62
--- a/dev/fd/63
+++ b/dev/fd/62
@@ -81,6 +81,7 @@ ok 1 selftests: mqueue: mq_open_tests # SKIP
 ok 2 selftests: mqueue: mq_perf_tests # SKIP
 ok 2 selftests: net: reuseport_bpf_cpu
 ok 4 selftests: net: reuseport_dualstack
+ok 6 selftests: net: tls
 ok 7 selftests: net: run_netsocktests
 ok 8 selftests: net: run_afpackettests
 ok 10 selftests: net: netdevice.sh # SKIP

$ gdiff <(grep '^not ok ' kselftest-before.log) <(grep '^not ok ' kselftest-after.log)
diff --git a/dev/fd/63 b/dev/fd/62
--- a/dev/fd/63
+++ b/dev/fd/62
@@ -5,7 +5,6 @@ not ok 4 selftests: lib: scanf.sh
 not ok 2 selftests: memfd: run_fuse_test.sh # exit=1
 not ok 1 selftests: net: reuseport_bpf # exit=1
 not ok 3 selftests: net: reuseport_bpf_numa # exit=1
-not ok 6 selftests: net: tls # exit=1
 not ok 9 selftests: net: test_bpf.sh # exit=1
 not ok 14 selftests: net: fib-onlink-tests.sh # exit=1
 not ok 15 selftests: net: pmtu.sh # exit=1
```
[kselftest-after.log](https://github.com/user-attachments/files/19085208/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/19085210/kselftest-before.log)