### PR TITLE
[LTS 8.6 RT] CVE-2023-4206, CVE-2023-4207, CVE-2023-4208

### DIFF
--- a/net/sched/cls_fw.c
+++ b/net/sched/cls_fw.c
@@ -270,7 +270,6 @@ static int fw_change(struct net *net, struct sk_buff *in_skb,
 			return -ENOBUFS;
 
 		fnew->id = f->id;
-		fnew->res = f->res;
 		fnew->ifindex = f->ifindex;
 		fnew->tp = f->tp;
 

--- a/net/sched/cls_route.c
+++ b/net/sched/cls_route.c
@@ -505,7 +505,6 @@ static int route4_change(struct net *net, struct sk_buff *in_skb,
 	if (fold) {
 		f->id = fold->id;
 		f->iif = fold->iif;
-		f->res = fold->res;
 		f->handle = fold->handle;
 
 		f->tp = fold->tp;

--- a/net/sched/cls_u32.c
+++ b/net/sched/cls_u32.c
@@ -812,7 +812,6 @@ static struct tc_u_knode *u32_init_knode(struct net *net, struct tcf_proto *tp,
 
 	new->ifindex = n->ifindex;
 	new->fshift = n->fshift;
-	new->res = n->res;
 	new->flags = n->flags;
 	RCU_INIT_POINTER(new->ht_down, ht);
 


### PR DESCRIPTION
[LTS 8.6 RT]
CVE-2023-4206 VULN-6645
CVE-2023-4207 VULN-6652
CVE-2023-4208 VULN-6659


# Problem

The PR addresses a series of related CVEs, which were once listed under a single [CVE-2023-4128](https://www.cve.org/CVERecord?id=CVE-2023-4128). From <https://lore.kernel.org/netdev/193d6cdf-d6c9-f9be-c36a-b2a7551d5fb6@mojatatu.com/>:

> Three classifiers (cls\_fw, cls\_u32 and cls\_route) always copy
> tcf\_result struct into the new instance of the filter on update.
> 
> This causes a problem when updating a filter bound to a class,
> as tcf\_unbind\_filter() is always called on the old instance in the
> success path, decreasing filter\_cnt of the still referenced class
> and allowing it to be deleted, leading to a use-after-free.
> 
> This patch set fixes this issue in all affected classifiers by no longer
> copying the tcf\_result struct from the old filter.

Each CVE is related to a different classifier:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">CVE</th>
<th scope="col" class="org-left">File</th>
<th scope="col" class="org-left">Option</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">CVE-2023-4206</td>
<td class="org-left">net/sched/cls&#95;route.c</td>
<td class="org-left">CONFIG&#95;NET&#95;CLS&#95;ROUTE4</td>
</tr>


<tr>
<td class="org-left">CVE-2023-4207</td>
<td class="org-left">net/sched/cls&#95;fw.c</td>
<td class="org-left">CONFIG&#95;NET&#95;CLS&#95;FW</td>
</tr>


<tr>
<td class="org-left">CVE-2023-4208</td>
<td class="org-left">net/sched/cls&#95;u32.c</td>
<td class="org-left">CONFIG&#95;NET&#95;CLS&#95;U32</td>
</tr>
</tbody>
</table>


# Analysis and solution


## Official fixes

The official fixes for each of the vulnerabilities are as follows:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">CVE</th>
<th scope="col" class="org-left">Mainline fix</th>
<th scope="col" class="org-left">Backport to 4.19 (closest to 4.18 of Rocky LTS 8.6 RT)</th>
<th scope="col" class="org-left">Relation to mainline fix</th>
<th scope="col" class="org-left">Applicable to LTS 8.6 RT</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">CVE-2023-4206</td>
<td class="org-left">b80b829e9e2c1b3f7aae34855e04d8f6ecaf13c8</td>
<td class="org-left"><a href="https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=ad8f36f96696a7f1d191da66637c415959bab6d8">ad8f36f96696a7f1d191da66637c415959bab6d8</a></td>
<td class="org-left">Same</td>
<td class="org-left">Yes</td>
</tr>


<tr>
<td class="org-left">CVE-2023-4207</td>
<td class="org-left">76e42ae831991c828cffa8c37736ebfb831ad5ec</td>
<td class="org-left"><a href="https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=4f38dc8496d1991e2c055a0068dd98fb48affcc6">4f38dc8496d1991e2c055a0068dd98fb48affcc6</a></td>
<td class="org-left">Same</td>
<td class="org-left">Yes</td>
</tr>


<tr>
<td class="org-left">CVE-2023-4208</td>
<td class="org-left">3044b16e7c6fe5d24b1cdbcf1bd0a9d92d1ebd81</td>
<td class="org-left"><a href="https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=4aae24015ecd70d824a953e2dc5b0ca2c4769243">4aae24015ecd70d824a953e2dc5b0ca2c4769243</a></td>
<td class="org-left">Same</td>
<td class="org-left">Yes</td>
</tr>
</tbody>
</table>


## Applicability

Each change is applicable to the LTS 8.6 RT from the configuration standpoint.

    grep -e '\(CONFIG_NET_SCHED\|CONFIG_NET_CLS\|CONFIG_NET_CLS_ROUTE4\|CONFIG_NET_CLS_FW\|CONFIG_NET_CLS_U32\)\b' configs/kernel-rt-4.18.0-x86_64.config

    CONFIG_NET_SCHED=y
    CONFIG_NET_CLS=y
    CONFIG_NET_CLS_ROUTE4=m
    CONFIG_NET_CLS_FW=m
    CONFIG_NET_CLS_U32=m


## Analysis

The official fix is very straightforward yet it begs the question: isn't the `tcf_result` -type struct needed in the new instance of the appropriate filter object? Doesn't the erasure of `res` field break some expectation some code using the `change` function may have, if the changing of `res` wasn't requested?

While the attempts to answer this question based on the encoded logic alone were inconclusive (no counter examples found but also too little expertise in this codebase to give definite affirmative answer), some support for this solution can be provided by comparing the modified classifiers to others.

The kernel provides 11 classifiers in total, based on modules implementing `tcf_proto_ops`:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Kind</th>
<th scope="col" class="org-left">File</th>
<th scope="col" class="org-left">.change function</th>
<th scope="col" class="org-left">Filter struct</th>
<th scope="col" class="org-left">Contains tcf_result?</th>
<th scope="col" class="org-left">Patch?</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">basic</td>
<td class="org-left">cls_basic.c</td>
<td class="org-left">basic_change</td>
<td class="org-left">basic_filter</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">bpf</td>
<td class="org-left">cls_bpf.c</td>
<td class="org-left">cls_bpf_change</td>
<td class="org-left">cls_bpf_prog</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">cgroup</td>
<td class="org-left">cls_cgroup.c</td>
<td class="org-left">cls_cgroup_change</td>
<td class="org-left">cls_cgroup_head</td>
<td class="org-left">No</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">flow</td>
<td class="org-left">cls_flow.c</td>
<td class="org-left">flow_change</td>
<td class="org-left">flow_filter</td>
<td class="org-left">No</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">flower</td>
<td class="org-left">cls_flower.c</td>
<td class="org-left">fl_change</td>
<td class="org-left">cls_fl_filter</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">fw</td>
<td class="org-left">cls_fw.c</td>
<td class="org-left">fw_change</td>
<td class="org-left">fw_filter</td>
<td class="org-left">Yes</td>
<td class="org-left">x</td>
</tr>


<tr>
<td class="org-left">matchall</td>
<td class="org-left">cls_matchall.c</td>
<td class="org-left">mall_change</td>
<td class="org-left">cls_mall_head</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">route</td>
<td class="org-left">cls_route.c</td>
<td class="org-left">route4_change</td>
<td class="org-left">route4_filter</td>
<td class="org-left">Yes</td>
<td class="org-left">x</td>
</tr>


<tr>
<td class="org-left">rsvp</td>
<td class="org-left">cls_rsvp.h</td>
<td class="org-left">rsvp_change</td>
<td class="org-left">rsvp_filter</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">tcindex</td>
<td class="org-left">cls_tcindex.c</td>
<td class="org-left">tcindex_change</td>
<td class="org-left">tcindex_filter_result</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">u32</td>
<td class="org-left">cls_u32.c</td>
<td class="org-left">u32_change</td>
<td class="org-left">tc_u_knode</td>
<td class="org-left">Yes</td>
<td class="org-left">x</td>
</tr>
</tbody>
</table>

Each classifier has an associated filter struct. Two of these filter structs (`cgroup`, `flow`) don't contain `tcf_result` -type field and thus cannot be compared against. Three classifiers are objects of the evaluation - `fw`, `route`, `u32`. This leaves 6 classifiers to check for how they operate on the `tcf_result` fields in their respective `change` function: `basic`, `bpf`, `flower`, `matchall`, `rsvp`, `tcindex`.

Analysis of the filter functions of these classifiers shows that **no `tcf_result` is copied on the creation of new filter struct instance**. The single exception is `tcindex`: copying of `tcf_result` struct to the newly created filter struct does seem to be taking place in a rather convoluted way. (The `**arg` in [tcindex\_change](https://github.com/ctrliq/kernel-src-tree/blob/bcdcbf36036e96902a1437be891fabb4f9887c0d/net/sched/cls_tcindex.c#L555) is passed as `r` to [tcindex\_set\_parms](https://github.com/ctrliq/kernel-src-tree/blob/bcdcbf36036e96902a1437be891fabb4f9887c0d/net/sched/cls_tcindex.c#L330). There the copy of `r->res` is [assigned](https://github.com/ctrliq/kernel-src-tree/blob/bcdcbf36036e96902a1437be891fabb4f9887c0d/net/sched/cls_tcindex.c#L406) to the local variable `cr` in case `r` wasn't null. Then it's [assigned back](https://github.com/ctrliq/kernel-src-tree/blob/bcdcbf36036e96902a1437be891fabb4f9887c0d/net/sched/cls_tcindex.c#L494) to `r->res`, except this time `r` may not be the same as provided in the argument, [but also](https://github.com/ctrliq/kernel-src-tree/blob/bcdcbf36036e96902a1437be891fabb4f9887c0d/net/sched/cls_tcindex.c#L464) `&new_filter_result`. In that case a new filter struct `f` [is created](https://github.com/ctrliq/kernel-src-tree/blob/bcdcbf36036e96902a1437be891fabb4f9887c0d/net/sched/cls_tcindex.c#L468) and [receives](https://github.com/ctrliq/kernel-src-tree/blob/bcdcbf36036e96902a1437be891fabb4f9887c0d/net/sched/cls_tcindex.c#L503) [the copy](https://github.com/ctrliq/kernel-src-tree/blob/bcdcbf36036e96902a1437be891fabb4f9887c0d/net/sched/cls_tcindex.c#L524) of `tcf_result`.) The error condition from CVEs doesn't seem to occur in this case though, as there is no `tcf_unbind_filter` call messing with the reference counters. This supports the thesis that **copying `tcf_result` into the newly created filter instance is preferable but perhaps not required and can be foregone when it's causing problems**.

Unrelated to the `tcf_result` issue, it may be worth considering the retirement of the `tcindex` filter in LTS 8.6 RT, as it was done in the mainline kernel for security reasons on 2023-02-16:

    commit 8c710f75256bb3cf05ac7b1672c82b92c43f3d28
    Author:     Jamal Hadi Salim <jhs@mojatatu.com>
    AuthorDate: Tue Feb 14 08:49:14 2023 -0500
    Commit:     Paolo Abeni <pabeni@redhat.com>
    CommitDate: Thu Feb 16 09:27:07 2023 +0100
    
        net/sched: Retire tcindex classifier
        
        The tcindex classifier has served us well for about a quarter of a century
        but has not been getting much TLC due to lack of known users. Most recently
        it has become easy prey to syzkaller. For this reason, we are retiring it.
        
        Signed-off-by: Jamal Hadi Salim <jhs@mojatatu.com>
        Acked-by: Jiri Pirko <jiri@nvidia.com>
        Signed-off-by: Paolo Abeni <pabeni@redhat.com>

(Syzkaller = Google's fuzzing framework)

Retiring `tcindex` from mainline kernel is unfortunate, because it leaves LTS 8.6 RT not only with rich source of vulnerabilities, as the commit's message suggests, but a *silent* source, without any CVEs nor patches made for them by kernel.org in the future.


# kABI check: omitted (unstable ABI of RT kernels)


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/19134675/boot-test.log>)


<a id="orgbd0c952"></a>

# Kselftests (general): passed relative


## Methodology

Source-compiled (`e1a9851e6068a6ef800ec6b2b48a7c243882ed06`) kselftests suite was used.


## Coverage (including tests skipped during execution)

`android`, `breakpoints`, `capabilities`, `core`, `cpu-hotplug`, `cpufreq`, `efivarfs`, `exec`, `filesystems`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `net`, `net/forwarding`, `net/mptcp`, `netfilter`, `nsfs`, `proc`, `pstore`, `ptrace`, `rseq`, `rtc`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `sysctl`, `tc-testing`, `timens`, `timers`, `tpm2`, `user`, `vm`, `x86`, `zram`


## Reference

Three test runs were conducted on the reference kernel.
[kselftests&#x2013;src&#x2013;ciqlts8\_6-rt&#x2013;run1.log](<https://github.com/user-attachments/files/19135191/kselftests--src--ciqlts8_6-rt--run1.log>)
[kselftests&#x2013;src&#x2013;ciqlts8\_6-rt&#x2013;run2.log](<https://github.com/user-attachments/files/19135190/kselftests--src--ciqlts8_6-rt--run2.log>)
[kselftests&#x2013;src&#x2013;ciqlts8\_6-rt&#x2013;run3.log](<https://github.com/user-attachments/files/19135188/kselftests--src--ciqlts8_6-rt--run3.log>)


## Patch

Two test runs were conducted on the patched kernel.
[kselftests&#x2013;src&#x2013;ciqlts8\_6-rt-CVE-2023-4206.4207.4208&#x2013;run1.log](<https://github.com/user-attachments/files/19135187/kselftests--src--ciqlts8_6-rt-CVE-2023-4206.4207.4208--run1.log>)
[kselftests&#x2013;src&#x2013;ciqlts8\_6-rt-CVE-2023-4206.4207.4208&#x2013;run2.log](<https://github.com/user-attachments/files/19135186/kselftests--src--ciqlts8_6-rt-CVE-2023-4206.4207.4208--run2.log>)


## Comparison

    ktests.xsh table --where "Summary = 'diff'" kselftests*.log

    Column    File
    --------  ---------------------------------------------------------------
    Status0   kselftests--src--ciqlts8_6-rt--run1.log
    Status1   kselftests--src--ciqlts8_6-rt--run2.log
    Status2   kselftests--src--ciqlts8_6-rt--run3.log
    Status3   kselftests--src--ciqlts8_6-rt-CVE-2023-4206.4207.4208--run1.log
    Status4   kselftests--src--ciqlts8_6-rt-CVE-2023-4206.4207.4208--run2.log
    
    TestCase                   Status0  Status1  Status2  Status3  Status4  Summary
    kvm:hardware_disable_test  pass     pass     pass     pass     fail     diff
    net/mptcp:mptcp_join.sh    fail     fail     fail     fail     pass     diff
    net:gro.sh                 pass     fail     pass     pass     pass     diff

All the differing results are for tests known before to give inconsistent results.


# Kselftests (networking): passed relative


## Methodology

In [general kselftests](#orgbd0c952) all the `net/forwarding` tests fail (really should be skipped) because of the missing tool dependencies

    # selftests: net/forwarding: bridge_igmp.sh
    # SKIP: jq not installed
    not ok 1 selftests: net/forwarding: bridge_igmp.sh # exit=1

Because the patch deals with networking specifically, an additional batch of tests was carried out after solving the test requirements issues.

    sudo make ARCH=$(uname -m) -C tools/testing/selftests TARGETS="net/forwarding" run_tests

The `tools/testing/selftests/net/forwarding/forwarding.config` file used was created directly from the `tools/testing/selftests/net/forwarding/forwarding.config.sample`.


## Reference

Three test runs were conducted on the reference kernel.
[kselftests-net-forwarding&#x2013;src&#x2013;ciqlts8\_6-rt&#x2013;run1.log](<https://github.com/user-attachments/files/19216027/kselftests-net-forwarding--src--ciqlts8_6-rt--run1.log>)
[kselftests-net-forwarding&#x2013;src&#x2013;ciqlts8\_6-rt&#x2013;run2.log](<https://github.com/user-attachments/files/19216026/kselftests-net-forwarding--src--ciqlts8_6-rt--run2.log>)
[kselftests-net-forwarding&#x2013;src&#x2013;ciqlts8\_6-rt&#x2013;run3.log](<https://github.com/user-attachments/files/19216025/kselftests-net-forwarding--src--ciqlts8_6-rt--run3.log>)


## Patch

A single test run was conducted on the patched kernel.
[kselftests-net-forwarding&#x2013;src&#x2013;ciqlts8\_6-rt-CVE-2023-4206.4207.4208&#x2013;run1.log](<https://github.com/user-attachments/files/19216024/kselftests-net-forwarding--src--ciqlts8_6-rt-CVE-2023-4206.4207.4208--run1.log>)


## Comparison and discussion

Results for the reference and patched kernel are the same.

    ktests.xsh table kselftests-net-forwarding*.log

    Column    File
    --------  ------------------------------------------------------------------------------
    Status0   kselftests-net-forwarding--src--ciqlts8_6-rt--run1.log
    Status1   kselftests-net-forwarding--src--ciqlts8_6-rt--run2.log
    Status2   kselftests-net-forwarding--src--ciqlts8_6-rt--run3.log
    Status3   kselftests-net-forwarding--src--ciqlts8_6-rt-CVE-2023-4206.4207.4208--run1.log
    
    TestCase                                     Status0  Status1  Status2  Status3  Summary
    net/forwarding:bridge_igmp.sh                fail     fail     fail     fail     same
    net/forwarding:bridge_port_isolation.sh      pass     pass     pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh          pass     pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh          fail     fail     fail     fail     same
    net/forwarding:bridge_vlan_unaware.sh        pass     pass     pass     pass     same
    net/forwarding:ethtool.sh                    fail     fail     fail     fail     same
    net/forwarding:gre_multipath.sh              fail     fail     fail     fail     same
    net/forwarding:ip6_forward_instats_vrf.sh    fail     fail     fail     fail     same
    net/forwarding:ipip_flat_gre.sh              pass     pass     pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh          pass     pass     pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh         pass     pass     pass     pass     same
    net/forwarding:ipip_hier_gre.sh              pass     pass     pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh          pass     pass     pass     pass     same
    net/forwarding:ipip_hier_gre_keys.sh         pass     pass     pass     pass     same
    net/forwarding:loopback.sh                   skip     skip     skip     skip     same
    net/forwarding:mirror_gre.sh                 fail     fail     fail     fail     same
    net/forwarding:mirror_gre_bound.sh           pass     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh       pass     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d_vlan.sh  fail     fail     fail     fail     same
    net/forwarding:mirror_gre_bridge_1q.sh       fail     fail     fail     fail     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh   fail     fail     fail     fail     same
    net/forwarding:mirror_gre_changes.sh         fail     fail     fail     fail     same
    net/forwarding:mirror_gre_flower.sh          fail     fail     fail     fail     same
    net/forwarding:mirror_gre_lag_lacp.sh        pass     pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh           pass     pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh              pass     pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh            pass     pass     pass     pass     same
    net/forwarding:mirror_gre_vlan_bridge_1q.sh  fail     fail     fail     fail     same
    net/forwarding:mirror_vlan.sh                pass     pass     pass     pass     same
    net/forwarding:router.sh                     fail     fail     fail     fail     same
    net/forwarding:router_bridge.sh              pass     pass     pass     pass     same
    net/forwarding:router_bridge_vlan.sh         pass     pass     pass     pass     same
    net/forwarding:router_broadcast.sh           fail     fail     fail     fail     same
    net/forwarding:router_multicast.sh           fail     fail     fail     fail     same
    net/forwarding:router_multipath.sh           fail     fail     fail     fail     same
    net/forwarding:router_vid_1.sh               pass     pass     pass     pass     same

The list of `net/forwarding` tests performed is not exhaustive (36 / 53). The `net/forwarding:sch_ets.sh` test executed right after `net/forwarding:router_vid_1.sh` causes the machine to hang for more than 10 minutes and the used testing framework interrupts the test suite.

    ...
    ok 36 selftests: net/forwarding: router_vid_1.sh
    # selftests: net/forwarding: sch_ets.sh
    # TEST: ping vlan 10                                                  [ OK ]
    # TEST: ping vlan 11                                                  [ OK ]
    # TEST: ping vlan 12                                                  [ OK ]
    # Running in priomap mode
    # Testing ets bands 3 strict 3, streams 0 1
    # TEST: band 0                                                        [ OK ]
    # INFO: Expected ratio >95% Measured ratio 100.00
    # TEST: band 1                                                        [ OK ]
    # INFO: Expected ratio <5% Measured ratio 0
    # Testing ets bands 3 strict 3, streams 1 2
    ERROR:root:Subprocess exceeded the maximum freeze time 600 s. Terminating
    INFO:root:Finished tests. Cleaning up the machine
    ...

The fix for the problem was deferred to another CVE for the sake of patching efficiency.

