### PR TITLE
[LTS 9.2 RT] CVE-2023-4206, CVE-2023-4207, CVE-2023-4208

### DIFF
--- a/net/sched/cls_fw.c
+++ b/net/sched/cls_fw.c
@@ -265,7 +265,6 @@ static int fw_change(struct net *net, struct sk_buff *in_skb,
 			return -ENOBUFS;
 
 		fnew->id = f->id;
-		fnew->res = f->res;
 		fnew->ifindex = f->ifindex;
 		fnew->tp = f->tp;
 

--- a/net/sched/cls_u32.c
+++ b/net/sched/cls_u32.c
@@ -811,7 +811,6 @@ static struct tc_u_knode *u32_init_knode(struct net *net, struct tcf_proto *tp,
 
 	new->ifindex = n->ifindex;
 	new->fshift = n->fshift;
-	new->res = n->res;
 	new->flags = n->flags;
 	RCU_INIT_POINTER(new->ht_down, ht);
 


### PR DESCRIPTION
[LTS 9.2 RT]
CVE-2023-4206 VULN-6650
CVE-2023-4207 VULN-6657
CVE-2023-4208 VULN-6664


# Problem

The PR addresses a series of related CVEs, which were once listed under a single [CVE-2023-4128](https://www.cve.org/CVERecord?id=CVE-2023-4128). From <https://lore.kernel.org/netdev/193d6cdf-d6c9-f9be-c36a-b2a7551d5fb6@mojatatu.com/>:

> Three classifiers (cls\_fw, cls\_u32 and cls\_route) always copy
> tcf\_result struct into the new instance of the filter on update.
> 
> This causes a problem when updating a filter bound to a class,
> as tcf\_unbind\_filter() is always called on the old instance in the
> success path, decreasing filter\_cnt of the still referenced class
> and allowing it to be deleted, leading to a use-after-free.
> 
> This patch set fixes this issue in all affected classifiers by no longer
> copying the tcf\_result struct from the old filter.

Each CVE is related to a different classifier:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">CVE</th>
<th scope="col" class="org-left">File</th>
<th scope="col" class="org-left">Option</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">CVE-2023-4206</td>
<td class="org-left">net/sched/cls&#95;route.c</td>
<td class="org-left">CONFIG&#95;NET&#95;CLS&#95;ROUTE4</td>
</tr>


<tr>
<td class="org-left">CVE-2023-4207</td>
<td class="org-left">net/sched/cls&#95;fw.c</td>
<td class="org-left">CONFIG&#95;NET&#95;CLS&#95;FW</td>
</tr>


<tr>
<td class="org-left">CVE-2023-4208</td>
<td class="org-left">net/sched/cls&#95;u32.c</td>
<td class="org-left">CONFIG&#95;NET&#95;CLS&#95;U32</td>
</tr>
</tbody>
</table>


# Analysis and solution


## Official fixes

The official fixes for each of the vulnerabilities are as follows:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">CVE</th>
<th scope="col" class="org-left">Mainline fix</th>
<th scope="col" class="org-left">Backport to 5.15 (closest to 5.14 of Rocky LTS 9.2 RT)</th>
<th scope="col" class="org-left">Relation to mainline fix</th>
<th scope="col" class="org-left">Applicable to LTS 9.2 RT</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">CVE-2023-4206</td>
<td class="org-left">b80b829e9e2c1b3f7aae34855e04d8f6ecaf13c8</td>
<td class="org-left"><a href="https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=79c3d81c9ad140957b081c91908d7e2964dc603f">79c3d81c9ad140957b081c91908d7e2964dc603f</a></td>
<td class="org-left">Same</td>
<td class="org-left">No</td>
</tr>


<tr>
<td class="org-left">CVE-2023-4207</td>
<td class="org-left">76e42ae831991c828cffa8c37736ebfb831ad5ec</td>
<td class="org-left"><a href="https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=9edf7955025a602ab6bcc94d923c436e160a10e3">9edf7955025a602ab6bcc94d923c436e160a10e3</a></td>
<td class="org-left">Same</td>
<td class="org-left">Yes</td>
</tr>


<tr>
<td class="org-left">CVE-2023-4208</td>
<td class="org-left">3044b16e7c6fe5d24b1cdbcf1bd0a9d92d1ebd81</td>
<td class="org-left"><a href="https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=262430dfc618509246e07acd26211cb4cca79ecc">262430dfc618509246e07acd26211cb4cca79ecc</a></td>
<td class="org-left">Same</td>
<td class="org-left">Yes</td>
</tr>
</tbody>
</table>


## Applicability

The CVE-2023-4206 is not applicable to the LTS 9.2 RT from the configuration standpoint, as the `route4` classifier is disabled by default. Other CVEs are applicable.

    grep -e '\(CONFIG_NET_SCHED\|CONFIG_NET_CLS\|CONFIG_NET_CLS_ROUTE4\|CONFIG_NET_CLS_FW\|CONFIG_NET_CLS_U32\)\b' configs/kernel-rt-5.14.0-x86_64.config

    CONFIG_NET_SCHED=y
    CONFIG_NET_CLS=y
    # CONFIG_NET_CLS_ROUTE4 is not set
    CONFIG_NET_CLS_FW=m
    CONFIG_NET_CLS_U32=m


## Analysis

For the discussion of the validity of a fix based on simply ignoring a certain field while copying a data structure where the actual copy may be expected see analysis for [LTS 8.6 RT Pull Request](https://github.com/ctrliq/kernel-src-tree/pull/155) - it was not repeated for the LTS 9.2 RT version. (Note that the doubts raised there about keeping `tcindex` filter don't apply to this version as this filter is disabled in LTS 9.2 RT configuration.)


# kABI check: omitted (unstable ABI of RT kernels)


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/19134691/boot-test.log>)


<a id="org85c7d19"></a>

# Kselftests: passed relative


## Methodology

A mix of `kernel-selftests-internal` and source-compiled tests were used:

-   **`kernel-selftests-internal`:** `bpf` tests, except:
    -   **`bpf:test_kmod.sh`:** takes very long time to finish and always fails anyway,
    -   **`bpf:test_progs`:** unstable, can crash the machine,
    -   **`bpf:test_progs-no_alu32`:** unstable, can crash the machine.
-   **source-compiled:** all the rest.


## Coverage (including tests skipped during execution)

`bpf`, `breakpoints`, `capabilities`, `clone3`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding`, `drivers/net/team`, `efivarfs`, `filesystems`, `filesystems/binderfs`, `filesystems/epoll`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `ir`, `kcmp`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net`, `net/forwarding`, `net/mptcp`, `netfilter`, `nsfs`, `openat2`, `pid_namespace`, `pidfd`, `pstore`, `ptrace`, `rlimits`, `rseq`, `rtc`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `syscall_user_dispatch`, `sysctl`, `tc-testing`, `tdx`, `timens`, `timers`, `tmpfs`, `tpm2`, `user`, `vDSO`, `vm`, `x86`, `zram`


## Reference

Three test runs were conducted on the reference kernel.
[kselftests&#x2013;mix&#x2013;ciqlts9\_2-rt&#x2013;run1.log](<https://github.com/user-attachments/files/19218716/kselftests--mix--ciqlts9_2-rt--run1.log>)
[kselftests&#x2013;mix&#x2013;ciqlts9\_2-rt&#x2013;run2.log](<https://github.com/user-attachments/files/19218715/kselftests--mix--ciqlts9_2-rt--run2.log>)
[kselftests&#x2013;mix&#x2013;ciqlts9\_2-rt&#x2013;run3.log](<https://github.com/user-attachments/files/19218714/kselftests--mix--ciqlts9_2-rt--run3.log>)


## Patch

A single test run was conducted on the patched kernel.
[kselftests&#x2013;mix&#x2013;ciqlts9\_2-rt-CVE-2023-4206.4207.4208&#x2013;run1.log](<https://github.com/user-attachments/files/19218712/kselftests--mix--ciqlts9_2-rt-CVE-2023-4206.4207.4208--run1.log>)


## Comparison

    ktests.xsh table --where "Summary = 'diff'" kselftests*.log

    Column    File
    --------  ---------------------------------------------------------------
    Status0   kselftests--mix--ciqlts9_2-rt--run1.log
    Status1   kselftests--mix--ciqlts9_2-rt--run2.log
    Status2   kselftests--mix--ciqlts9_2-rt--run3.log
    Status3   kselftests--mix--ciqlts9_2-rt-CVE-2023-4206.4207.4208--run1.log
    
    TestCase                 Status0  Status1  Status2  Status3  Summary
    bpf:test_tcpnotify_user  fail     pass     pass     fail     diff
    kvm:tsc_scaling_sync     pass     pass     fail     fail     diff
    net:udpgso_bench.sh      pass     pass     pass     fail     diff
    rtc:rtctest              fail     fail     fail     pass     diff
    seccomp:seccomp_bpf      fail     fail     pass     pass     diff
    timers:raw_skew          pass     pass     pass     fail     diff

The tests `bpf:test_tcpnotify_user`, `kvm:tsc_scaling_sync` were known to give inconsistent results before.

The test `rtc:rtctest` was known to give inconsistent results before, although only for `ciqlts9_2` - added to the list of flappy tests for `ciqlts9_2-rt`.

The test `net:udpgso_bench.sh` shown inconsistent behavior within the reference suite - added to the list of flappy tests for `ciqlts9_2-rt`.

Because of the `net:udpgso_bench.sh`, `timers:raw_skew` test results the `net` and `timers` suites were repeated additional two times on the patched kernel

[kselftests-net-timers&#x2013;src&#x2013;ciqlts9\_2-rt-CVE-2023-4206.4207.4208&#x2013;run1.log](<https://github.com/user-attachments/files/19218711/kselftests-net-timers--src--ciqlts9_2-rt-CVE-2023-4206.4207.4208--run1.log>)
[kselftests-net-timers&#x2013;src&#x2013;ciqlts9\_2-rt-CVE-2023-4206.4207.4208&#x2013;run2.log](<https://github.com/user-attachments/files/19218710/kselftests-net-timers--src--ciqlts9_2-rt-CVE-2023-4206.4207.4208--run2.log>)

    ktests.xsh table --where "Summary = 'diff'"  kselftests--mix*.log kselftests-net-timers*.log

    Column    File
    --------  --------------------------------------------------------------------------
    Status0   kselftests--mix--ciqlts9_2-rt--run1.log
    Status1   kselftests--mix--ciqlts9_2-rt--run2.log
    Status2   kselftests--mix--ciqlts9_2-rt--run3.log
    Status3   kselftests--mix--ciqlts9_2-rt-CVE-2023-4206.4207.4208--run1.log
    Status4   kselftests-net-timers--src--ciqlts9_2-rt-CVE-2023-4206.4207.4208--run1.log
    Status5   kselftests-net-timers--src--ciqlts9_2-rt-CVE-2023-4206.4207.4208--run2.log
    
    TestCase                 Status0  Status1  Status2  Status3  Status4  Status5  Summary
    bpf:test_tcpnotify_user  fail     pass     pass     fail                       diff
    kvm:tsc_scaling_sync     pass     pass     fail     fail                       diff
    net:altnames.sh          skip     skip     skip     skip     pass     pass     diff
    net:gro.sh               pass     pass     pass     pass     fail     pass     diff
    net:udpgso_bench.sh      pass     pass     pass     fail     pass     pass     diff
    rtc:rtctest              fail     fail     fail     pass                       diff
    seccomp:seccomp_bpf      fail     fail     pass     pass                       diff
    timers:raw_skew          pass     pass     pass     fail     skip     pass     diff

The `net:udpgso_bench.sh` passed the new run, suggesting that the test may be unstable. 

The `timers:raw_skew` achieved a passing run on the patched kernel. It's unlikely that the patch introduced instabilitiy to this test as the change was not at all related to timers, rather the test itself should be noted to be unstable for future testing.

The `net:altnames.sh` test passed while it was being skipped before because of the `jq` tool installed on the testing machines in the meantime.


# Kselftests (networking): passed relative


## Methodology

In [general kselftests](#org85c7d19) all the `net/forwarding` tests fail (really should be skipped) because of the missing tool dependencies

    # selftests: net/forwarding: bridge_igmp.sh
    # SKIP: jq not installed
    not ok 1 selftests: net/forwarding: bridge_igmp.sh # exit=1

Because the patch deals with networking specifically, an additional batch of tests was carried out after solving the test requirements issues.

    sudo make ARCH=$(uname -m) -C tools/testing/selftests TARGETS="net/forwarding" run_tests

The `tools/testing/selftests/net/forwarding/forwarding.config` file used was created directly from the `tools/testing/selftests/net/forwarding/forwarding.config.sample`.


## Reference

Three test runs were conducted on the reference kernel.
[kselftests-net-forwarding&#x2013;src&#x2013;ciqlts9\_2-rt&#x2013;run1.log](<https://github.com/user-attachments/files/19216070/kselftests-net-forwarding--src--ciqlts9_2-rt--run1.log>)
[kselftests-net-forwarding&#x2013;src&#x2013;ciqlts9\_2-rt&#x2013;run2.log](<https://github.com/user-attachments/files/19216069/kselftests-net-forwarding--src--ciqlts9_2-rt--run2.log>)
[kselftests-net-forwarding&#x2013;src&#x2013;ciqlts9\_2-rt&#x2013;run3.log](<https://github.com/user-attachments/files/19216068/kselftests-net-forwarding--src--ciqlts9_2-rt--run3.log>)


## Patch

A single test run was conducted on the patched kernel.
[kselftests-net-forwarding&#x2013;src&#x2013;ciqlts9\_2-rt-CVE-2023-4206.4207.4208&#x2013;run1.log](<https://github.com/user-attachments/files/19216067/kselftests-net-forwarding--src--ciqlts9_2-rt-CVE-2023-4206.4207.4208--run1.log>)


## Comparison and discussion

Results for the reference and patched kernel are the same.

    ktests.xsh table kselftests-net-forwarding*.log

    Column    File
    --------  ------------------------------------------------------------------------------
    Status0   kselftests-net-forwarding--src--ciqlts9_2-rt--run1.log
    Status1   kselftests-net-forwarding--src--ciqlts9_2-rt--run2.log
    Status2   kselftests-net-forwarding--src--ciqlts9_2-rt--run3.log
    Status3   kselftests-net-forwarding--src--ciqlts9_2-rt-CVE-2023-4206.4207.4208--run1.log
    
    TestCase                                        Status0  Status1  Status2  Status3  Summary
    net/forwarding:bridge_igmp.sh                   fail     fail     fail     fail     same
    net/forwarding:bridge_locked_port.sh            pass     pass     pass     pass     same
    net/forwarding:bridge_mld.sh                    fail     fail     fail     fail     same
    net/forwarding:bridge_port_isolation.sh         pass     pass     pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh             pass     pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh             fail     fail     fail     fail     same
    net/forwarding:bridge_vlan_mcast.sh             fail     fail     fail     fail     same
    net/forwarding:bridge_vlan_unaware.sh           pass     pass     pass     pass     same
    net/forwarding:custom_multipath_hash.sh         fail     fail     fail     fail     same
    net/forwarding:dual_vxlan_bridge.sh             pass     pass     pass     pass     same
    net/forwarding:ethtool.sh                       fail     fail     fail     fail     same
    net/forwarding:ethtool_extended_state.sh        fail     fail     fail     fail     same
    net/forwarding:gre_custom_multipath_hash.sh     fail     fail     fail     fail     same
    net/forwarding:gre_inner_v4_multipath.sh        fail     fail     fail     fail     same
    net/forwarding:gre_inner_v6_multipath.sh        fail     fail     fail     fail     same
    net/forwarding:gre_multipath.sh                 fail     fail     fail     fail     same
    net/forwarding:gre_multipath_nh.sh              fail     fail     fail     fail     same
    net/forwarding:gre_multipath_nh_res.sh          fail     fail     fail     fail     same
    net/forwarding:hw_stats_l3.sh                   fail     fail     fail     fail     same
    net/forwarding:hw_stats_l3_gre.sh               fail     fail     fail     fail     same
    net/forwarding:ip6_forward_instats_vrf.sh       fail     fail     fail     fail     same
    net/forwarding:ip6gre_custom_multipath_hash.sh  fail     fail     fail     fail     same
    net/forwarding:ip6gre_flat.sh                   pass     pass     pass     pass     same
    net/forwarding:ip6gre_flat_key.sh               pass     pass     pass     pass     same
    net/forwarding:ip6gre_flat_keys.sh              pass     pass     pass     pass     same
    net/forwarding:ip6gre_hier.sh                   pass     pass     pass     pass     same
    net/forwarding:ip6gre_hier_key.sh               pass     pass     pass     pass     same
    net/forwarding:ip6gre_hier_keys.sh              pass     pass     pass     pass     same
    net/forwarding:ip6gre_inner_v4_multipath.sh     fail     fail     fail     fail     same
    net/forwarding:ip6gre_inner_v6_multipath.sh     fail     fail     fail     fail     same
    net/forwarding:ipip_flat_gre.sh                 pass     pass     pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh             pass     pass     pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh            pass     pass     pass     pass     same
    net/forwarding:ipip_hier_gre.sh                 pass     pass     pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh             pass     pass     pass     pass     same
    net/forwarding:ipip_hier_gre_keys.sh            pass     pass     pass     pass     same
    net/forwarding:loopback.sh                      skip     skip     skip     skip     same
    net/forwarding:mirror_gre.sh                    fail     fail     fail     fail     same
    net/forwarding:mirror_gre_bound.sh              pass     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh          pass     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d_vlan.sh     fail     fail     fail     fail     same
    net/forwarding:mirror_gre_bridge_1q.sh          fail     fail     fail     fail     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh      fail     fail     fail     fail     same
    net/forwarding:mirror_gre_changes.sh            fail     fail     fail     fail     same
    net/forwarding:mirror_gre_flower.sh             fail     fail     fail     fail     same
    net/forwarding:mirror_gre_lag_lacp.sh           fail     fail     fail     fail     same
    net/forwarding:mirror_gre_neigh.sh              pass     pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh                 pass     pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh               pass     pass     pass     pass     same
    net/forwarding:mirror_gre_vlan_bridge_1q.sh     fail     fail     fail     fail     same
    net/forwarding:mirror_vlan.sh                   pass     pass     pass     pass     same
    net/forwarding:pedit_dsfield.sh                 pass     pass     pass     pass     same
    net/forwarding:pedit_ip.sh                      pass     pass     pass     pass     same
    net/forwarding:pedit_l4port.sh                  pass     pass     pass     pass     same
    net/forwarding:q_in_vni.sh                      pass     pass     pass     pass     same
    net/forwarding:q_in_vni_ipv6.sh                 pass     pass     pass     pass     same
    net/forwarding:router.sh                        skip     skip     skip     skip     same
    net/forwarding:router_bridge.sh                 pass     pass     pass     pass     same
    net/forwarding:router_bridge_vlan.sh            pass     pass     pass     pass     same
    net/forwarding:router_broadcast.sh              pass     pass     pass     pass     same
    net/forwarding:router_mpath_nh.sh               fail     fail     fail     fail     same
    net/forwarding:router_mpath_nh_res.sh           fail     fail     fail     fail     same
    net/forwarding:router_multicast.sh              skip     skip     skip     skip     same
    net/forwarding:router_multipath.sh              fail     fail     fail     fail     same
    net/forwarding:router_nh.sh                     pass     pass     pass     pass     same
    net/forwarding:router_vid_1.sh                  pass     pass     pass     pass     same

The list of `net/forwarding` tests performed is not exhaustive (66 / 92). The `net/forwarding:sch_ets.sh` test executed right after `net/forwarding:router_vid_1.sh` causes the machine to hang for more than 10 minutes and the used testing framework interrupts the test suite.

    ...
    ok 66 selftests: net/forwarding: router_vid_1.sh
    # selftests: net/forwarding: sch_ets.sh
    # TEST: ping vlan 10                                                  [ OK ]
    # TEST: ping vlan 11                                                  [ OK ]
    # TEST: ping vlan 12                                                  [ OK ]
    # Running in priomap mode
    # Testing ets bands 3 strict 3, streams 0 1
    # TEST: band 0                                                        [ OK ]
    # INFO: Expected ratio >95% Measured ratio 100.00
    # TEST: band 1                                                        [ OK ]
    # INFO: Expected ratio <5% Measured ratio 0
    # Testing ets bands 3 strict 3, streams 1 2
    ERROR:root:Subprocess exceeded the maximum freeze time 600 s. Terminating
    INFO:root:Finished tests. Cleaning up the machine
    ...

The fix for the problem was deferred to another CVE for the sake of patching efficiency.

