### PR TITLE
[ciqlts9_2-rt] can: bcm: Fix UAF in bcm_proc_show()

### DIFF
--- a/net/can/bcm.c
+++ b/net/can/bcm.c
@@ -1511,6 +1511,12 @@ static int bcm_release(struct socket *sock)
 
 	lock_sock(sk);
 
+#if IS_ENABLED(CONFIG_PROC_FS)
+	/* remove procfs entry */
+	if (net->can.bcmproc_dir && bo->bcm_proc_read)
+		remove_proc_entry(bo->procname, net->can.bcmproc_dir);
+#endif /* CONFIG_PROC_FS */
+
 	list_for_each_entry_safe(op, next, &bo->tx_ops, list)
 		bcm_remove_op(op);
 
@@ -1545,12 +1551,6 @@ static int bcm_release(struct socket *sock)
 
 	list_for_each_entry_safe(op, next, &bo->rx_ops, list)
 		bcm_remove_op(op);
-
-#if IS_ENABLED(CONFIG_PROC_FS)
-	/* remove procfs entry */
-	if (net->can.bcmproc_dir && bo->bcm_proc_read)
-		remove_proc_entry(bo->procname, net->can.bcmproc_dir);
-#endif /* CONFIG_PROC_FS */
 
 	/* remove device reference */
 	if (bo->bound) {


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [ ] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-36341
cve CVE-2023-52922
commit-author YueHaibing <yuehaibing@huawei.com>
commit 55c3b96074f3f9b0aee19bf93cd71af7516582bb

BUG: KASAN: slab-use-after-free in bcm_proc_show+0x969/0xa80 Read of size 8 at addr ffff888155846230 by task cat/7862

CPU: 1 PID: 7862 Comm: cat Not tainted 6.5.0-rc1-00153-gc8746099c197 #230 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.15.0-1 04/01/2014 Call Trace:
 <TASK>
 dump_stack_lvl+0xd5/0x150
 print_report+0xc1/0x5e0
 kasan_report+0xba/0xf0
 bcm_proc_show+0x969/0xa80
 seq_read_iter+0x4f6/0x1260
 seq_read+0x165/0x210
 proc_reg_read+0x227/0x300
 vfs_read+0x1d5/0x8d0
 ksys_read+0x11e/0x240
 do_syscall_64+0x35/0xb0
 entry_SYSCALL_64_after_hwframe+0x63/0xcd

Allocated by task 7846:
 kasan_save_stack+0x1e/0x40
 kasan_set_track+0x21/0x30
 __kasan_kmalloc+0x9e/0xa0
 bcm_sendmsg+0x264b/0x44e0
 sock_sendmsg+0xda/0x180
 ____sys_sendmsg+0x735/0x920
 ___sys_sendmsg+0x11d/0x1b0
 __sys_sendmsg+0xfa/0x1d0
 do_syscall_64+0x35/0xb0
 entry_SYSCALL_64_after_hwframe+0x63/0xcd

Freed by task 7846:
 kasan_save_stack+0x1e/0x40
 kasan_set_track+0x21/0x30
 kasan_save_free_info+0x27/0x40
 ____kasan_slab_free+0x161/0x1c0
 slab_free_freelist_hook+0x119/0x220
 __kmem_cache_free+0xb4/0x2e0
 rcu_core+0x809/0x1bd0

bcm_op is freed before procfs entry be removed in bcm_release(), this lead to bcm_proc_show() may read the freed bcm_op.

Fixes: ffd980f976e7 ("[CAN]: Add broadcast manager (bcm) protocol")
	Signed-off-by: YueHaibing <yuehaibing@huawei.com>
	Reviewed-by: Oliver Hartkopp <socketcan@hartkopp.net>
	Acked-by: Oliver Hartkopp <socketcan@hartkopp.net>
Link: https://lore.kernel.org/all/20230715092543.15548-1-yuehaibing@huawei.com
	Cc: stable@vger.kernel.org
	Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>
(cherry picked from commit 55c3b96074f3f9b0aee19bf93cd71af7516582bb)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```
### Kernel build logs
```
  INSTALL /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-_ppatel__ciqlts9_2-rt+
[TIMER]{MODULES}: 32s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-_ppatel__ciqlts9_2-rt+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 12s
Checking kABI
Error: kABI check failed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_ppatel__ciqlts9_2-rt+ and Index to 0
The default is /boot/loader/entries/7cfa9635a1144771843e9a61949d2155-5.14.0-_ppatel__ciqlts9_2-rt+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-_ppatel__ciqlts9_2-rt+
The default is /boot/loader/entries/7cfa9635a1144771843e9a61949d2155-5.14.0-_ppatel__ciqlts9_2-rt+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-_ppatel__ciqlts9_2-rt+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 4s
[TIMER]{BUILD}: 847s
[TIMER]{MODULES}: 32s
[TIMER]{INSTALL}: 12s
[TIMER]{TOTAL} 900s
Rebooting in 10 seconds
```
[kernel_build.log](https://github.com/user-attachments/files/19162514/kernel_build.log)

### Kselftests
**The tests for `lkdtm` were skipped because the kselftest would get stuck after displaying `# ./stack-entropy.sh: line 13: /sys/kernel/debug/provoke-crash/DIRECT: Permission denied`.**
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
317
317

$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
73
73
```
[kselftest-after.log](https://github.com/user-attachments/files/19162511/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/19162512/kselftest-before.log)
