### PR TITLE
Integrate NVidia patches to improve IPSec performance with hw offload

### DIFF
--- a/Documentation/networking/xfrm_device.rst
+++ b/Documentation/networking/xfrm_device.rst
@@ -136,7 +136,8 @@ the stack in xfrm_input().
 
 	hand the packet to napi_gro_receive() as usual
 
-In ESN mode, xdo_dev_state_advance_esn() is called from xfrm_replay_advance_esn().
+In ESN mode, xdo_dev_state_advance_esn() is called from
+xfrm_replay_advance_esn() for RX, and xfrm_replay_overflow_offload_esn for TX.
 Driver will check packet seq number and update HW ESN state machine if needed.
 
 When the SA is removed by the user, the driver's xdo_dev_state_delete()

--- a/drivers/net/bonding/bond_main.c
+++ b/drivers/net/bonding/bond_main.c
@@ -1408,6 +1408,7 @@ static void bond_compute_features(struct bonding *bond)
 {
 	unsigned int dst_release_flag = IFF_XMIT_DST_RELEASE |
 					IFF_XMIT_DST_RELEASE_PERM;
+	netdev_features_t gso_partial_features = NETIF_F_GSO_ESP;
 	netdev_features_t vlan_features = BOND_VLAN_FEATURES;
 	netdev_features_t enc_features  = BOND_ENC_FEATURES;
 #ifdef CONFIG_XFRM_OFFLOAD
@@ -1440,6 +1441,9 @@ static void bond_compute_features(struct bonding *bond)
 							  BOND_XFRM_FEATURES);
 #endif /* CONFIG_XFRM_OFFLOAD */
 
+		if (slave->dev->hw_enc_features & NETIF_F_GSO_PARTIAL)
+			gso_partial_features &= slave->dev->gso_partial_features;
+
 		mpls_features = netdev_increment_features(mpls_features,
 							  slave->dev->mpls_features,
 							  BOND_MPLS_FEATURES);
@@ -1452,6 +1456,11 @@ static void bond_compute_features(struct bonding *bond)
 		tso_max_segs = min(tso_max_segs, slave->dev->tso_max_segs);
 	}
 	bond_dev->hard_header_len = max_hard_header_len;
+
+	if (gso_partial_features & NETIF_F_GSO_ESP)
+		bond_dev->gso_partial_features |= NETIF_F_GSO_ESP;
+	else
+		bond_dev->gso_partial_features &= ~NETIF_F_GSO_ESP;
 
 done:
 	bond_dev->vlan_features = vlan_features;

--- a/drivers/net/bonding/bond_main.c
+++ b/drivers/net/bonding/bond_main.c
@@ -1398,17 +1398,20 @@ static netdev_features_t bond_fix_features(struct net_device *dev,
 				 NETIF_F_HIGHDMA | NETIF_F_LRO)
 
 #define BOND_ENC_FEATURES	(NETIF_F_HW_CSUM | NETIF_F_SG | \
-				 NETIF_F_RXCSUM | NETIF_F_GSO_SOFTWARE)
+				 NETIF_F_RXCSUM | NETIF_F_GSO_SOFTWARE | \
+				 NETIF_F_GSO_PARTIAL)
 
 #define BOND_MPLS_FEATURES	(NETIF_F_HW_CSUM | NETIF_F_SG | \
 				 NETIF_F_GSO_SOFTWARE)
 
+#define BOND_GSO_PARTIAL_FEATURES (NETIF_F_GSO_ESP)
+
 
 static void bond_compute_features(struct bonding *bond)
 {
+	netdev_features_t gso_partial_features = BOND_GSO_PARTIAL_FEATURES;
 	unsigned int dst_release_flag = IFF_XMIT_DST_RELEASE |
 					IFF_XMIT_DST_RELEASE_PERM;
-	netdev_features_t gso_partial_features = NETIF_F_GSO_ESP;
 	netdev_features_t vlan_features = BOND_VLAN_FEATURES;
 	netdev_features_t enc_features  = BOND_ENC_FEATURES;
 #ifdef CONFIG_XFRM_OFFLOAD
@@ -1441,8 +1444,9 @@ static void bond_compute_features(struct bonding *bond)
 							  BOND_XFRM_FEATURES);
 #endif /* CONFIG_XFRM_OFFLOAD */
 
-		if (slave->dev->hw_enc_features & NETIF_F_GSO_PARTIAL)
-			gso_partial_features &= slave->dev->gso_partial_features;
+		gso_partial_features = netdev_increment_features(gso_partial_features,
+								 slave->dev->gso_partial_features,
+								 BOND_GSO_PARTIAL_FEATURES);
 
 		mpls_features = netdev_increment_features(mpls_features,
 							  slave->dev->mpls_features,
@@ -1457,12 +1461,8 @@ static void bond_compute_features(struct bonding *bond)
 	}
 	bond_dev->hard_header_len = max_hard_header_len;
 
-	if (gso_partial_features & NETIF_F_GSO_ESP)
-		bond_dev->gso_partial_features |= NETIF_F_GSO_ESP;
-	else
-		bond_dev->gso_partial_features &= ~NETIF_F_GSO_ESP;
-
 done:
+	bond_dev->gso_partial_features = gso_partial_features;
 	bond_dev->vlan_features = vlan_features;
 	bond_dev->hw_enc_features = enc_features | NETIF_F_GSO_ENCAP_ALL |
 				    NETIF_F_HW_VLAN_CTAG_TX |
@@ -5798,6 +5798,7 @@ void bond_setup(struct net_device *bond_dev)
 	bond_dev->hw_features |= NETIF_F_GSO_ENCAP_ALL;
 	bond_dev->features |= bond_dev->hw_features;
 	bond_dev->features |= NETIF_F_HW_VLAN_CTAG_TX | NETIF_F_HW_VLAN_STAG_TX;
+	bond_dev->features |= NETIF_F_GSO_PARTIAL;
 #ifdef CONFIG_XFRM_OFFLOAD
 	bond_dev->hw_features |= BOND_XFRM_FEATURES;
 	/* Only enable XFRM features if this is an active-backup config */

--- a/drivers/net/ethernet/chelsio/cxgb4/cxgb4_main.c
+++ b/drivers/net/ethernet/chelsio/cxgb4/cxgb4_main.c
@@ -6572,6 +6572,9 @@ static void cxgb4_advance_esn_state(struct xfrm_state *x)
 {
 	struct adapter *adap = netdev2adap(x->xso.dev);
 
+	if (x->xso.dir != XFRM_DEV_OFFLOAD_IN)
+		return;
+
 	if (!mutex_trylock(&uld_mutex)) {
 		dev_dbg(adap->pdev_dev,
 			"crypto uld critical resource is under use\n");

--- a/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec.c
+++ b/drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec.c
@@ -419,6 +419,9 @@ static void mlx5e_xfrm_advance_esn_state(struct xfrm_state *x)
 		&sa_entry->modify_work;
 	bool need_update;
 
+	if (x->xso.dir != XFRM_DEV_OFFLOAD_IN)
+		return;
+
 	need_update = mlx5e_ipsec_update_esn_state(sa_entry);
 	if (!need_update)
 		return;

--- a/net/xfrm/xfrm_output.c
+++ b/net/xfrm/xfrm_output.c
@@ -738,7 +738,7 @@ int xfrm_output(struct sock *sk, struct sk_buff *skb)
 		skb->encapsulation = 1;
 
 		if (skb_is_gso(skb)) {
-			if (skb->inner_protocol)
+			if (skb->inner_protocol && x->props.mode == XFRM_MODE_TUNNEL)
 				return xfrm_output_gso(net, sk, skb);
 
 			skb_shinfo(skb)->gso_type |= SKB_GSO_ESP;

--- a/net/xfrm/xfrm_replay.c
+++ b/net/xfrm/xfrm_replay.c
@@ -729,6 +729,7 @@ static int xfrm_replay_overflow_offload_esn(struct xfrm_state *x, struct sk_buff
 		}
 
 		replay_esn->oseq = oseq;
+		xfrm_dev_state_advance_esn(x);
 
 		if (xfrm_aevent_is_on(net))
 			xfrm_replay_notify(x, XFRM_REPLAY_UPDATE);


### PR DESCRIPTION
### Commits

Cherry-picking 4 patches from upstream:

1. [bonding: add ESP offload features when slaves support](https://lore.kernel.org/all/20241105192721.584822-1-tariqt@nvidia.com/)
This patch fixes a perf issue in the bonding driver where ESP segmentation was not being offloaded to the slave devices.

2. [bonding: Correctly support GSO ESP offload](https://lore.kernel.org/netdev/20250127104147.759658-1-cratiu@nvidia.com/)
The fix in patch 1 is incomplete and this change fixes the ESP segmentation issue.
 
3. [xfrm_output: Force software GSO only in tunnel mode](https://lore.kernel.org/netdev/20250219105248.226962-1-cratiu@nvidia.com/)
Fix in xfrm_output to only trigger software GSO in crypto offload cases for already encapsulated packets in tunnel mode.

4. [xfrm: Support ESN context update to hardware for TX](https://lore.kernel.org/all/874f965d786606b0b4351c976f50271349f68b03.1734611621.git.leon@kernel.org/)
Previously xfrm_dev_state_advance_esn() was added for RX only in commit 50bd870a9e5cca9, but is needed for TX as well.

### Build

```
/mnt/ciq/sneginha/kernel-src-tree
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys

<SNIP>

[TIMER]{MRPROPER}: 19s
x86_64 architecture detected, copying config
'configs/kernel-5.14.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o

<SNIP>

  BTF [M] sound/usb/usx2y/snd-usb-usx2y.ko
  BTF [M] sound/virtio/virtio_snd.ko
  BTF [M] sound/xen/snd_xen_front.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 2333s
Making Modules
  INSTALL /lib/modules/5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  STRIP   /lib/modules/5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  SIGN    /lib/modules/5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  STRIP   /lib/modules/5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  SIGN    /lib/modules/5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+/kernel/arch/x86/crypto/blowfish-x86_64.ko

<SNIP>

  STRIP   /lib/modules/5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+
[TIMER]{MODULES}: 46s
Making Install
sh ./arch/x86/boot/install.sh \
        6.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-03b404b81bf2+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 25s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-00adedc58a8e+ and Index to 1
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 19s
[TIMER]{BUILD}: 2333s
[TIMER]{MODULES}: 46s
[TIMER]{INSTALL}: 25s
[TIMER]{TOTAL} 2431s
Rebooting in 10 seconds

```

### kABI Check

```
Checking kABI
kABI check passed
```

###  Reboot and Verify
```
Linux localhost 5.14.0-sneginhal-fips-9-compliant_5.14.0-284.30.1-00adedc58a8e+ #1 SMP PREEMPT_DYNAMIC Thu Mar 20 06:03:26 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
```

### Kernel Self Tests

[kselftest_output.txt](https://github.com/user-attachments/files/19374666/kselftest_output.txt)
