### PR TITLE
[ciqlts9_4] can: bcm: Fix UAF in bcm_proc_show()

### DIFF
--- a/net/can/bcm.c
+++ b/net/can/bcm.c
@@ -1511,6 +1511,12 @@ static int bcm_release(struct socket *sock)
 
 	lock_sock(sk);
 
+#if IS_ENABLED(CONFIG_PROC_FS)
+	/* remove procfs entry */
+	if (net->can.bcmproc_dir && bo->bcm_proc_read)
+		remove_proc_entry(bo->procname, net->can.bcmproc_dir);
+#endif /* CONFIG_PROC_FS */
+
 	list_for_each_entry_safe(op, next, &bo->tx_ops, list)
 		bcm_remove_op(op);
 
@@ -1545,12 +1551,6 @@ static int bcm_release(struct socket *sock)
 
 	list_for_each_entry_safe(op, next, &bo->rx_ops, list)
 		bcm_remove_op(op);
-
-#if IS_ENABLED(CONFIG_PROC_FS)
-	/* remove procfs entry */
-	if (net->can.bcmproc_dir && bo->bcm_proc_read)
-		remove_proc_entry(bo->procname, net->can.bcmproc_dir);
-#endif /* CONFIG_PROC_FS */
 
 	/* remove device reference */
 	if (bo->bound) {


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-36337
cve CVE-2023-52922
commit-author YueHaibing <yuehaibing@huawei.com>
commit 55c3b96074f3f9b0aee19bf93cd71af7516582bb

BUG: KASAN: slab-use-after-free in bcm_proc_show+0x969/0xa80 Read of size 8 at addr ffff888155846230 by task cat/7862

CPU: 1 PID: 7862 Comm: cat Not tainted 6.5.0-rc1-00153-gc8746099c197 #230 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.15.0-1 04/01/2014 Call Trace:
 <TASK>
 dump_stack_lvl+0xd5/0x150
 print_report+0xc1/0x5e0
 kasan_report+0xba/0xf0
 bcm_proc_show+0x969/0xa80
 seq_read_iter+0x4f6/0x1260
 seq_read+0x165/0x210
 proc_reg_read+0x227/0x300
 vfs_read+0x1d5/0x8d0
 ksys_read+0x11e/0x240
 do_syscall_64+0x35/0xb0
 entry_SYSCALL_64_after_hwframe+0x63/0xcd

Allocated by task 7846:
 kasan_save_stack+0x1e/0x40
 kasan_set_track+0x21/0x30
 __kasan_kmalloc+0x9e/0xa0
 bcm_sendmsg+0x264b/0x44e0
 sock_sendmsg+0xda/0x180
 ____sys_sendmsg+0x735/0x920
 ___sys_sendmsg+0x11d/0x1b0
 __sys_sendmsg+0xfa/0x1d0
 do_syscall_64+0x35/0xb0
 entry_SYSCALL_64_after_hwframe+0x63/0xcd

Freed by task 7846:
 kasan_save_stack+0x1e/0x40
 kasan_set_track+0x21/0x30
 kasan_save_free_info+0x27/0x40
 ____kasan_slab_free+0x161/0x1c0
 slab_free_freelist_hook+0x119/0x220
 __kmem_cache_free+0xb4/0x2e0
 rcu_core+0x809/0x1bd0

bcm_op is freed before procfs entry be removed in bcm_release(), this lead to bcm_proc_show() may read the freed bcm_op.

Fixes: ffd980f976e7 ("[CAN]: Add broadcast manager (bcm) protocol")
	Signed-off-by: YueHaibing <yuehaibing@huawei.com>
	Reviewed-by: Oliver Hartkopp <socketcan@hartkopp.net>
	Acked-by: Oliver Hartkopp <socketcan@hartkopp.net>
Link: https://lore.kernel.org/all/20230715092543.15548-1-yuehaibing@huawei.com
	Cc: stable@vger.kernel.org
	Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>
(cherry picked from commit 55c3b96074f3f9b0aee19bf93cd71af7516582bb)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```
### Kernel build logs
```
/run/media/kernel/kernel-src-tree
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/kvm
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/tools
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr/include
  CLEAN   usr
  CLEAN   vmlinux.symvers modules-only.symvers modules.builtin modules.builtin.modinfo
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 48s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ppatel__ciqlts9_4-c6ffc5657c77"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
[---snip---]
  INSTALL /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+
[TIMER]{MODULES}: 36s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 11s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+ and Index to 2
The default is /boot/loader/entries/ea3333b54824407fad5251e1e4b9f9d4-5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+
The default is /boot/loader/entries/ea3333b54824407fad5251e1e4b9f9d4-5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-_ppatel__ciqlts9_4-c6ffc5657c77+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 48s
[TIMER]{BUILD}: 1239s
[TIMER]{MODULES}: 36s
[TIMER]{INSTALL}: 11s
[TIMER]{TOTAL} 1344s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/19432270/kernel-build.log)

### Kselftests
**The tests for `lkdtm` were skipped because the kselftest would get stuck after displaying `# ./stack-entropy.sh: line 13: /sys/kernel/debug/provoke-crash/DIRECT: Permission denied`.**
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
365
351

$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
91
86
```
For some reason, less tests were run with the patch applied than before.
[kselftest-after.log](https://github.com/user-attachments/files/19432274/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/19432275/kselftest-before.log)