### PR TITLE
[ciqlts8_8] can: bcm: Fix UAF in bcm_proc_show()

### DIFF
--- a/net/can/bcm.c
+++ b/net/can/bcm.c
@@ -1503,6 +1503,12 @@ static int bcm_release(struct socket *sock)
 
 	lock_sock(sk);
 
+#if IS_ENABLED(CONFIG_PROC_FS)
+	/* remove procfs entry */
+	if (net->can.bcmproc_dir && bo->bcm_proc_read)
+		remove_proc_entry(bo->procname, net->can.bcmproc_dir);
+#endif /* CONFIG_PROC_FS */
+
 	list_for_each_entry_safe(op, next, &bo->tx_ops, list)
 		bcm_remove_op(op);
 
@@ -1537,12 +1543,6 @@ static int bcm_release(struct socket *sock)
 
 	list_for_each_entry_safe(op, next, &bo->rx_ops, list)
 		bcm_remove_op(op);
-
-#if IS_ENABLED(CONFIG_PROC_FS)
-	/* remove procfs entry */
-	if (net->can.bcmproc_dir && bo->bcm_proc_read)
-		remove_proc_entry(bo->procname, net->can.bcmproc_dir);
-#endif /* CONFIG_PROC_FS */
 
 	/* remove device reference */
 	if (bo->bound) {


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-36332
cve CVE-2023-52922
commit-author YueHaibing <yuehaibing@huawei.com>
commit 55c3b96074f3f9b0aee19bf93cd71af7516582bb

BUG: KASAN: slab-use-after-free in bcm_proc_show+0x969/0xa80 Read of size 8 at addr ffff888155846230 by task cat/7862

CPU: 1 PID: 7862 Comm: cat Not tainted 6.5.0-rc1-00153-gc8746099c197 #230 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.15.0-1 04/01/2014 Call Trace:
 <TASK>
 dump_stack_lvl+0xd5/0x150
 print_report+0xc1/0x5e0
 kasan_report+0xba/0xf0
 bcm_proc_show+0x969/0xa80
 seq_read_iter+0x4f6/0x1260
 seq_read+0x165/0x210
 proc_reg_read+0x227/0x300
 vfs_read+0x1d5/0x8d0
 ksys_read+0x11e/0x240
 do_syscall_64+0x35/0xb0
 entry_SYSCALL_64_after_hwframe+0x63/0xcd

Allocated by task 7846:
 kasan_save_stack+0x1e/0x40
 kasan_set_track+0x21/0x30
 __kasan_kmalloc+0x9e/0xa0
 bcm_sendmsg+0x264b/0x44e0
 sock_sendmsg+0xda/0x180
 ____sys_sendmsg+0x735/0x920
 ___sys_sendmsg+0x11d/0x1b0
 __sys_sendmsg+0xfa/0x1d0
 do_syscall_64+0x35/0xb0
 entry_SYSCALL_64_after_hwframe+0x63/0xcd

Freed by task 7846:
 kasan_save_stack+0x1e/0x40
 kasan_set_track+0x21/0x30
 kasan_save_free_info+0x27/0x40
 ____kasan_slab_free+0x161/0x1c0
 slab_free_freelist_hook+0x119/0x220
 __kmem_cache_free+0xb4/0x2e0
 rcu_core+0x809/0x1bd0

bcm_op is freed before procfs entry be removed in bcm_release(), this lead to bcm_proc_show() may read the freed bcm_op.

Fixes: ffd980f976e7 ("[CAN]: Add broadcast manager (bcm) protocol")
	Signed-off-by: YueHaibing <yuehaibing@huawei.com>
	Reviewed-by: Oliver Hartkopp <socketcan@hartkopp.net>
	Acked-by: Oliver Hartkopp <socketcan@hartkopp.net>
Link: https://lore.kernel.org/all/20230715092543.15548-1-yuehaibing@huawei.com
	Cc: stable@vger.kernel.org
	Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>
(cherry picked from commit 55c3b96074f3f9b0aee19bf93cd71af7516582bb)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
/run/media/kernel/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ppatel__ciqlts8_8-581ac8f566a1"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  UPD     include/config/kernel.release
  UPD     include/generated/uapi/linux/version.h
  DESCEND objtool
  DESCEND bpf/resolve_btfids
[---snip---]
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-_ppatel__ciqlts8_8-581ac8f566a1+
[TIMER]{MODULES}: 42s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-_ppatel__ciqlts8_8-581ac8f566a1+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 10s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_8-581ac8f566a1+ and Index to 0
The default is /boot/loader/entries/3d9e347e81244bb1a7c9ccdb05863a3e-4.18.0-_ppatel__ciqlts8_8-581ac8f566a1+.conf with index 0 and kernel /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_8-581ac8f566a1+
The default is /boot/loader/entries/3d9e347e81244bb1a7c9ccdb05863a3e-4.18.0-_ppatel__ciqlts8_8-581ac8f566a1+.conf with index 0 and kernel /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_8-581ac8f566a1+
Generating grub configuration file ...
Adding boot menu entry for EFI firmware configuration
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1285s
[TIMER]{MODULES}: 42s
[TIMER]{INSTALL}: 10s
[TIMER]{TOTAL} 1342s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/19456500/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
02:08:10|
--------+
230
230

$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
62
62
```
[kselftest-after.log](https://github.com/user-attachments/files/19456510/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/19456511/kselftest-before.log)