### PR TITLE
[LTS 9.2] mptcp CVEs {CVE-2024-57882,CVE-2024-53122} + bugfix

### DIFF
--- a/net/mptcp/options.c
+++ b/net/mptcp/options.c
@@ -664,8 +664,15 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 		    &echo, &drop_other_suboptions))
 		return false;
 
+	/*
+	 * Later on, mptcp_write_options() will enforce mutually exclusion with
+	 * DSS, bail out if such option is set and we can't drop it.
+	 */
 	if (drop_other_suboptions)
 		remaining += opt_size;
+	else if (opts->suboptions & OPTION_MPTCP_DSS)
+		return false;
+
 	len = mptcp_add_addr_len(opts->addr.family, echo, !!opts->addr.port);
 	if (remaining < len)
 		return false;

--- a/net/mptcp/options.c
+++ b/net/mptcp/options.c
@@ -652,6 +652,7 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 	struct mptcp_sock *msk = mptcp_sk(subflow->conn);
 	bool drop_other_suboptions = false;
 	unsigned int opt_size = *size;
+	struct mptcp_addr_info addr;
 	bool echo;
 	int len;
 
@@ -660,7 +661,7 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 	 */
 	if (!mptcp_pm_should_add_signal(msk) ||
 	    (opts->suboptions & (OPTION_MPTCP_MPJ_ACK | OPTION_MPTCP_MPC_ACK)) ||
-	    !mptcp_pm_add_addr_signal(msk, skb, opt_size, remaining, &opts->addr,
+	    !mptcp_pm_add_addr_signal(msk, skb, opt_size, remaining, &addr,
 		    &echo, &drop_other_suboptions))
 		return false;
 
@@ -673,7 +674,7 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 	else if (opts->suboptions & OPTION_MPTCP_DSS)
 		return false;
 
-	len = mptcp_add_addr_len(opts->addr.family, echo, !!opts->addr.port);
+	len = mptcp_add_addr_len(addr.family, echo, !!addr.port);
 	if (remaining < len)
 		return false;
 
@@ -690,6 +691,7 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 		opts->ahmac = 0;
 		*size -= opt_size;
 	}
+	opts->addr = addr;
 	opts->suboptions |= OPTION_MPTCP_ADD_ADDR;
 	if (!echo) {
 		opts->ahmac = add_addr_generate_hmac(msk->local_key,

--- a/net/mptcp/protocol.c
+++ b/net/mptcp/protocol.c
@@ -1980,7 +1980,8 @@ static void mptcp_rcv_space_adjust(struct mptcp_sock *msk, int copied)
 				slow = lock_sock_fast(ssk);
 				WRITE_ONCE(ssk->sk_rcvbuf, rcvbuf);
 				tcp_sk(ssk)->window_clamp = window_clamp;
-				tcp_cleanup_rbuf(ssk, 1);
+				if (tcp_can_send_ack(ssk))
+					tcp_cleanup_rbuf(ssk, 1);
 				unlock_sock_fast(ssk, slow);
 			}
 		}


### PR DESCRIPTION
ontext this has 2 CVES and a bug fix to the same commit as CVE-2024-57882 

Despite MPTCP (MultiPath TCP) is disabled by default we do know that some customers use MultiPath in various ways and can be incredibly difficult to trouble shoot so we're address some additional CVEs outside our priority matrix to make this a little bit better.

## Commit Merge Conflicts
https://github.com/ctrliq/kernel-src-tree/pull/181/commits/a562bf3d8b93d0069846e7e8e12c3d4d69c35fa0
A recent change f410cbe introduced in v6.10-rc1 `tcp annotate data-races around tp->window_clamp` had some fuzz due to the WRITE_ONCE and keep the original code.  No conflicts in merged in code.

## BUILD
```
/mnt/code/kernel-src-tree-build
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-5.14.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_jmaple__ciqlts9_2-f51d4f2003d3"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h

[SNIP]

  LD [M]  virt/lib/irqbypass.ko
  BTF [M] sound/xen/snd_xen_front.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1392s
Making Modules
  INSTALL /lib/modules/5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  STRIP   /lib/modules/5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+/kernel/arch/x86/crypto/blake2s-x86_64.ko

[SNIP]

  STRIP   /lib/modules/5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+
[TIMER]{MODULES}: 35s
Making Install
sh ./arch/x86/boot/install.sh \
        5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 23s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1392s
[TIMER]{MODULES}: 35s
[TIMER]{INSTALL}: 23s
[TIMER]{TOTAL} 1453s
Rebooting in 10 seconds
```

## Kernel Self Tests
For what ever reason 1 iteration of `kselftest` from the rpm install bail out early every single time afterwards and the rebuidl would always bail at `userfaultfsd` which it only just started recently running (looking through old version it would skip MM selftest)
This comparison is between a default `kselftest` run and a manual compile one.
Both are about 88-90% `^ok` rate (pretty common)
```
$ grep '^ok ' kernel_5.14.0-284.30.1.el9_2.92ciq_lts.4.1.x86_64_iteration_1.log | wc -l
205
$ grep '^not ok ' kernel_5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+_manual_selftest.log | wc -l
34

$ grep '^ok ' kernel_5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+_manual_selftest.log | wc -l
264
$ grep '^not ok ' kernel_5.14.0-_jmaple__ciqlts9_2-f51d4f2003d3+_manual_selftest.log | wc -l
34
```

[6.12.15-_jmaple__ciq-6.12.y-b3fa7c3036f6+.kselftest.log](https://github.com/user-attachments/files/19541473/6.12.15-_jmaple__ciq-6.12.y-b3fa7c3036f6%2B.kselftest.log)
[6.12.15-_jmaple__sb_ciq-6.12.y-4e5411d06b62+.kselftest.log](https://github.com/user-attachments/files/19541474/6.12.15-_jmaple__sb_ciq-6.12.y-4e5411d06b62%2B.kselftest.log)
