### PR TITLE
[LTS 9.4] mptcp CVE-2024-57882 + bugfix

### DIFF
--- a/net/mptcp/options.c
+++ b/net/mptcp/options.c
@@ -666,8 +666,15 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 		    &echo, &drop_other_suboptions))
 		return false;
 
+	/*
+	 * Later on, mptcp_write_options() will enforce mutually exclusion with
+	 * DSS, bail out if such option is set and we can't drop it.
+	 */
 	if (drop_other_suboptions)
 		remaining += opt_size;
+	else if (opts->suboptions & OPTION_MPTCP_DSS)
+		return false;
+
 	len = mptcp_add_addr_len(opts->addr.family, echo, !!opts->addr.port);
 	if (remaining < len)
 		return false;

--- a/net/mptcp/options.c
+++ b/net/mptcp/options.c
@@ -654,6 +654,7 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 	struct mptcp_sock *msk = mptcp_sk(subflow->conn);
 	bool drop_other_suboptions = false;
 	unsigned int opt_size = *size;
+	struct mptcp_addr_info addr;
 	bool echo;
 	int len;
 
@@ -662,7 +663,7 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 	 */
 	if (!mptcp_pm_should_add_signal(msk) ||
 	    (opts->suboptions & (OPTION_MPTCP_MPJ_ACK | OPTION_MPTCP_MPC_ACK)) ||
-	    !mptcp_pm_add_addr_signal(msk, skb, opt_size, remaining, &opts->addr,
+	    !mptcp_pm_add_addr_signal(msk, skb, opt_size, remaining, &addr,
 		    &echo, &drop_other_suboptions))
 		return false;
 
@@ -675,7 +676,7 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 	else if (opts->suboptions & OPTION_MPTCP_DSS)
 		return false;
 
-	len = mptcp_add_addr_len(opts->addr.family, echo, !!opts->addr.port);
+	len = mptcp_add_addr_len(addr.family, echo, !!addr.port);
 	if (remaining < len)
 		return false;
 
@@ -692,6 +693,7 @@ static bool mptcp_established_options_add_addr(struct sock *sk, struct sk_buff *
 		opts->ahmac = 0;
 		*size -= opt_size;
 	}
+	opts->addr = addr;
 	opts->suboptions |= OPTION_MPTCP_ADD_ADDR;
 	if (!echo) {
 		MPTCP_INC_STATS(sock_net(sk), MPTCP_MIB_ADDADDRTX);


### PR DESCRIPTION
Context this has 1 CVES and a bug fix to the same commit as CVE-2024-57882 

Despite MPTCP (MultiPath TCP) is disabled by default we do know that some customers use MultiPath in various ways and can be incredibly difficult to trouble shoot so we're address some additional CVEs outside our priority matrix to make this a little bit better.

## Commit Merge Conflicts
https://github.com/ctrliq/kernel-src-tree/pull/181/commits/a562bf3d8b93d0069846e7e8e12c3d4d69c35fa0
A recent change f410cbe introduced in v6.10-rc1 `tcp annotate data-races around tp->window_clamp` had some fuzz due to the WRITE_ONCE and keep the original code.  No conflicts in merged in code.

## BUILD
```
/mnt/code/kernel-src-tree-build
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_jmaple__ciqlts9_4-6a14a722bfe4"
Making olddefconfig
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h

[SNIP]

  BTF [M] virt/lib/irqbypass.ko
  BTF [M] sound/xen/snd_xen_front.ko
[TIMER]{BUILD}: 1596s
Making Modules
  INSTALL /lib/modules/5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  STRIP   /lib/modules/5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  SIGN    /lib/modules/5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4+/kernel/arch/x86/crypto/blake2s-x86_64.ko

[SNIP]

  SIGN    /lib/modules/5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4+
[TIMER]{MODULES}: 44s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4+ \
        arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 23s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1596s
[TIMER]{MODULES}: 44s
[TIMER]{INSTALL}: 23s
[TIMER]{TOTAL} 1667s
Rebooting in 10 seconds
```

## Kselftest
```
[jmaple@devbox code]$ grep '^ok ' 5.14.0-427.42.1.el9_4.94ciq_lts.2.1.x86_64.keselftest.log | wc -l
303

[jmaple@devbox code]$ grep '^ok ' 5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4+.keselftest.log | wc -l
303

```
[5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4+.keselftest.log](https://github.com/user-attachments/files/19542774/5.14.0-_jmaple__ciqlts9_4-6a14a722bfe4%2B.keselftest.log)
[5.14.0-427.42.1.el9_4.94ciq_lts.2.1.x86_64.keselftest.log](https://github.com/user-attachments/files/19542775/5.14.0-427.42.1.el9_4.94ciq_lts.2.1.x86_64.keselftest.log)
