### PR TITLE
[fips-8-legacy] netfilter: nft_set_pipapo: skip inactive elements during set walk

### DIFF
--- a/net/netfilter/nft_set_pipapo.c
+++ b/net/netfilter/nft_set_pipapo.c
@@ -1934,6 +1934,9 @@ static void nft_pipapo_walk(const struct nft_ctx *ctx, struct nft_set *set,
 
 		elem.priv = e;
 
+		if (!nft_set_elem_active(&e->ext, iter->genmask))
+			goto cont;
+
 		iter->err = iter->fn(ctx, set, iter, &elem);
 		if (iter->err < 0)
 			goto out;


### PR DESCRIPTION
jira VULN-8903
cve CVE-2023-6817

```
commit-author Florian Westphal <fw@strlen.de>
commit 317eb9685095678f2c9f5a8189de698c5354316a
upstream-diff The change itself is the same as upstream, but there was
              a minor conflict in code surrounding the change because
              this kernel hasn't moved set element objects into the
              transaction yet.

Otherwise set elements can be deactivated twice which will cause a crash.

	Reported-by: Xingyuan Mo <hdthky0@gmail.com>
Fixes: 3c4287f62044 ("nf_tables: Add set type for arbitrary concatenation of ranges")
	Signed-off-by: Florian Westphal <fw@strlen.de>
	Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
(cherry picked from commit 317eb9685095678f2c9f5a8189de698c5354316a)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build log

[build.log](https://github.com/user-attachments/files/19554853/build.log)

### Testing

kselftests were run before and after the change

[selftests-before.log](https://github.com/user-attachments/files/19554862/selftests-before.log)

[selftests-after.log](https://github.com/user-attachments/files/19554865/selftests-after.log)

```
brett@lycia ~/ciq/vuln-8903 % grep ^ok selftests-before.log | wc -l
214
brett@lycia ~/ciq/vuln-8903 % grep ^ok selftests-after.log | wc -l
214
brett@lycia ~/ciq/vuln-8903 %

```
