### PR TITLE
[ciqlts8_6] can: bcm: Fix UAF in bcm_proc_show()

### DIFF
--- a/net/can/bcm.c
+++ b/net/can/bcm.c
@@ -1503,6 +1503,12 @@ static int bcm_release(struct socket *sock)
 
 	lock_sock(sk);
 
+#if IS_ENABLED(CONFIG_PROC_FS)
+	/* remove procfs entry */
+	if (net->can.bcmproc_dir && bo->bcm_proc_read)
+		remove_proc_entry(bo->procname, net->can.bcmproc_dir);
+#endif /* CONFIG_PROC_FS */
+
 	list_for_each_entry_safe(op, next, &bo->tx_ops, list)
 		bcm_remove_op(op);
 
@@ -1537,12 +1543,6 @@ static int bcm_release(struct socket *sock)
 
 	list_for_each_entry_safe(op, next, &bo->rx_ops, list)
 		bcm_remove_op(op);
-
-#if IS_ENABLED(CONFIG_PROC_FS)
-	/* remove procfs entry */
-	if (net->can.bcmproc_dir && bo->bcm_proc_read)
-		remove_proc_entry(bo->procname, net->can.bcmproc_dir);
-#endif /* CONFIG_PROC_FS */
 
 	/* remove device reference */
 	if (bo->bound) {


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-36331
cve CVE-2023-52922
commit-author YueHaibing <yuehaibing@huawei.com>
commit 55c3b96074f3f9b0aee19bf93cd71af7516582bb

BUG: KASAN: slab-use-after-free in bcm_proc_show+0x969/0xa80 Read of size 8 at addr ffff888155846230 by task cat/7862

CPU: 1 PID: 7862 Comm: cat Not tainted 6.5.0-rc1-00153-gc8746099c197 #230 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.15.0-1 04/01/2014 Call Trace:
 <TASK>
 dump_stack_lvl+0xd5/0x150
 print_report+0xc1/0x5e0
 kasan_report+0xba/0xf0
 bcm_proc_show+0x969/0xa80
 seq_read_iter+0x4f6/0x1260
 seq_read+0x165/0x210
 proc_reg_read+0x227/0x300
 vfs_read+0x1d5/0x8d0
 ksys_read+0x11e/0x240
 do_syscall_64+0x35/0xb0
 entry_SYSCALL_64_after_hwframe+0x63/0xcd

Allocated by task 7846:
 kasan_save_stack+0x1e/0x40
 kasan_set_track+0x21/0x30
 __kasan_kmalloc+0x9e/0xa0
 bcm_sendmsg+0x264b/0x44e0
 sock_sendmsg+0xda/0x180
 ____sys_sendmsg+0x735/0x920
 ___sys_sendmsg+0x11d/0x1b0
 __sys_sendmsg+0xfa/0x1d0
 do_syscall_64+0x35/0xb0
 entry_SYSCALL_64_after_hwframe+0x63/0xcd

Freed by task 7846:
 kasan_save_stack+0x1e/0x40
 kasan_set_track+0x21/0x30
 kasan_save_free_info+0x27/0x40
 ____kasan_slab_free+0x161/0x1c0
 slab_free_freelist_hook+0x119/0x220
 __kmem_cache_free+0xb4/0x2e0
 rcu_core+0x809/0x1bd0

bcm_op is freed before procfs entry be removed in bcm_release(), this lead to bcm_proc_show() may read the freed bcm_op.

Fixes: ffd980f976e7 ("[CAN]: Add broadcast manager (bcm) protocol")
	Signed-off-by: YueHaibing <yuehaibing@huawei.com>
	Reviewed-by: Oliver Hartkopp <socketcan@hartkopp.net>
	Acked-by: Oliver Hartkopp <socketcan@hartkopp.net>
Link: https://lore.kernel.org/all/20230715092543.15548-1-yuehaibing@huawei.com
	Cc: stable@vger.kernel.org
	Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>
(cherry picked from commit 55c3b96074f3f9b0aee19bf93cd71af7516582bb)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
/run/media/kernel/kernel-src-tree
  CLEAN   .
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/tools
  CLEAN    resolve_btfids
  CLEAN   .tmp_versions
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config usr/include include/generated arch/x86/include/generated
  CLEAN   .config .config.old .version Module.symvers
[TIMER]{MRPROPER}: 47s
x86_64 architecture detected, copying config
'configs/kernel-4.18.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ppatel__ciqlts8_6-9d5962ee5f58"
CONFIG_LOCALVERSION="-_ppatel__ciqlts8_6-9d5962ee5f58"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
.config:237:warning: override: reassigning to symbol CGROUP_DEBUG
.config:279:warning: override: reassigning to symbol COMPILE_TEST
.config:280:warning: override: reassigning to symbol CONTEXT_TRACKING_FORCE
.config:614:warning: override: reassigning to symbol GENERIC_IRQ_DEBUGFS
.config:701:warning: override: reassigning to symbol HZ_PERIODIC
.config:762:warning: override: reassigning to symbol IKCONFIG
.config:869:warning: override: reassigning to symbol KERNEL_BZIP2
.config:870:warning: override: reassigning to symbol KERNEL_LZ4
.config:871:warning: override: reassigning to symbol KERNEL_LZMA
.config:872:warning: override: reassigning to symbol KERNEL_LZO
.config:873:warning: override: reassigning to symbol KERNEL_XZ
.config:957:warning: override: reassigning to symbol LOCALVERSION_AUTO
.config:1273:warning: override: reassigning to symbol NO_HZ_IDLE
.config:1468:warning: override: reassigning to symbol RCU_EXPERT
.config:1903:warning: override: reassigning to symbol SYSFS_DEPRECATED
.config:2129:warning: override: reassigning to symbol USELIB
.config:2240:warning: override: reassigning to symbol 64BIT
.config:2355:warning: override: reassigning to symbol AUDIT
.config:2356:warning: override: reassigning to symbol AUDITSYSCALL
.config:2382:warning: override: reassigning to symbol BLK_CGROUP
.config:2390:warning: override: reassigning to symbol BLK_DEV_INITRD
.config:2422:warning: override: reassigning to symbol BPF_JIT
.config:2423:warning: override: reassigning to symbol BPF_JIT_ALWAYS_ON
.config:2425:warning: override: reassigning to symbol BPF_LSM
.config:2428:warning: override: reassigning to symbol BPF_SYSCALL
.config:2429:warning: override: reassigning to symbol BPF_UNPRIV_DEFAULT_OFF
.config:2463:warning: override: reassigning to symbol BSD_PROCESS_ACCT
.config:2464:warning: override: reassigning to symbol BSD_PROCESS_ACCT_V3
.config:2532:warning: override: reassigning to symbol CC_OPTIMIZE_FOR_PERFORMANCE
.config:2532:warning: override: CC_OPTIMIZE_FOR_PERFORMANCE changes choice state
.config:2543:warning: override: reassigning to symbol CFS_BANDWIDTH
.config:2544:warning: override: reassigning to symbol CGROUPS
.config:2545:warning: override: reassigning to symbol CGROUP_BPF
.config:2546:warning: override: reassigning to symbol CGROUP_CPUACCT
.config:2547:warning: override: reassigning to symbol CGROUP_DEVICE
.config:2548:warning: override: reassigning to symbol CGROUP_FREEZER
.config:2549:warning: override: reassigning to symbol CGROUP_HUGETLB
.config:2552:warning: override: reassigning to symbol CGROUP_PERF
.config:2553:warning: override: reassigning to symbol CGROUP_PIDS
.config:2554:warning: override: reassigning to symbol CGROUP_RDMA
.config:2555:warning: override: reassigning to symbol CGROUP_SCHED
.config:2557:warning: override: reassigning to symbol CHECKPOINT_RESTORE
.config:2593:warning: override: reassigning to symbol CPUSETS
.config:2616:warning: override: reassigning to symbol CROSS_MEMORY_ATTACH
.config:2755:warning: override: reassigning to symbol DEFAULT_HOSTNAME
.config:3007:warning: override: reassigning to symbol FAIR_GROUP_SCHED
.config:3066:warning: override: reassigning to symbol GENERIC_ISA_DMA
.config:3187:warning: override: reassigning to symbol HIGH_RES_TIMERS
.config:3330:warning: override: reassigning to symbol IKHEADERS
.config:3392:warning: override: reassigning to symbol INITRAMFS_SOURCE
.config:3489:warning: override: reassigning to symbol IPC_NS
.config:3591:warning: override: reassigning to symbol IRQ_TIME_ACCOUNTING
.config:3669:warning: override: reassigning to symbol KERNEL_GZIP
.config:3669:warning: override: KERNEL_GZIP changes choice state
.config:3735:warning: override: reassigning to symbol LOCALVERSION
.config:3745:warning: override: reassigning to symbol LOG_BUF_SHIFT
.config:3746:warning: override: reassigning to symbol LOG_CPU_MAX_BUF_SHIFT
.config:3815:warning: override: reassigning to symbol MEMCG
.config:3816:warning: override: reassigning to symbol MEMCG_SWAP
.config:3921:warning: override: reassigning to symbol MMU
.config:3984:warning: override: reassigning to symbol NAMESPACES
.config:4125:warning: override: reassigning to symbol NET_NS
.config:4363:warning: override: reassigning to symbol NO_HZ
.config:4364:warning: override: reassigning to symbol NO_HZ_FULL
.config:4364:warning: override: NO_HZ_FULL changes choice state
.config:4376:warning: override: reassigning to symbol NUMA_BALANCING
.config:4377:warning: override: reassigning to symbol NUMA_BALANCING_DEFAULT_ENABLED
.config:4454:warning: override: reassigning to symbol PID_NS
.config:4479:warning: override: reassigning to symbol POSIX_MQUEUE
.config:4506:warning: override: reassigning to symbol PRINTK_SAFE_LOG_BUF_SHIFT
.config:4513:warning: override: reassigning to symbol PROC_PID_CPUSET
.config:4519:warning: override: reassigning to symbol PSI
.config:4520:warning: override: reassigning to symbol PSI_DEFAULT_DISABLED
.config:4558:warning: override: reassigning to symbol RCU_NOCB_CPU
.config:4566:warning: override: reassigning to symbol RD_BZIP2
.config:4567:warning: override: reassigning to symbol RD_GZIP
.config:4568:warning: override: reassigning to symbol RD_LZ4
.config:4569:warning: override: reassigning to symbol RD_LZMA
.config:4570:warning: override: reassigning to symbol RD_LZO
.config:4571:warning: override: reassigning to symbol RD_XZ
.config:4574:warning: override: reassigning to symbol RELAY
.config:4673:warning: override: reassigning to symbol RT_GROUP_SCHED
.config:4684:warning: override: reassigning to symbol SCHED_AUTOGROUP
.config:5157:warning: override: reassigning to symbol SPARSE_IRQ
.config:5189:warning: override: reassigning to symbol SWAP
.config:5201:warning: override: reassigning to symbol SYSVIPC
.config:5208:warning: override: reassigning to symbol TASKSTATS
.config:5209:warning: override: reassigning to symbol TASK_DELAY_ACCT
.config:5210:warning: override: reassigning to symbol TASK_IO_ACCOUNTING
.config:5211:warning: override: reassigning to symbol TASK_XACCT
.config:5284:warning: override: reassigning to symbol TREE_RCU
.config:5537:warning: override: reassigning to symbol USER_NS
.config:5538:warning: override: reassigning to symbol UTS_NS
.config:5622:warning: override: reassigning to symbol VIRT_CPU_ACCOUNTING_GEN
.config:5622:warning: override: VIRT_CPU_ACCOUNTING_GEN changes choice state
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  HOSTCC  scripts/basic/bin2c
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  UPD     include/generated/uapi/linux/version.h
  DESCEND objtool
  UPD     include/config/kernel.release
  DESCEND bpf/resolve_btfids
  MKDIR     /run/media/kernel/kernel-src-tree/tools/bpf/resolve_btfids//libbpf
  MKDIR     /run/media/kernel/kernel-src-tree/tools/bpf/resolve_btfids//libsubcmd
  HOSTCC  /run/media/kernel/kernel-src-tree/tools/objtool/fixdep.o
  HOSTCC  /run/media/kernel/kernel-src-tree/tools/bpf/resolve_btfids/fixdep.o
  GEN     /run/media/kernel/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h
  HOSTLD  /run/media/kernel/kernel-src-tree/tools/objtool/fixdep-in.o
  HOSTLD  /run/media/kernel/kernel-src-tree/tools/bpf/resolve_btfids/fixdep-in.o
  MKDIR   /run/media/kernel/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/
  LINK    /run/media/kernel/kernel-src-tree/tools/objtool/fixdep
  LINK    /run/media/kernel/kernel-src-tree/tools/bpf/resolve_btfids/fixdep
  CC      /run/media/kernel/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/libbpf.o
[---snip---]
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-_ppatel__ciqlts8_6-9d5962ee5f58+
[TIMER]{MODULES}: 41s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-_ppatel__ciqlts8_6-9d5962ee5f58+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 10s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_6-9d5962ee5f58+ and Index to 0
The default is /boot/loader/entries/74447cfd379141518e0d01ed1a411e3c-4.18.0-_ppatel__ciqlts8_6-9d5962ee5f58+.conf with index 0 and kernel /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_6-9d5962ee5f58+
The default is /boot/loader/entries/74447cfd379141518e0d01ed1a411e3c-4.18.0-_ppatel__ciqlts8_6-9d5962ee5f58+.conf with index 0 and kernel /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_6-9d5962ee5f58+
Generating grub configuration file ...
Adding boot menu entry for EFI firmware configuration
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 47s
[TIMER]{BUILD}: 1253s
[TIMER]{MODULES}: 41s
[TIMER]{INSTALL}: 10s
[TIMER]{TOTAL} 1356s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/19555916/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
210
210

$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
56
56
```
[kselftest-after.log](https://github.com/user-attachments/files/19555928/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/19555929/kselftest-before.log)
