### PR TITLE
Add kernel sync github action

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,6 +20,9 @@ jobs:
            - branch: stable_6.12.y
              remote: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
              remote_branch: linux-6.12.y
+           - branch: centos9
+             remote: https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9
+             remote_branch: main
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a github action to sync the kernel-mainline, stable_6.12.y, and centos9 branches with their respective upstreams.  The sync happens daily at 8am (an arbitrary choice of time) or manually.  This should be easily extensible by adding new local branch, remote, and remote branch information to the build matrix (see the 2nd and 3rd commit that add stable_6.12.y and centos9 as examples of that).

Initially I thought that each branch would have its own github action, but then I realized that adding the github action would mess up the history and would mean the branches were not identical to their upstream.  So I ended up adding a github action to the main branch (similar to how [kernels-upstream](https://github.com/ctrliq/kernels-upstream/blob/main/.github/workflows/kernel.yml) does things).

I didn't want to let this loose on our actual branches so I've done a bit of testing on a fork of the repo to get warm fuzzies that it does the right thing.  That being said I will monitor things for a while after this is merged to make sure everything is happening correctly.

LE-2708
LE-2709
LE-2710

