### PR TITLE
[ciqcbr7_9] can: bcm: Fix UAF in bcm_proc_show()

### DIFF
--- a/net/can/bcm.c
+++ b/net/can/bcm.c
@@ -1499,24 +1499,31 @@ static int bcm_connect(struct socket *sock, struct sockaddr *uaddr, int len,
 	struct sockaddr_can *addr = (struct sockaddr_can *)uaddr;
 	struct sock *sk = sock->sk;
 	struct bcm_sock *bo = bcm_sk(sk);
+	int ret = 0;
 
 	if (len < sizeof(*addr))
 		return -EINVAL;
 
-	if (bo->bound)
-		return -EISCONN;
+	lock_sock(sk);
+
+	if (bo->bound) {
+		ret = -EISCONN;
+		goto fail;
+	}
 
 	/* bind a device to this socket */
 	if (addr->can_ifindex) {
 		struct net_device *dev;
 
 		dev = dev_get_by_index(&init_net, addr->can_ifindex);
-		if (!dev)
-			return -ENODEV;
-
+		if (!dev) {
+			ret = -ENODEV;
+			goto fail;
+		}
 		if (dev->type != ARPHRD_CAN) {
 			dev_put(dev);
-			return -ENODEV;
+			ret = -ENODEV;
+			goto fail;
 		}
 
 		bo->ifindex = dev->ifindex;
@@ -1527,17 +1534,24 @@ static int bcm_connect(struct socket *sock, struct sockaddr *uaddr, int len,
 		bo->ifindex = 0;
 	}
 
-	bo->bound = 1;
-
 	if (proc_dir) {
 		/* unique socket address as filename */
 		sprintf(bo->procname, "%lu", sock_i_ino(sk));
 		bo->bcm_proc_read = proc_create_data(bo->procname, 0644,
 						     proc_dir,
 						     &bcm_proc_fops, sk);
+		if (!bo->bcm_proc_read) {
+			ret = -ENOMEM;
+			goto fail;
+		}
 	}
 
-	return 0;
+	bo->bound = 1;
+
+fail:
+	release_sock(sk);
+
+	return ret;
 }
 
 static int bcm_recvmsg(struct kiocb *iocb, struct socket *sock,

--- a/net/can/bcm.c
+++ b/net/can/bcm.c
@@ -1445,6 +1445,12 @@ static int bcm_release(struct socket *sock)
 
 	lock_sock(sk);
 
+#if IS_ENABLED(CONFIG_PROC_FS)
+	/* remove procfs entry */
+	if (proc_dir && bo->bcm_proc_read)
+		remove_proc_entry(bo->procname, proc_dir);
+#endif /* CONFIG_PROC_FS */
+
 	list_for_each_entry_safe(op, next, &bo->tx_ops, list)
 		bcm_remove_op(op);
 
@@ -1475,12 +1481,6 @@ static int bcm_release(struct socket *sock)
 
 		bcm_remove_op(op);
 	}
-
-#if IS_ENABLED(CONFIG_PROC_FS)
-	/* remove procfs entry */
-	if (proc_dir && bo->bcm_proc_read)
-		remove_proc_entry(bo->procname, proc_dir);
-#endif /* CONFIG_PROC_FS */
 
 	/* remove device reference */
 	if (bo->bound) {

--- a/net/can/bcm.c
+++ b/net/can/bcm.c
@@ -140,6 +140,7 @@ static inline struct bcm_sock *bcm_sk(const struct sock *sk)
 /*
  * procfs functions
  */
+#if IS_ENABLED(CONFIG_PROC_FS)
 static char *bcm_proc_getifname(char *result, int ifindex)
 {
 	struct net_device *dev;
@@ -236,6 +237,7 @@ static const struct file_operations bcm_proc_fops = {
 	.llseek		= seq_lseek,
 	.release	= single_release,
 };
+#endif /* CONFIG_PROC_FS */
 
 /*
  * bcm_can_tx - send the (next) CAN frame to the appropriate CAN interface
@@ -1474,9 +1476,11 @@ static int bcm_release(struct socket *sock)
 		bcm_remove_op(op);
 	}
 
+#if IS_ENABLED(CONFIG_PROC_FS)
 	/* remove procfs entry */
 	if (proc_dir && bo->bcm_proc_read)
 		remove_proc_entry(bo->procname, proc_dir);
+#endif /* CONFIG_PROC_FS */
 
 	/* remove device reference */
 	if (bo->bound) {
@@ -1534,6 +1538,7 @@ static int bcm_connect(struct socket *sock, struct sockaddr *uaddr, int len,
 		bo->ifindex = 0;
 	}
 
+#if IS_ENABLED(CONFIG_PROC_FS)
 	if (proc_dir) {
 		/* unique socket address as filename */
 		sprintf(bo->procname, "%lu", sock_i_ino(sk));
@@ -1545,6 +1550,7 @@ static int bcm_connect(struct socket *sock, struct sockaddr *uaddr, int len,
 			goto fail;
 		}
 	}
+#endif /* CONFIG_PROC_FS */
 
 	bo->bound = 1;
 
@@ -1636,8 +1642,10 @@ static int __init bcm_module_init(void)
 		return err;
 	}
 
+#if IS_ENABLED(CONFIG_PROC_FS)
 	/* create /proc/net/can-bcm directory */
 	proc_dir = proc_mkdir("can-bcm", init_net.proc_net);
+#endif /* CONFIG_PROC_FS */
 	return 0;
 }
 
@@ -1645,8 +1653,10 @@ static void __exit bcm_module_exit(void)
 {
 	can_proto_unregister(&bcm_can_proto);
 
+#if IS_ENABLED(CONFIG_PROC_FS)
 	if (proc_dir)
 		remove_proc_entry("can-bcm", init_net.proc_net);
+#endif /* CONFIG_PROC_FS */
 }
 
 module_init(bcm_module_init);


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Things done
This PR contains 2 commits. The commit `can: fix CAN BCM build with CONFIG_PROC_FS disabled` adds some required gating for the proc FS functions. And the commit `can: bcm: Fix UAF in bcm_proc_show()` is the actual commit fixing the CVE of ID `CVE-2023-52922`.

### Merge conflicts
There were merge conflicts for both patches cherry picked from upstream due to the CentOS 7.9 kernel being extremely ~~out of date~~ _old_. But both of the merge conflicts were caused by a fuzz mismatch and were easy to resolve by hand.

### Kernel build logs
```
/run/media/kernel/kernel-src-tree
  clean   .
  clean   arch/x86/kernel/cpu
  clean   arch/x86/kernel
  clean   arch/x86/purgatory
  clean   arch/x86/realmode/rm
  clean   arch/x86/vdso
  clean   arch/x86/lib
  clean   drivers/gpu/drm/radeon
  clean   drivers/scsi/aic7xxx
  clean   drivers/tty/vt
  clean   drivers/video/logo
  clean   firmware
  clean   security/selinux
  clean   usr
  clean   arch/x86/boot/compressed
  clean   arch/x86/boot
  clean   arch/x86/tools
  clean   .tmp_versions
  clean   scripts/basic
  clean   scripts/genksyms
  clean   scripts/kconfig
  clean   scripts/mod
  clean   scripts/selinux/genheaders
  clean   scripts/selinux/mdp
  clean   scripts
  clean   include/config usr/include include/generated arch/x86/include/generated
  clean   .config .config.old .version include/generated/uapi/linux/version.h module.symvers signing_key.priv signing_key.x509 x509.genkey
[timer]{mrproper}: 45s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
setting local version for build
config_localversion="-_ppatel__ciqcbr7_9-539b1c8"
making olddefconfig
  hostcc  scripts/basic/fixdep
  hostcc  scripts/kconfig/conf.o
  shipped scripts/kconfig/zconf.tab.c
  shipped scripts/kconfig/zconf.lex.c
  shipped scripts/kconfig/zconf.hash.c
  hostcc  scripts/kconfig/zconf.tab.o
  hostld  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig kconfig
#
# configuration written to .config
#
starting build
scripts/kconfig/conf --silentoldconfig kconfig
  syshdr  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  syshdr  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  syshdr  arch/x86/syscalls/../include/generated/uapi/asm/unistd_x32.h
  systbl  arch/x86/syscalls/../include/generated/asm/syscalls_32.h
  syshdr  arch/x86/syscalls/../include/generated/asm/unistd_32_ia32.h
  syshdr  arch/x86/syscalls/../include/generated/asm/unistd_64_x32.h
  systbl  arch/x86/syscalls/../include/generated/asm/syscalls_64.h
  hostcc  scripts/basic/bin2c
  wrap    arch/x86/include/generated/asm/clkdev.h
  wrap    arch/x86/include/generated/asm/mm-arch-hooks.h
  wrap    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  chk     include/generated/uapi/linux/version.h
  upd     include/generated/uapi/linux/version.h
  chk     include/generated/qrwlock.h
  upd     include/generated/qrwlock.h
  chk     include/generated/qrwlock_api_smp.h
  upd     include/generated/qrwlock_api_smp.h
  chk     include/generated/qrwlock_types.h
  upd     include/generated/qrwlock_types.h
  chk     kernel/qrwlock_gen.c
  upd     kernel/qrwlock_gen.c
  chk     lib/qrwlock_debug.c
  upd     lib/qrwlock_debug.c
  descend  objtool
  hostcc  scripts/kallsyms
  cc      scripts/mod/empty.o
[---snip---]
  INSTALL /lib/firmware/ti_3410.fw
  INSTALL /lib/firmware/ti_5052.fw
  INSTALL /lib/firmware/mts_cdma.fw
  INSTALL /lib/firmware/mts_gsm.fw
  INSTALL /lib/firmware/mts_edge.fw
  INSTALL /lib/firmware/edgeport/boot.fw
  INSTALL /lib/firmware/edgeport/boot2.fw
  INSTALL /lib/firmware/edgeport/down.fw
  INSTALL /lib/firmware/edgeport/down2.fw
  INSTALL /lib/firmware/edgeport/down3.bin
  INSTALL /lib/firmware/whiteheat_loader.fw
  INSTALL /lib/firmware/whiteheat.fw
  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-_ppatel__ciqcbr7_9-539b1c8+
[TIMER]{MODULES}: 67s
Making Install
sh ./arch/x86/boot/install.sh 3.10.0-_ppatel__ciqcbr7_9-539b1c8+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 8s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-_ppatel__ciqcbr7_9-539b1c8+ and Index to 0
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7_9.ciqcbr.3.1.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7_9.ciqcbr.3.1.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7_9.ciqcbr.2.1.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7_9.ciqcbr.2.1.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-_ppatel__ciqcbr7_9-539b1c8+
Found initrd image: /boot/initramfs-3.10.0-_ppatel__ciqcbr7_9-539b1c8+.img
Found linux image: /boot/vmlinuz-3.10.0-ciqcbr7_9-be03ca1+
Found initrd image: /boot/initramfs-3.10.0-ciqcbr7_9-be03ca1+.img
Found linux image: /boot/vmlinuz-3.10.0-ciqcbr7_9-be03ca1+.old
Found initrd image: /boot/initramfs-3.10.0-ciqcbr7_9-be03ca1+.img
Found linux image: /boot/vmlinuz-0-rescue-2ff74c8e754a456895c0dd6a20a321c4
Found initrd image: /boot/initramfs-0-rescue-2ff74c8e754a456895c0dd6a20a321c4.img
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 45s
[TIMER]{BUILD}: 684s
[TIMER]{MODULES}: 67s
[TIMER]{INSTALL}: 8s
[TIMER]{TOTAL} 807s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/19712437/kernel-build.log)



### Kselftests
**Note: None of the tests ran on my VM. The command I ran was: `make -C tools TARGETS="breakpoints cpu-hotplug efivarfs livepatch memory-hotplug mqueue net ptrace vm powerpc"`**
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
0
0

$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
0
0
```
[kselftest-after.log](https://github.com/user-attachments/files/19648497/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/19648498/kselftest-before.log)

