### PR TITLE
[SIG CLOUD 9] rebase custom changes to 5.14.0-503.29.1.el9_5

### DIFF
--- a/tools/testing/selftests/mm/hmm-tests.c
+++ b/tools/testing/selftests/mm/hmm-tests.c
@@ -159,6 +159,10 @@ FIXTURE_TEARDOWN(hmm)
 {
 	int ret = close(self->fd);
 
+	if (ret != 0) {
+		fprintf(stderr, "close returned (%d) fd is (%d)\n", ret, self->fd);
+		exit(1);
+	}
 	ASSERT_EQ(ret, 0);
 	self->fd = -1;
 }


### PR DESCRIPTION
## Update process (This kernel CentOS base for `5.15.0-503`)
* Kernel History Rebuild Process for all `src.rpm`s hosted by RESF
* Create `sig-cloud-8/4.18.0-553.40.1.el8_10` branch
* Check if any maintained code is included in the new `el` release.
* Cherry-pick all code from previous branch into new branch (skipping unneeded code) 
  * Fix conflicts as they arise 
* Build and Test

## Removed Commits
```
[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch
- Commit 77cd727f669fcc8a95d57cff25c1ae3c8d95483d already present in new base branch: 77cd727f669fcc8a95d57cff25c1ae3c8d95483d x86/kaslr: Expose and use the end of the physical memory address space
- CIQ Commit 1347da8e14bc1b35373b6f9511dc44197cf4e586 already present in new base branch: 1347da8e14bc1b35373b6f9511dc44197cf4e586 github actions: Make Builds on Merge Request Work
[rolling release update] Removing commits from the new branch
77cd727f669fcc8a95d57cff25c1ae3c8d95483d x86/kaslr: Expose and use the end of the physical memory address space
1347da8e14bc1b35373b6f9511dc44197cf4e586 github actions: Make Builds on Merge Request Work
```
Technically this just leaves our update to enable `HMM x86/kaslr:  Expose and use the end of the physical memory address space` testing this probably doesn't need to be carried anymore, but we should investigate later since it ONLY impacts Kernelselftest which is not distributed.

## Build
```
/mnt/code/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-5.14.0-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_sig-cloud-9_5.14.0-503.29.1.el9_5-f6d894e8c2c4"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h

[SNIP]

  LD [M]  sound/xen/snd_xen_front.ko
  BTF [M] sound/xen/snd_xen_front.ko
[TIMER]{BUILD}: 1727s
Making Modules
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-503.29.1.el9_5-f6d894e8c2c4+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-503.29.1.el9_5-f6d894e8c2c4+/kernel/arch/x86/crypto/blowfish-x86_64.ko

  SIGN    /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-503.29.1.el9_5-f6d894e8c2c4+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-503.29.1.el9_5-f6d894e8c2c4+
[TIMER]{MODULES}: 10s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-jmaple_sig-cloud-9_5.14.0-503.29.1.el9_5-f6d894e8c2c4+ \
        arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 23s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-jmaple_sig-cloud-9_5.14.0-503.29.1.el9_5-f6d894e8c2c4+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1727s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 23s
[TIMER]{TOTAL} 1765s
Rebooting in 10 seconds
```

## Kselftest
```
$ grep '^ok ' 5.14.0-rocky9_5_rebuild-c9a24474a2ec.kselftests.log | wc -l
316

$ grep '^ok ' 5.14.0-jmaple_sig-cloud-9_5.14.0-503.29.1.el9_5-f6d894e8c2c4+.keselftest.log | wc -l
317
```