### PR TITLE
[LTS 9.2] arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array

### DIFF
--- a/arch/arm64/kernel/cacheinfo.c
+++ b/arch/arm64/kernel/cacheinfo.c
@@ -87,16 +87,18 @@ int populate_cache_leaves(unsigned int cpu)
 	unsigned int level, idx;
 	enum cache_type type;
 	struct cpu_cacheinfo *this_cpu_ci = get_cpu_cacheinfo(cpu);
-	struct cacheinfo *this_leaf = this_cpu_ci->info_list;
+	struct cacheinfo *infos = this_cpu_ci->info_list;
 
 	for (idx = 0, level = 1; level <= this_cpu_ci->num_levels &&
-	     idx < this_cpu_ci->num_leaves; idx++, level++) {
+	     idx < this_cpu_ci->num_leaves; level++) {
 		type = get_cache_type(level);
 		if (type == CACHE_TYPE_SEPARATE) {
-			ci_leaf_init(this_leaf++, CACHE_TYPE_DATA, level);
-			ci_leaf_init(this_leaf++, CACHE_TYPE_INST, level);
+			if (idx + 1 >= this_cpu_ci->num_leaves)
+				break;
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_DATA, level);
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_INST, level);
 		} else {
-			ci_leaf_init(this_leaf++, type, level);
+			ci_leaf_init(&infos[idx++], type, level);
 		}
 	}
 	return 0;


### PR DESCRIPTION
[LTS 9.2]
CVE-2025-21785
VULN-54130


# Problem

<https://www.cve.org/CVERecord?id=CVE-2025-21785>
> In the Linux kernel, the following vulnerability has been resolved: arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array The loop that detects/populates cache information already has a bounds check on the array size but does not account for cache levels with separate data/instructions cache. Fix this by incrementing the index for any populated leaf (instead of any populated level).


# Solution

The official fix in the mainline kernel is provided in the 875d742cf5327c93cba1f11e12b08d3cce7a88d2 commit

    arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array
    
    The loop that detects/populates cache information already has a bounds
    check on the array size but does not account for cache levels with
    separate data/instructions cache. Fix this by incrementing the index
    for any populated leaf (instead of any populated level).

The 5.15 backport (closest to `ciqlts9_2` kernel version 5.14) is provided in the [88a3e6afaf002250220793df99404977d343db14](https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=88a3e6afaf002250220793df99404977d343db14) commit, and it has no differences compared to the mainline solution.


# kABI check: passed

    CVE=CVE-2025-21785 ./ninja.sh -d explain _kabi_checked__aarch64--test--ciqlts9_2-CVE-2025-21785

    [0/1] 	Check ABI of kernel [ciqlts9_2-CVE-2025-21785]	_kabi_checked__aarch64--test--ciqlts9_2-CVE-2025-21785
    ++ uname -m
    + python3 /home/pvts/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /home/pvts/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_aarch64 -s vms/aarch64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2025-21785/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2025-21785/aarch64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/19694789/boot-test.log>)


# Kselftests: passed relative


## Methodology

The tests were run using the [rocky-patching](https://gitlab.conclusive.pl/devices/rocky-patching) framework (qemu-kvm virtualization of Rocky base cloud aarch64 images) ported to the local [WHLE-LS1046A](https://conclusive.tech/products/whle-ls1-sbc/) machine, based on the [NXP Layerscape LS1046A](https://www.nxp.com/products/LS1046A) arm64 processor.

-   **`kernel-selftests-internal` package:** `bpf` tests, except `bpf:test_kmod.sh`, `bpf:test_progs`, `bpf:test_progs-no_alu32` (unstable, can crash the machine).
-   **source-compiled selftests:** (commit f08be21dd6d4b10d0da6f60abbf8c20337f8b836) all the rest. Some collections were skipped due to problems they caused on the testing virtual machines (hangs), interfering with the testing procedure: `exec`, `kexec`, `lkdtm`, `net/forwarding`, `netfilter`.


## Coverage

`arm64/bti`, `arm64/fp`, `arm64/mte`, `arm64/pauth`, `arm64/signal`, `arm64/tags`, `bpf`, `breakpoints`, `capabilities`, `cgroup`, `clone3`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding`, `drivers/net/team`, `efivarfs`, `filesystems`, `filesystems/binderfs`, `filesystems/epoll`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `ir`, `kcmp`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net`, `net/mptcp`, `nsfs`, `openat2`, `pid_namespace`, `pidfd`, `proc`, `pstore`, `ptrace`, `rlimits`, `rseq`, `rtc`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `syscall_user_dispatch`, `sysctl`, `tc-testing`, `tdx`, `timens`, `timers`, `tmpfs`, `tpm2`, `user`, `vDSO`, `vm`, `zram`


## Reference

[kselftests&#x2013;mix&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/19814742/kselftests--mix--ciqlts9_2--run1.log>)
[kselftests&#x2013;mix&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/19814741/kselftests--mix--ciqlts9_2--run2.log>)
[kselftests&#x2013;mix&#x2013;ciqlts9\_2&#x2013;run3.log](<https://github.com/user-attachments/files/19814740/kselftests--mix--ciqlts9_2--run3.log>)
[kselftests&#x2013;mix&#x2013;ciqlts9\_2&#x2013;run4.log](<https://github.com/user-attachments/files/19814739/kselftests--mix--ciqlts9_2--run4.log>)
[kselftests&#x2013;mix&#x2013;ciqlts9\_2&#x2013;run5.log](<https://github.com/user-attachments/files/19814738/kselftests--mix--ciqlts9_2--run5.log>)


## Patch

[kselftests&#x2013;mix&#x2013;ciqlts9\_2-CVE-2025-21785&#x2013;run1.log](<https://github.com/user-attachments/files/19814737/kselftests--mix--ciqlts9_2-CVE-2025-21785--run1.log>)
[kselftests&#x2013;mix&#x2013;ciqlts9\_2-CVE-2025-21785&#x2013;run2.log](<https://github.com/user-attachments/files/19814736/kselftests--mix--ciqlts9_2-CVE-2025-21785--run2.log>)


## Comparison

    ./ktests.xsh table kselftests*.log --where 'Summary = "diff"'

    Column    File
    --------  ---------------------------------------------------
    Status0   kselftests--mix--ciqlts9_2--run1.log
    Status1   kselftests--mix--ciqlts9_2--run2.log
    Status2   kselftests--mix--ciqlts9_2--run3.log
    Status3   kselftests--mix--ciqlts9_2--run4.log
    Status4   kselftests--mix--ciqlts9_2--run5.log
    Status5   kselftests--mix--ciqlts9_2-CVE-2025-21785--run1.log
    Status6   kselftests--mix--ciqlts9_2-CVE-2025-21785--run2.log
    
    TestCase              Status0  Status1  Status2  Status3  Status4  Status5  Status6  Summary
    cgroup:test_freezer   pass     fail     pass     fail     pass     pass     pass     diff
    net:gro.sh            fail     pass     pass     pass     pass     fail     pass     diff
    proc:proc-uptime-001  pass     fail     pass     pass     pass     pass     fail     diff
    timers:raw_skew       skip     skip     fail     skip     fail     fail     fail     diff

The different results are all contained in the reference run:

    ./ktests.xsh diff  --where 'Summary = "diff"' kselftests*ciqlts9_2--*.log

    Column    File
    --------  ------------------------------------
    Status0   kselftests--mix--ciqlts9_2--run1.log
    Status1   kselftests--mix--ciqlts9_2--run2.log
    Status2   kselftests--mix--ciqlts9_2--run3.log
    Status3   kselftests--mix--ciqlts9_2--run4.log
    Status4   kselftests--mix--ciqlts9_2--run5.log
    
    TestCase              Status0  Status1  Status2  Status3  Status4  Summary
    cgroup:test_freezer   pass     fail     pass     fail     pass     diff
    net:gro.sh            fail     pass     pass     pass     pass     diff
    proc:proc-uptime-001  pass     fail     pass     pass     pass     diff
    timers:raw_skew       skip     skip     fail     skip     fail     diff


### Differences highlights

1.  `cgroup:test_freezer`

    Inconsistent results for the `test_cgfreezer_ptrace`.
    
        ./ktests.xsh show_groups kselftests--mix--ciqlts9_2--run*.log --test cgroup:test_freezer
    
        kselftests--mix--ciqlts9_2--run1.log:
        kselftests--mix--ciqlts9_2--run3.log:
        kselftests--mix--ciqlts9_2--run5.log:
        cgroup:test_freezer:
        # ok 1 test_cgfreezer_simple
        # ok 2 test_cgfreezer_tree
        # ok 3 test_cgfreezer_forkbomb
        # ok 4 test_cgfreezer_mkdir
        # ok 5 test_cgfreezer_rmdir
        # ok 6 test_cgfreezer_migrate
        # ok 7 test_cgfreezer_ptrace
        # ok 8 test_cgfreezer_stopped
        # ok 9 test_cgfreezer_ptraced
        # ok 10 test_cgfreezer_vfork
        ok 4 selftests: cgroup: test_freezer
        
        kselftests--mix--ciqlts9_2--run2.log:
        kselftests--mix--ciqlts9_2--run4.log:
        cgroup:test_freezer:
        # ok 1 test_cgfreezer_simple
        # ok 2 test_cgfreezer_tree
        # ok 3 test_cgfreezer_forkbomb
        # ok 4 test_cgfreezer_mkdir
        # ok 5 test_cgfreezer_rmdir
        # ok 6 test_cgfreezer_migrate
        # Cgroup /sys/fs/cgroup/cg_test_ptrace isn't frozen
        # not ok 7 test_cgfreezer_ptrace
        # ok 8 test_cgfreezer_stopped
        # ok 9 test_cgfreezer_ptraced
        # ok 10 test_cgfreezer_vfork
        not ok 4 selftests: cgroup: test_freezer

2.  `net:gro.sh`

    Inconsistent results for the ip6 packet geometry.
    
        ./ktests.xsh show kselftests--mix--ciqlts9_2--run1.log --test net:gro.sh | tail -n 20
    
        # Received {65475 899 }, Total 2 packets.
        # Expected {64576 900 900 }, Total 3 packets
        # Received {32288 [!=64576]33188 [!=900]900 }, Total 3 packets.
        # ./gro: incorrect packet geometry
        # Gro::large test passed.
        # Expected {65475 899 }, Total 2 packets
        # Received {65475 899 }, Total 2 packets.
        # Expected {64576 900 900 }, Total 3 packets
        # Received {56504 [!=64576]8972 [!=900]900 }, Total 3 packets.
        # ./gro: incorrect packet geometry
        # Gro::large test passed.
        # Expected {65475 899 }, Total 2 packets
        # Received {65475 899 }, Total 2 packets.
        # Expected {64576 900 900 }, Total 3 packets
        # Received {20180 [!=64576]45296 [!=900]900 }, Total 3 packets.
        # ./gro: incorrect packet geometry
        # Gro::large test passed.
        # failed tests: ipv6_large.     Please see log.txt for more logs
        not ok 53 selftests: net: gro.sh

3.  `proc:proc-uptime-001`

    Unspecified internal problem with the testing binary.
    
        ./ktests.xsh show_groups kselftests--mix--ciqlts9_2--run*.log --test proc:proc-uptime-001
    
        kselftests--mix--ciqlts9_2--run1.log:
        kselftests--mix--ciqlts9_2--run3.log:
        kselftests--mix--ciqlts9_2--run4.log:
        kselftests--mix--ciqlts9_2--run5.log:
        proc:proc-uptime-001:
        ok 11 selftests: proc: proc-uptime-001
        
        kselftests--mix--ciqlts9_2--run2.log:
        proc:proc-uptime-001:
        # proc-uptime-001: proc-uptime-001.c:39: main: Assertion `i1 >= i0' failed.
        # /usr/bin/timeout: the monitored command dumped core
        not ok 11 selftests: proc: proc-uptime-001

4.  `timers:raw_skew`

    Well-known issue with the external clock adjustments.
    
        ./ktests.xsh show_groups kselftests--mix--ciqlts9_2--run*.log --test timers:raw_skew
    
        kselftests--mix--ciqlts9_2--run1.log:
        timers:raw_skew:
        # Estimating clock drift: -196.453(est) 3.559(act)	[SKIP]
        # 1..0 # SKIP The clock was adjusted externally. Shutdown NTPd or other time sync daemons
        ok 7 selftests: timers: raw_skew
        
        kselftests--mix--ciqlts9_2--run2.log:
        timers:raw_skew:
        # Estimating clock drift: -196.446(est) 3.603(act)	[SKIP]
        # 1..0 # SKIP The clock was adjusted externally. Shutdown NTPd or other time sync daemons
        ok 7 selftests: timers: raw_skew
        
        kselftests--mix--ciqlts9_2--run3.log:
        timers:raw_skew:
        # Estimating clock drift: -196.397(est) 3.641(act)	[FAILED]
        # # Totals: pass:0 fail:0 xfail:0 xpass:0 skip:0 error:0
        not ok 7 selftests: timers: raw_skew
        
        kselftests--mix--ciqlts9_2--run4.log:
        timers:raw_skew:
        # Estimating clock drift: -196.70(est) 3.934(act)	[SKIP]
        # 1..0 # SKIP The clock was adjusted externally. Shutdown NTPd or other time sync daemons
        ok 7 selftests: timers: raw_skew
        
        kselftests--mix--ciqlts9_2--run5.log:
        timers:raw_skew:
        # Estimating clock drift: -196.96(est) 3.941(act)	[FAILED]
        # # Totals: pass:0 fail:0 xfail:0 xpass:0 skip:0 error:0
        not ok 7 selftests: timers: raw_skew


# Specific tests: skipped

To be done on demand

