### PR TITLE
[lts94]: Use dummy-tools for olddefconfig

### DIFF
--- a/.github/workflows/build-check_aarch64-rt.yml
+++ b/.github/workflows/build-check_aarch64-rt.yml
@@ -30,5 +30,5 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
           cp configs/kernel-aarch64-rt-rhel.config .config
-          make olddefconfig
+          make ARCH=arm64 CROSS_COMPILE=./scripts/dummy-tools/ olddefconfig
           make -j8

--- a/.github/workflows/build-check_aarch64.yml
+++ b/.github/workflows/build-check_aarch64.yml
@@ -30,5 +30,5 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
           cp configs/kernel-aarch64-rhel.config .config
-          make olddefconfig
+          make ARCH=arm64 CROSS_COMPILE=./scripts/dummy-tools/ olddefconfig
           make -j8

--- a/.github/workflows/build-check_x86_64-rt.yml
+++ b/.github/workflows/build-check_x86_64-rt.yml
@@ -30,5 +30,5 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
           cp configs/kernel-x86_64-rt-rhel.config .config
-          make olddefconfig
+          make ARCH=x86_64 CROSS_COMPILE=./scripts/dummy-tools/ olddefconfig
           make -j8

--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -30,5 +30,5 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
           cp configs/kernel-x86_64-rhel.config .config
-          make olddefconfig
+          make ARCH=x86_64 CROSS_COMPILE=./scripts/dummy-tools/ olddefconfig
           make -j8


### PR DESCRIPTION
* github actions: build-check: Use ./scripts/dummy-tools/ for olddefconfig

LE-2788

Note: configs/kernel*.config are already in sync with dist-git