### PR TITLE
[SIG CLOUD 8] rebase custom changes to 4.18.0-553.50.1.el8_10

### DIFF
--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1041,6 +1041,10 @@ static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 
 		c->x86_virt_bits = (eax >> 8) & 0xff;
 		c->x86_phys_bits = eax & 0xff;
+
+		/* Provide a sane default if not enumerated: */
+		if (!c->x86_clflush_size)
+			c->x86_clflush_size = 32;
 	}
 
 	c->x86_cache_bits = c->x86_phys_bits;

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1020,18 +1020,9 @@ void get_cpu_cap(struct cpuinfo_x86 *c)
 static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 {
 	u32 eax, ebx, ecx, edx;
-	bool vp_bits_from_cpuid = true;
 
 	if (!cpu_has(c, X86_FEATURE_CPUID) ||
-	    (c->extended_cpuid_level < 0x80000008))
-		vp_bits_from_cpuid = false;
-
-	if (vp_bits_from_cpuid) {
-		cpuid(0x80000008, &eax, &ebx, &ecx, &edx);
-
-		c->x86_virt_bits = (eax >> 8) & 0xff;
-		c->x86_phys_bits = eax & 0xff;
-	} else {
+	    (c->extended_cpuid_level < 0x80000008)) {
 		if (IS_ENABLED(CONFIG_X86_64)) {
 			c->x86_clflush_size = 64;
 			c->x86_phys_bits = 36;
@@ -1045,7 +1036,13 @@ static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 			    cpu_has(c, X86_FEATURE_PSE36))
 				c->x86_phys_bits = 36;
 		}
+	} else {
+		cpuid(0x80000008, &eax, &ebx, &ecx, &edx);
+
+		c->x86_virt_bits = (eax >> 8) & 0xff;
+		c->x86_phys_bits = eax & 0xff;
 	}
+
 	c->x86_cache_bits = c->x86_phys_bits;
 	c->x86_cache_alignment = c->x86_clflush_size;
 }

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1020,17 +1020,32 @@ void get_cpu_cap(struct cpuinfo_x86 *c)
 static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 {
 	u32 eax, ebx, ecx, edx;
+	bool vp_bits_from_cpuid = true;
 
-	if (c->extended_cpuid_level >= 0x80000008) {
+	if (!cpu_has(c, X86_FEATURE_CPUID) ||
+	    (c->extended_cpuid_level < 0x80000008))
+		vp_bits_from_cpuid = false;
+
+	if (vp_bits_from_cpuid) {
 		cpuid(0x80000008, &eax, &ebx, &ecx, &edx);
 
 		c->x86_virt_bits = (eax >> 8) & 0xff;
 		c->x86_phys_bits = eax & 0xff;
+	} else {
+		if (IS_ENABLED(CONFIG_X86_64)) {
+			c->x86_clflush_size = 64;
+			c->x86_phys_bits = 36;
+			c->x86_virt_bits = 48;
+		} else {
+			c->x86_clflush_size = 32;
+			c->x86_virt_bits = 32;
+			c->x86_phys_bits = 32;
+
+			if (cpu_has(c, X86_FEATURE_PAE) ||
+			    cpu_has(c, X86_FEATURE_PSE36))
+				c->x86_phys_bits = 36;
+		}
 	}
-#ifdef CONFIG_X86_32
-	else if (cpu_has(c, X86_FEATURE_PAE) || cpu_has(c, X86_FEATURE_PSE36))
-		c->x86_phys_bits = 36;
-#endif
 	c->x86_cache_bits = c->x86_phys_bits;
 }
 
@@ -1468,15 +1483,6 @@ static void __init cpu_parse_early_param(void)
  */
 static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 {
-#ifdef CONFIG_X86_64
-	c->x86_clflush_size = 64;
-	c->x86_phys_bits = 36;
-	c->x86_virt_bits = 48;
-#else
-	c->x86_clflush_size = 32;
-	c->x86_phys_bits = 32;
-	c->x86_virt_bits = 32;
-#endif
 	c->x86_cache_alignment = c->x86_clflush_size;
 
 	memset(&c->x86_capability, 0, sizeof(c->x86_capability));
@@ -1488,7 +1494,6 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 		get_cpu_vendor(c);
 		get_cpu_cap(c);
 		get_model_name(c); /* RHEL8: get model name for unsupported check */
-		get_cpu_address_sizes(c);
 		setup_force_cpu_cap(X86_FEATURE_CPUID);
 		cpu_parse_early_param();
 
@@ -1504,6 +1509,8 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 		identify_cpu_without_cpuid(c);
 		setup_clear_cpu_cap(X86_FEATURE_CPUID);
 	}
+
+	get_cpu_address_sizes(c);
 
 	setup_force_cpu_cap(X86_FEATURE_ALWAYS);
 

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1494,6 +1494,7 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 		get_cpu_cap(c);
 		get_model_name(c); /* RHEL8: get model name for unsupported check */
 		setup_force_cpu_cap(X86_FEATURE_CPUID);
+		get_cpu_address_sizes(c);
 		cpu_parse_early_param();
 
 		if (this_cpu->c_early_init)
@@ -1507,9 +1508,8 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 	} else {
 		identify_cpu_without_cpuid(c);
 		setup_clear_cpu_cap(X86_FEATURE_CPUID);
+		get_cpu_address_sizes(c);
 	}
-
-	get_cpu_address_sizes(c);
 
 	setup_force_cpu_cap(X86_FEATURE_ALWAYS);
 

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1047,6 +1047,7 @@ static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 		}
 	}
 	c->x86_cache_bits = c->x86_phys_bits;
+	c->x86_cache_alignment = c->x86_clflush_size;
 }
 
 static void identify_cpu_without_cpuid(struct cpuinfo_x86 *c)
@@ -1483,8 +1484,6 @@ static void __init cpu_parse_early_param(void)
  */
 static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 {
-	c->x86_cache_alignment = c->x86_clflush_size;
-
 	memset(&c->x86_capability, 0, sizeof(c->x86_capability));
 	c->extended_cpuid_level = 0;
 


### PR DESCRIPTION
## Update process (This kernel CentOS base for `4.18.0-553`)
* Kernel History Rebuild Process for all `src.rpm`s hosted by RESF
* Create `sig-cloud-8/4.18.0-553.40.1.el8_10` branch
* Check if any maintained code is included in the new `el` release.
* Cherry-pick all code from previous branch into new branch (skipping unneeded code) 
  * Fix conflicts as they arise 
* Build and Test

## Removed Commits
None

## Rebase Results
```
[rolling release update] Rolling Product:  sig-cloud-8
[rolling release update] Checking out branch:  sig-cloud-8/4.18.0-553.47.1.el8_10
[rolling release update] Gathering all the RESF kernel Tags
b'01aef32f4a9b (tag: resf_kernel-4.18.0-553.47.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.47.1.el8_10'
b'e622eefa811c (tag: resf_kernel-4.18.0-553.46.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.46.1.el8_10'
b'f025379c5d08 (tag: resf_kernel-4.18.0-553.45.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.45.1.el8_10'
b'16dc63866351 (tag: resf_kernel-4.18.0-553.44.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.44.1.el8_10'
b'5b691f92af91 (tag: resf_kernel-4.18.0-553.42.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.42.1.el8_10'
b'0dbf87712115 (tag: resf_kernel-4.18.0-553.40.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.40.1.el8_10'
b'26d9a06a4a5f (tag: resf_kernel-4.18.0-553.37.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.37.1.el8_10'
b'4673f9b8360d (tag: resf_kernel-4.18.0-553.36.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.36.1.el8_10'
b'7e4fb1a14fcd (tag: resf_kernel-4.18.0-553.34.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.34.1.el8_10'
b'72ceaa9ab31e (tag: resf_kernel-4.18.0-553.33.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.33.1.el8_10'
b'0570eb3e10e4 (tag: resf_kernel-4.18.0-553.32.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.32.1.el8_10'
b'657b4d21132b (tag: resf_kernel-4.18.0-553.30.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.30.1.el8_10'
b'c1970aa3f569 (tag: resf_kernel-4.18.0-553.27.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.27.1.el8_10'
b'8bf75aa29fd0 (tag: resf_kernel-4.18.0-553.22.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.22.1.el8_10'
b'ea7f8a5da93b (tag: resf_kernel-4.18.0-553.16.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.16.1.el8_10'
b'2fd9e62e45de (tag: resf_kernel-4.18.0-553.8.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.8.1.el8_10'
b'a2d1b1a06ff8 (tag: resf_kernel-4.18.0-553.5.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.5.1.el8_10'
b'4533b19a3a3e (tag: resf_kernel-4.18.0-553.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.el8_10'
[rolling release update] Old Rolling Branch Tags:  [b'01aef32f4a9b', b'e622eefa811c', b'f025379c5d08', b'16dc63866351', b'5b691f92af91', b'0dbf87712115', b'26d9a06a4a5f', b'4673f9b8360d', b'7e4fb1a14fcd', b'72ceaa9ab31e', b'0570eb3e10e4', b'657b4d21132b', b'c1970aa3f569', b'8bf75aa29fd0', b'ea7f8a5da93b', b'2fd9e62e45de', b'a2d1b1a06ff8', b'4533b19a3a3e']
[rolling release update] Checking out branch:  rocky8_10
[rolling release update] Gathering all the RESF kernel Tags
b'32fa0f457b22 (HEAD -> rocky8_10, tag: resf_kernel-4.18.0-553.50.1.el8_10, origin/rocky8_10) Rebuild rocky8_10 with kernel-4.18.0-553.50.1.el8_10'
b'01aef32f4a9b (tag: resf_kernel-4.18.0-553.47.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.47.1.el8_10'
b'e622eefa811c (tag: resf_kernel-4.18.0-553.46.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.46.1.el8_10'
b'f025379c5d08 (tag: resf_kernel-4.18.0-553.45.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.45.1.el8_10'
b'16dc63866351 (tag: resf_kernel-4.18.0-553.44.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.44.1.el8_10'
b'5b691f92af91 (tag: resf_kernel-4.18.0-553.42.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.42.1.el8_10'
b'0dbf87712115 (tag: resf_kernel-4.18.0-553.40.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.40.1.el8_10'
b'26d9a06a4a5f (tag: resf_kernel-4.18.0-553.37.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.37.1.el8_10'
b'4673f9b8360d (tag: resf_kernel-4.18.0-553.36.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.36.1.el8_10'
b'7e4fb1a14fcd (tag: resf_kernel-4.18.0-553.34.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.34.1.el8_10'
b'72ceaa9ab31e (tag: resf_kernel-4.18.0-553.33.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.33.1.el8_10'
b'0570eb3e10e4 (tag: resf_kernel-4.18.0-553.32.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.32.1.el8_10'
b'657b4d21132b (tag: resf_kernel-4.18.0-553.30.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.30.1.el8_10'
b'c1970aa3f569 (tag: resf_kernel-4.18.0-553.27.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.27.1.el8_10'
b'8bf75aa29fd0 (tag: resf_kernel-4.18.0-553.22.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.22.1.el8_10'
b'ea7f8a5da93b (tag: resf_kernel-4.18.0-553.16.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.16.1.el8_10'
b'2fd9e62e45de (tag: resf_kernel-4.18.0-553.8.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.8.1.el8_10'
b'a2d1b1a06ff8 (tag: resf_kernel-4.18.0-553.5.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.5.1.el8_10'
b'4533b19a3a3e (tag: resf_kernel-4.18.0-553.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.el8_10'
[rolling release update] New Base Branch Tags:  [b'32fa0f457b22', b'01aef32f4a9b', b'e622eefa811c', b'f025379c5d08', b'16dc63866351', b'5b691f92af91', b'0dbf87712115', b'26d9a06a4a5f', b'4673f9b8360d', b'7e4fb1a14fcd', b'72ceaa9ab31e', b'0570eb3e10e4', b'657b4d21132b', b'c1970aa3f569', b'8bf75aa29fd0', b'ea7f8a5da93b', b'2fd9e62e45de', b'a2d1b1a06ff8', b'4533b19a3a3e']
[rolling release update] Latest RESF tag sha:  b'01aef32f4a9b'
"01aef32f4a9b58774afddf6d9b1f68ba7ab25b0f Rebuild rocky8_10 with kernel-4.18.0-553.47.1.el8_10"
[rolling release update] Checking out old rolling branch:  sig-cloud-8/4.18.0-553.47.1.el8_10
[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD
[rolling release update] Last RESF tag sha:  b'01aef32f4a9b'
[rolling release update] Total Commit in old branch:  5
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
{
  "47271680c8930198eeb09cced86f99feead25066": "2a38e4ca302280fdcce370ba2bee79bac16c4587",
  "6ec363e93d517189f63d5631add320e8c51b624c": "95bfb35269b2e85cff0dd2c957b2d42ebf95ae5f",
  "a4e00af5e7c88c456e556023d53bc42ffefce7a0": "9a458198eba98b7207669a166e64d04b04cb651b",
  "d5291f9759b4f99d0c9f8b5984be37e937bf4d57": "3e32552652917f10c0aa8ac75cdc8f0b8d257dec",
  "90bc95a9a1088f9c8826fef5030edce6da1463a6": "fbf6449f84bf5e4ad09f2c09ee70ed7d629b5ff6"
}
[rolling release update] Checking out new base branch:  rocky8_10
[rolling release update] Finding the kernel version for the new rolling release
b'32fa0f457b22 (HEAD -> rocky8_10, tag: resf_kernel-4.18.0-553.50.1.el8_10, origin/rocky8_10) Rebuild rocky8_10 with kernel-4.18.0-553.50.1.el8_10'
<re.Match object; span=(0, 72), match=b'32fa0f457b22 (HEAD -> rocky8_10, tag: resf_kerne>
[rolling release update} New Branch to create  sig-cloud-8/4.18.0-553.50.1.el8_10
[rolling release update] Check if branch Exists:  sig-cloud-8/4.18.0-553.50.1.el8_10
Branch sig-cloud-8/4.18.0-553.50.1.el8_10 does not exists creating
[rolling release update] Creating new branch for PR:  jmaple_sig-cloud-8/4.18.0-553.50.1.el8_10
[rolling release update] Creating Map of all new commits from last rolling release fork
[rolling release update] Total Commit in new branch:  32
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
Printing first 5 and last 5 commits
{
  "32fa0f457b229b901c1b7f0b9e1aa02591f0573e": "",
  "d6322e8e7d000bb391b0ac424efb6e760eb6af2c": "188ac720d364035008a54d249cf47b4cc100f819",
  "9b9d574008f32f1c90d03b007c4616c58c8fc520": "a3dd4d63eeb452cfb064a13862fb376ab108f6a6",
  "9e2ade340bb42ccc289c9e2595fa2c0f94a01cce": "87c4b5e8a6b65189abd9ea5010ab308941f964a4",
  "ee3a5915af417dea59457f13b2da8053f880efa0": "22118810fc7cc98f3afb38919348060ab67ddc5b"
}
{
  "8c159e0eecd2304b7565c7efddf3ba7147bf6923": "9947a06d29c0a30da88cdc6376ca5fd87083e130",
  "889aae68de859a417ad1ee472082918297b665ae": "86934198eefa10a71f35162b06c44c36d85b98ba",
  "1cd0f7c85e7abe6fbe5366390a2dde5385041f2a": "865cc3e9cc0b1d4b81c10d53174bced76decf888",
  "2eb7176035a5c1629277f1e1c0fbc9a741099b1e": "03ff3781bf6c149554d88e7b702a3abd5e400dc0",
  "a3b99786ffc2253985380822f74b11a7bc85e4c3": "ce895cf15ab60b93464ebbb515f2fc9e7a8cef9a"
}
[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch
[rolling release update] Removing commits from the new branch
[rolling release update] Applying the remaining commits to the new branch
Applying commit  "90bc95a9a1088f9c8826fef5030edce6da1463a6 x86/sev-es: Set x86_virt_bits to the correct value straight away, instead of a two-phase approach"
Applying commit  "d5291f9759b4f99d0c9f8b5984be37e937bf4d57 x86/boot: Move x86_cache_alignment initialization to correct spot"
Applying commit  "a4e00af5e7c88c456e556023d53bc42ffefce7a0 x86/cpu: Allow reducing x86_phys_bits during early_identify_cpu()"
Applying commit  "6ec363e93d517189f63d5631add320e8c51b624c x86/cpu: Get rid of an unnecessary local variable in get_cpu_address_sizes()"
Applying commit  "47271680c8930198eeb09cced86f99feead25066 x86/cpu: Provide default cache line size if not enumerated"
```

## BUILD
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" kbuild.jmaple_sig-cloud-8_4.18.0-553.50.1.el8_10.log
/mnt/code/kernel-src-tree-build
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   .config .config.old
[TIMER]{MRPROPER}: 4s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_sig-cloud-8_4.18.0-553.50.1.el8_10-6fda250e64b7"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1841s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-jmaple_sig-cloud-8_4.18.0-553.50.1.el8_10-6fda250e64b7+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-jmaple_sig-cloud-8_4.18.0-553.50.1.el8_10-6fda250e64b7+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 24s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-jmaple_sig-cloud-8_4.18.0-553.50.1.el8_10-6fda250e64b7+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 4s
[TIMER]{BUILD}: 1841s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 24s
[TIMER]{TOTAL} 1888s
Rebooting in 10 seconds
```

## Boot 
```
[maple@r8-sigcloud-builder kernel-src-tree-build]$ uname -r
4.18.0-jmaple_sig-cloud-8_4.18.0-553.50.1.el8_10-6fda250e64b7+
```

## KselfTests
```
kselftest.resf_kernel-4.18.0-553.50.1.el8_10.4.18.0-jmaple_sig-cloud-8_4.18.0-553.50.1.el8_10-6fda250e64b7+.log
206
kselftest.resf_kernel-4.18.0-553.50.1.el8_10.4.18.0-rocky8_10_rebuild-32fa0f457b22+.log
206
```