### PR TITLE
[cbr79] [container] github actions: Add build check action

### DIFF
--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -1,0 +1,38 @@
+name: x86_64 CI
+on:
+  pull_request:
+    branches:
+      - '**'
+      - '!mainline'
+
+jobs:
+  kernel-build-job:
+    runs-on:
+      labels: kernel-build
+    container:
+      image: centos:7
+      options: --cpus 8
+    steps:
+      - name: Point yum to vault
+        run: |
+          sed -e '/mirrorlist=.*/d' \
+              -e 's/#baseurl=/baseurl=/' \
+              -e "s/\$releasever/7.9.2009/g" \
+              -e "s/mirror.centos.org/dl.rockylinux.org\/vault/g" \
+              -i /etc/yum.repos.d/CentOS-Base.repo
+
+      - name: Install tools and Libraries
+        run: |
+          yum groupinstall 'Development Tools' -y
+          yum install bc dwarves git glibc-devel hostname kernel-devel mpfr openssl openssl-devel elfutils-libelf-devel -y
+
+      - name: Checkout code
+        run: |
+          git clone --branch ${{ github.head_ref }} "https://oauth2:$GITHUB_TOKEN@github.com/ctrliq/kernel-src-tree"
+
+      - name: Build the Kernel
+        working-directory: kernel-src-tree
+        run: |
+          cp configs/kernel-3.10.0-x86_64.config .config
+          make olddefconfig
+          make -j8


### PR DESCRIPTION
LE-2898

We want to build the kernel using a centos 7 userspace, so we are calling for a centos:7 container.  However we need to configure yum to pull packages from vault instead of mirror.centos.org in order to install all of the required build tools.  github's actions/checkout@v* will not work here since the packages in centos 7 are so old, so we do a simple git clone to get the code.  After that its the same configure and build steps as all of our other github action build checks.