### PR TITLE
[cbr79] [chroot] github actions: Add build check action

### DIFF
--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -1,0 +1,49 @@
+name: x86_64 CI
+on:
+  pull_request:
+    branches:
+      - '**'
+      - '!mainline'
+
+jobs:
+  kernel-build-job:
+    runs-on:
+      labels: kernel-build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.head.sha }}"
+          fetch-depth: 0
+          path: kernel-src-tree
+
+      - name: Install rinse
+        run: |
+          sudo apt-get install rinse
+
+      - name: Build centos7 chroot
+        run: |
+          sudo rinse --distribution centos-7 \
+                --mirror http://dl.rockylinux.org/vault/centos/7/os/x86_64/Packages \
+                --arch amd64 \
+                --directory centos-7-chroot
+
+      - name: Point yum to vault (in chroot)
+        run: |
+          sudo sed -e '/mirrorlist=.*/d' \
+              -e 's/#baseurl=/baseurl=/' \
+              -e "s/\$releasever/7.9.2009/g" \
+              -e "s/mirror.centos.org/dl.rockylinux.org\/vault/g" \
+              -i centos-7-chroot/etc/yum.repos.d/CentOS-Base.repo
+
+      - name: Install tools and Libraries (in chroot)
+        run: |
+          sudo chroot centos-7-chroot yum groupinstall 'Development Tools' -y
+          sudo chroot centos-7-chroot yum install bc dwarves git glibc-devel hostname kernel-devel mpfr openssl openssl-devel elfutils-libelf-devel -y
+
+      - name: Build the Kernel (in chroot)
+        run: |
+          sudo mv kernel-src-tree centos-7-chroot
+          sudo chroot centos-7-chroot sh -c "cd kernel-src-tree && cp configs/kernel-3.10.0-x86_64.config .config"
+          sudo chroot centos-7-chroot sh -c "cd kernel-src-tree && make olddefconfig"
+          sudo chroot centos-7-chroot sh -c "cd kernel-src-tree && make -j$(nproc)"


### PR DESCRIPTION
LE-2898

In order to test build the kernel using a centos 7 userspace, we use the rinse tool to create a centos 7 chroot using vault packages. We configure yum to pull packages from vault as well and download the required build tools.  Then we do the same configure and build steps as our other github build checks, except they are run inside the chroot.