### PR TITLE
[LTS 8.6] arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array

### DIFF
--- a/arch/arm64/kernel/cacheinfo.c
+++ b/arch/arm64/kernel/cacheinfo.c
@@ -94,16 +94,18 @@ static int __populate_cache_leaves(unsigned int cpu)
 	unsigned int level, idx;
 	enum cache_type type;
 	struct cpu_cacheinfo *this_cpu_ci = get_cpu_cacheinfo(cpu);
-	struct cacheinfo *this_leaf = this_cpu_ci->info_list;
+	struct cacheinfo *infos = this_cpu_ci->info_list;
 
 	for (idx = 0, level = 1; level <= this_cpu_ci->num_levels &&
-	     idx < this_cpu_ci->num_leaves; idx++, level++) {
+	     idx < this_cpu_ci->num_leaves; level++) {
 		type = get_cache_type(level);
 		if (type == CACHE_TYPE_SEPARATE) {
-			ci_leaf_init(this_leaf++, CACHE_TYPE_DATA, level);
-			ci_leaf_init(this_leaf++, CACHE_TYPE_INST, level);
+			if (idx + 1 >= this_cpu_ci->num_leaves)
+				break;
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_DATA, level);
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_INST, level);
 		} else {
-			ci_leaf_init(this_leaf++, type, level);
+			ci_leaf_init(&infos[idx++], type, level);
 		}
 	}
 	return 0;


### PR DESCRIPTION
[LTS 8.6]
CVE-2025-21785
VULN-54125


# Problem

<https://www.cve.org/CVERecord?id=CVE-2025-21785>
> In the Linux kernel, the following vulnerability has been resolved: arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array The loop that detects/populates cache information already has a bounds check on the array size but does not account for cache levels with separate data/instructions cache. Fix this by incrementing the index for any populated leaf (instead of any populated level).


# Solution

The official fix in the mainline kernel is provided in the 875d742cf5327c93cba1f11e12b08d3cce7a88d2 commit

    arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array
    
    The loop that detects/populates cache information already has a bounds
    check on the array size but does not account for cache levels with
    separate data/instructions cache. Fix this by incrementing the index
    for any populated leaf (instead of any populated level).


# kABI check: passed

    DESCR_TARGET=1 DEBUG=1 CVE=CVE-2025-21785 ./ninja.sh -d explain _kabi_checked__aarch64--test--ciqlts8_6-CVE-2025-21785

    …
    [2/3] 	Check ABI of kernel [ciqlts8_6-CVE-2025-21785]	_kabi_checked__aarch64--test--ciqlts8_6-CVE-2025-21785
    ++ uname -m
    + python3 /home/pvts/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /home/pvts/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_aarch64 -s vms/aarch64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2025-21785/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2025-21785/aarch64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/19900176/boot-test.log>)


# Kselftests


## Methodology

The tests were run using the [rocky-patching](https://gitlab.conclusive.pl/devices/rocky-patching) framework (qemu-kvm virtualization of Rocky base cloud aarch64 images) ported to the local [WHLE-LS1046A](https://conclusive.tech/products/whle-ls1-sbc/) machine, based on the [NXP Layerscape LS1046A](https://www.nxp.com/products/LS1046A) arm64 processor.

The selftests were source-compiled from the recent `ciqlts8_6` branch (commit 00366e25fab0eaec1a251fc27443fa37a95c00a4).


## Coverage

`breakpoints` (except `breakpoint_test_arm64`), `capabilities`, `core`, `cpu-hotplug`, `cpufreq`, `efivarfs`, `exec`, `filesystems`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `net`, `net/forwarding` (except `sch_ets.sh`), `net/mptcp`, `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `proc` (except `setns-dcache`), `pstore`, `ptrace`, `rtc`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `sysctl`, `tc-testing`, `timens`, `timers`, `tpm2`, `user`, `vm`, `zram`


## Reference

[kselftests&#x2013;mix&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/19899649/kselftests--mix--ciqlts8_6--run1.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/19899648/kselftests--mix--ciqlts8_6--run2.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_6&#x2013;run3.log](<https://github.com/user-attachments/files/19899647/kselftests--mix--ciqlts8_6--run3.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_6&#x2013;run4.log](<https://github.com/user-attachments/files/19899646/kselftests--mix--ciqlts8_6--run4.log>)


## Patch

[kselftests&#x2013;mix&#x2013;ciqlts8\_6-CVE-2025-21785&#x2013;run1.log](<https://github.com/user-attachments/files/19899645/kselftests--mix--ciqlts8_6-CVE-2025-21785--run1.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_6-CVE-2025-21785&#x2013;run2.log](<https://github.com/user-attachments/files/19899643/kselftests--mix--ciqlts8_6-CVE-2025-21785--run2.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_6-CVE-2025-21785&#x2013;run3.log](<https://github.com/user-attachments/files/19899642/kselftests--mix--ciqlts8_6-CVE-2025-21785--run3.log>)


## Comparison

    ktests.xsh diff  --where 'Summary = "diff"'  kselftests*.log

    Column    File
    --------  ---------------------------------------------------
    Status0   kselftests--mix--ciqlts8_6--run1.log
    Status1   kselftests--mix--ciqlts8_6--run2.log
    Status2   kselftests--mix--ciqlts8_6--run3.log
    Status3   kselftests--mix--ciqlts8_6--run4.log
    Status4   kselftests--mix--ciqlts8_6-CVE-2025-21785--run1.log
    Status5   kselftests--mix--ciqlts8_6-CVE-2025-21785--run2.log
    Status6   kselftests--mix--ciqlts8_6-CVE-2025-21785--run3.log
    
    TestCase                Status0  Status1  Status2  Status3  Status4  Status5  Status6  Summary
    filesystems:devpts_pts  skip     skip     skip     pass     skip     skip     skip     diff
    net:gro.sh              pass     pass     pass     pass     pass     fail     pass     diff
    net:ip_defrag.sh        pass     pass     fail     fail     fail     pass     pass     diff
    net:udpgso_bench.sh     skip     skip     skip     skip     fail     skip     skip     diff

The differences between runs are contained within the reference version for `net:ip_defrag.sh` and `filesystems:devpts_pts`. The spills into the patched version for `net:udpgso_bench.sh` and `net:gro.sh` are discussed below.


## Differences highlights


### `filesystems:devpts_pts`

The `filesystems:devpts_pts` test requires interactive terminal and only one test run was conducted inside one.

    ktests.xsh show_groups kselftests*.log --test filesystems:devpts_pts

    kselftests--mix--ciqlts8_6--run1.log:
    kselftests--mix--ciqlts8_6--run2.log:
    kselftests--mix--ciqlts8_6--run3.log:
    kselftests--mix--ciqlts8_6-CVE-2025-21785--run1.log:
    kselftests--mix--ciqlts8_6-CVE-2025-21785--run2.log:
    kselftests--mix--ciqlts8_6-CVE-2025-21785--run3.log:
    filesystems:devpts_pts:
    # Standard input file descriptor is not attached to a terminal. Skipping test
    ok 1 selftests: filesystems: devpts_pts # SKIP
    
    kselftests--mix--ciqlts8_6--run4.log:
    filesystems:devpts_pts:
    # Failed to perform TIOCGPTPEER ioctl
    ok 1 selftests: filesystems: devpts_pts


### `net:gro.sh`

The `net:gro.sh` test reported inconsistent results multiple times in the past, for all versions. It will be removed from the future test runs.

    ktests.xsh show kselftests--mix--ciqlts8_6-CVE-2025-21785--run2.log --test net:gro.sh

    …
    # running test ipv6 large
    # Expected {65475 899 }, Total 2 packets
    # Received {65475 899 }, Total 2 packets.
    # Expected {64576 900 900 }, Total 3 packets
    # Received {64576 ./gro: could not receive: Network is down
    # Cannot open network namespace "server_ns": No such file or directory
    # Cannot open network namespace "client_ns": No such file or directory
    # Cannot open network namespace "server_ns": No such file or directory
    # Cannot open network namespace "client_ns": No such file or directory
    #
    not ok 1 selftests: net: gro.sh # TIMEOUT 300 seconds

    ktests.xsh show kselftests--mix--ciqlts8_6-CVE-2025-21785--run1.log --test net:gro.sh

    …
    # running test ipv6 large
    # Expected {65475 899 }, Total 2 packets
    # Received {65475 899 }, Total 2 packets.
    # Expected {64576 900 900 }, Total 3 packets
    # Received {64576 900 900 }, Total 3 packets.
    # All Tests Succeeded!
    ok 1 selftests: net: gro.sh


### `net:ip_defrag.sh`

The test both passed and failed in both the reference and patched kernel, as it did many times in the past. It's unclear at the moment what's the failure's culprit.

    ktests.xsh show_groups kselftests--mix--ciqlts8_6--run{2,3}.log --test net:ip_defrag.sh

    kselftests--mix--ciqlts8_6--run2.log:
    net:ip_defrag.sh:
    # ipv4 defrag
    # PASS
    # seed = 1745430105
    # ipv4 defrag with overlaps
    # PASS
    # seed = 1745430106
    # ipv6 defrag
    # PASS
    # seed = 1745430112
    # ipv6 defrag with overlaps
    # PASS
    # seed = 1745430112
    # ipv6 nf_conntrack defrag
    # PASS
    # seed = 1745430120
    # ipv6 nf_conntrack defrag with overlaps
    # PASS
    # seed = 1745430120
    # all tests done
    ok 1 selftests: net: ip_defrag.sh
    
    kselftests--mix--ciqlts8_6--run3.log:
    net:ip_defrag.sh:
    # ipv4 defrag
    # PASS
    # seed = 1745436206
    # ipv4 defrag with overlaps
    # PASS
    # seed = 1745436206
    # ipv6 defrag
    # PASS
    # seed = 1745436212
    # ipv6 defrag with overlaps
    # PASS
    # seed = 1745436213
    # ipv6 nf_conntrack defrag
    # seed = 1745436218
    # ./ip_defrag: recv: payload_len = 8087 max_frag_len = 8: Resource temporarily unavailable
    not ok 1 selftests: net: ip_defrag.sh # exit=1


### `net:udpgso_bench.sh`

The benchmark test failed in one of the patch tests because of the "Connection refused" error. This doesn't seem to be related to the introduced change in any way.

    ktests.xsh show kselftests--mix--ciqlts8_6-CVE-2025-21785--run1.log --test net:udpgso_bench.sh

    …
    # ./udpgso_bench_tx: sendmsg: Connection refused
    …
    # SO_ZEROCOPY not supportedudpgso_bench.sh: PASS=11 SKIP=6 FAIL=1
    # udpgso_bench.sh: FAIL
    not ok 1 selftests: net: udpgso_bench.sh # exit=1

Note that the other runs aren't entirely skipped, only the 6 subtests.

    ktests.xsh show kselftests--mix--ciqlts8_6-CVE-2025-21785--run3.log --test net:udpgso_bench.sh

    …
    # SO_ZEROCOPY not supportedudpgso_bench.sh: PASS=12 SKIP=6 FAIL=0
    # udpgso_bench.sh: SKIP
    ok 1 selftests: net: udpgso_bench.sh # SKIP

The skipped parts are related to the `SO_ZEROCOPY`

    …
    # udp gso zerocopy
    # SO_ZEROCOPY not supportedudp gso timestamp
    …


# Specific tests: skipped

To be done on demand

