### PR TITLE
[LTS 8.6] nvme-tcp: fix potential memory corruption in nvme_tcp_recv_pdu()

### DIFF
--- a/drivers/nvme/host/tcp.c
+++ b/drivers/nvme/host/tcp.c
@@ -150,6 +150,18 @@ static inline int nvme_tcp_queue_id(struct nvme_tcp_queue *queue)
 	return queue - queue->ctrl->queues;
 }
 
+static inline bool nvme_tcp_recv_pdu_supported(enum nvme_tcp_pdu_type type)
+{
+	switch (type) {
+	case nvme_tcp_c2h_data:
+	case nvme_tcp_r2t:
+	case nvme_tcp_rsp:
+		return true;
+	default:
+		return false;
+	}
+}
+
 static inline struct blk_mq_tags *nvme_tcp_tagset(struct nvme_tcp_queue *queue)
 {
 	u32 queue_idx = nvme_tcp_queue_id(queue);
@@ -663,6 +675,16 @@ static int nvme_tcp_recv_pdu(struct nvme_tcp_queue *queue, struct sk_buff *skb,
 		return 0;
 
 	hdr = queue->pdu;
+	if (unlikely(hdr->hlen != sizeof(struct nvme_tcp_rsp_pdu))) {
+		if (!nvme_tcp_recv_pdu_supported(hdr->type))
+			goto unsupported_pdu;
+
+		dev_err(queue->ctrl->ctrl.device,
+			"pdu type %d has unexpected header length (%d)\n",
+			hdr->type, hdr->hlen);
+		return -EPROTO;
+	}
+
 	if (queue->hdr_digest) {
 		ret = nvme_tcp_verify_hdgst(queue, queue->pdu, hdr->hlen);
 		if (unlikely(ret))
@@ -686,10 +708,13 @@ static int nvme_tcp_recv_pdu(struct nvme_tcp_queue *queue, struct sk_buff *skb,
 		nvme_tcp_init_recv_ctx(queue);
 		return nvme_tcp_handle_r2t(queue, (void *)queue->pdu);
 	default:
-		dev_err(queue->ctrl->ctrl.device,
-			"unsupported pdu type (%d)\n", hdr->type);
-		return -EINVAL;
+		goto unsupported_pdu;
 	}
+
+unsupported_pdu:
+	dev_err(queue->ctrl->ctrl.device,
+		"unsupported pdu type (%d)\n", hdr->type);
+	return -EINVAL;
 }
 
 static inline void nvme_tcp_end_request(struct request *rq, u16 status)


### PR DESCRIPTION
[LTS 8.6]
CVE-2025-21927
VULN-56023


# Problem

<https://www.cve.org/CVERecord?id=CVE-2025-21927>
> In the Linux kernel, the following vulnerability has been resolved: nvme-tcp: fix potential memory corruption in nvme\_tcp\_recv\_pdu() nvme\_tcp\_recv\_pdu() doesn't check the validity of the header length. When header digests are enabled, a target might send a packet with an invalid header length (e.g. 255), causing nvme\_tcp\_verify\_hdgst() to access memory outside the allocated area and cause memory corruptions by overwriting it with the calculated digest. Fix this by rejecting packets with an unexpected header length.


# Analysis and Solution (same as for [ciqlts8\_8](https://github.com/ctrliq/kernel-src-tree/pull/234))


## Context

NVME (Non-Volatile Memory Express) is a communication protocol designed for accessing high-speed storage media, particularly solid-state drives (SSDs). NVMe over Fabrics (NVMe-oF) is an extension of the NVMe protocol that allows NVMe commands to be sent over a network fabric, enabling remote access to NVMe storage devices. 

The "target" mentioned in CVE description is the host providing access to the local NVME device (the server). The host importing the remote NVME device is called simply a "host", or "initiator" (the client). The module implementing NVMe-oF on target's side is `nvmet-tcp`, on the initiator's side it's `nvme-tcp` - the subject of this patch.


## Applicability

All the key options related to NVMe-oF, specifically `CONFIG_NVME_TCP` enabling the `nvme-tcp` module, are enabled in `ciqlts8_6`. Per `.config` file created from `configs/kernel-x86_64.config`:

    #
    # NVME Support
    #
    CONFIG_NVME_CORE=m
    CONFIG_BLK_DEV_NVME=m
    CONFIG_NVME_MULTIPATH=y
    # CONFIG_NVME_HWMON is not set
    CONFIG_NVME_FABRICS=m
    CONFIG_NVME_RDMA=m
    CONFIG_NVME_FC=m
    CONFIG_NVME_TCP=m
    CONFIG_NVME_TARGET=m
    # CONFIG_NVME_TARGET_PASSTHRU is not set
    CONFIG_NVME_TARGET_LOOP=m
    CONFIG_NVME_TARGET_RDMA=m
    CONFIG_NVME_TARGET_FC=m
    CONFIG_NVME_TARGET_FCLOOP=m
    CONFIG_NVME_TARGET_TCP=m


## Solution

The solution in the mainline kernel is provided in the ad95bab0cd28ed77c2c0d0b6e76e03e031391064 commit. It was not backported to any stable kernel older than 6.12.

Naive cherry-picking results in conflicts with git's attempt to introduce additional functions (`nvme_tcp_tls_configured`, `nvme_tcp_queue_tls`) and code branches (`nvme_tcp_c2h_term` packet type check in the `nvme_tcp_recv_pdu` function) introduced in more recent versions of the module but not related to the bug fix.

A small change was made to the `nvme_tcp_recv_pdu_supported` function introduced in the official fix ad95bab0cd28ed77c2c0d0b6e76e03e031391064 for the sake of `nvme_tcp_recv_pdu`'s behavior consistency between the scenarios of receiving a packet with a proper and an improper header - the removal of the `nvme_tcp_c2h_term` case.

Consider the behavior cases in case a packet with a proper header was received:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">&#xa0;</th>
<th scope="col" class="org-left">Packet type:</th>
<th scope="col" class="org-left">X ∈ {c2h&#95;term}</th>
<th scope="col" class="org-left">X ∈ {c2h&#95;data, rsp, r2t}</th>
<th scope="col" class="org-left">X ∉ {c2h&#95;term, c2h&#95;data, rsp, r2t}</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">a</td>
<td class="org-left">Mainline, after patch (ad95bab0)</td>
<td class="org-left">nvme&#95;tcp&#95;handle&#95;X</td>
<td class="org-left">nvme&#95;tcp&#95;handle&#95;X</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>


<tr>
<td class="org-left">b</td>
<td class="org-left">ciqlts8&#95;6, after patch, c2h&#95;term included</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
<td class="org-left">nvme&#95;tcp&#95;handle&#95;X</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>


<tr>
<td class="org-left">c</td>
<td class="org-left">ciqlts8&#95;6, after patch, c2h&#95;term excluded</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
<td class="org-left">nvme&#95;tcp&#95;handle&#95;X</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>
</tbody>
</table>

Then in case a packet with an improper header was received:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">&#xa0;</th>
<th scope="col" class="org-left">Packet type:</th>
<th scope="col" class="org-left">X ∈ {c2h&#95;term}</th>
<th scope="col" class="org-left">X ∈ {c2h&#95;data, rsp, r2t}</th>
<th scope="col" class="org-left">X ∉ {c2h&#95;term, c2h&#95;data, rsp, r2t}</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">x</td>
<td class="org-left">Mainline, after patch (ad95bab0)</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>


<tr>
<td class="org-left">y</td>
<td class="org-left">ciqlts8&#95;6, after patch, c2h&#95;term included</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>


<tr>
<td class="org-left">z</td>
<td class="org-left">ciqlts8&#95;6, after patch, c2h&#95;term excluded</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>
</tbody>
</table>

Solution `a` is to `x` *not* as `b` is to `y`, but as `c` is to `z`, thus the `c`, `z` pair was chosen.


# kABI check: passed

    DEBUG=1 RELAXED_DEPS=1 CVE=CVE-2025-21927 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_6-CVE-2025-21927

    [0/1] Check ABI of kernel [ciqlts8_6-CVE-2025-21927]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2025-21927/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2025-21927/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/19969645/boot-test.log>)


# Kselftests


## Methodology

The selftests were source-compiled from the recent `ciqlts8_6` branch (commit 00366e25fab0eaec1a251fc27443fa37a95c00a4).

The tests were run using an explicit list which omitted certain tests known to give inconsistent results. Details in the [src/run-kselftests.sh](https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/9eefc3f7cd8823dd28ab8e0eddd6978649492c8f/src/run-kselftests.sh) script of the `rocky-patching` project.


## Coverage

`android`, `bpf` (except `test_kmod.sh`, `test_progs`, `test_progs-no_alu32`, `test_sockmap`, `test_xsk.sh`), `breakpoints`, `capabilities`, `core`, `cpu-hotplug`, `cpufreq`, `efivarfs`, `exec`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kexec`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `net` (except `gro.sh`, `ip_defrag.sh`, `reuseaddr_conflict`, `txtimestamp.sh`, `udpgso_bench.sh`), `net/forwarding` (except `ipip_hier_gre_keys.sh`, `sch_ets.sh`, `sch_tbf_ets.sh`, `sch_tbf_prio.sh`, `sch_tbf_root.sh`, `tc_actions.sh`), `net/mptcp`, `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `proc`, `pstore`, `ptrace`, `rseq`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `sysctl`, `tc-testing`, `timens`, `timers` (except `raw_skew`), `tpm2`, `user`, `vm`, `x86`, `zram`.


## Reference

The results are provided in two parts, because the first batch run was ending prematurely and missing around 1/3 of tests.

[kselftests&#x2013;ciqlts8\_6&#x2013;part1&#x2013;run1.log](<https://github.com/user-attachments/files/19969644/kselftests--ciqlts8_6--part1--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;part1&#x2013;run2.log](<https://github.com/user-attachments/files/19969643/kselftests--ciqlts8_6--part1--run2.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;part1&#x2013;run3.log](<https://github.com/user-attachments/files/19969642/kselftests--ciqlts8_6--part1--run3.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;part2&#x2013;run1.log](<https://github.com/user-attachments/files/19969641/kselftests--ciqlts8_6--part2--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;part2&#x2013;run2.log](<https://github.com/user-attachments/files/19969640/kselftests--ciqlts8_6--part2--run2.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;part2&#x2013;run3.log](<https://github.com/user-attachments/files/19969639/kselftests--ciqlts8_6--part2--run3.log>)


## Patch

The results are provided in two parts, because the first batch run was ending prematurely and missing around 1/3 of tests.

[kselftests&#x2013;ciqlts8\_6-CVE-2025-21927&#x2013;part1&#x2013;run1.log](<https://github.com/user-attachments/files/19969638/kselftests--ciqlts8_6-CVE-2025-21927--part1--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2025-21927&#x2013;part2&#x2013;run1.log](<https://github.com/user-attachments/files/19969637/kselftests--ciqlts8_6-CVE-2025-21927--part2--run1.log>)


## Comparison

The results are the same in the reference and patched kernel.

    ./ktests.xsh diff -d  kselftests*.log

    Column    File
    --------  -----------------------------------------------------
    Status0   kselftests--ciqlts8_6--part1--run1.log
    Status1   kselftests--ciqlts8_6--part1--run2.log
    Status2   kselftests--ciqlts8_6--part1--run3.log
    Status3   kselftests--ciqlts8_6--part2--run1.log
    Status4   kselftests--ciqlts8_6--part2--run2.log
    Status5   kselftests--ciqlts8_6--part2--run3.log
    Status6   kselftests--ciqlts8_6-CVE-2025-21927--part1--run1.log
    Status7   kselftests--ciqlts8_6-CVE-2025-21927--part2--run1.log


# Specific tests: suspended

See the situation for <https://github.com/ctrliq/kernel-src-tree/pull/234>.

