### PR TITLE
Kselftests wiki update

### DIFF
--- a/kselftests/README.rst
+++ b/kselftests/README.rst
@@ -342,7 +342,7 @@ Printing the list of all available tests
 
 .. code:: shell
 
-   for col in $(make --print-data-base -C tools/testing/selftests --dry-run clean \
+   for col in $(make --print-data-base -C tools/testing/selftests SKIP_TARGETS= --dry-run clean \
                     | grep '^TARGETS :\?=' \
                     | sed -e 's/.*:\?=//g'); do
        make --silent COLLECTION=${col} -C tools/testing/selftests/${col} emit_tests
@@ -356,6 +356,10 @@ Explanation:
    ``--print-data-base``
       Prints the value of ``TARGETS`` variable (among many other
       information)
+   ``SKIP_TARGETS=``
+      Demands explicitly to **not** remove any positions from the
+      ``TARGETS`` variable (yes, the Makefile may decide for the user to
+      skip some targets, eg. ``bpf`` on ``ciqlts9_2``)
    ``clean``
       Any valid target will do, ``clean`` just takes least time.
    ``--dry-run``

--- a/kselftests/net/forwarding/README.rst
+++ b/kselftests/net/forwarding/README.rst
@@ -1,0 +1,22 @@
+Requirements
+============
+
+#. The tests require ``jq`` and ``mausezahn`` tools to run (packages
+   ``jq`` and ``netsniff-ng`` on RHEL)
+
+#. The file ``tools/testing/selftests/net/forwarding/forwarding.config``
+   must be created in kernel's source dir for the tests not to crash.
+   The
+   ``tools/testing/selftests/net/forwarding/forwarding.config.sample``
+   is provided in the repo as a prototype to start with. No need to
+   deviate from it though to have a working configuration - just copying
+   ``forwarding.config.sample`` to ``forwarding.config`` should be
+   enough to have functional ``net/forwarding`` tests collection.
+
+Problems
+========
+
+The tests ``sch_ets.sh``, ``sch_red.sh``, ``sch_tbf_ets.sh``,
+``sch_tbf_prio.sh``, ``sch_tbf_root.sh`` can hang the machine for more
+than 10 minutes. Whether it's expected or dyfunctional was not
+established yet. In either case this hinders efficient testing.


### PR DESCRIPTION
-   Brief basics for running tests from the `net/forwarding` collection.
-   Added note about the exception of how `kvm` organizes its tests - the testing binaries aren't contained directly in the collection's directory, which confuses the `run_kselftest.sh` script.
-   Fixed a bug in the test names listing snippet - without explicitly setting `SKIP_TARGETS` to nothing some collections may be omitted by the makefile.

