### PR TITLE
[LTS 9.2] nvme-tcp: fix potential memory corruption in nvme_tcp_recv_pdu()

### DIFF
--- a/drivers/nvme/host/tcp.c
+++ b/drivers/nvme/host/tcp.c
@@ -189,6 +189,18 @@ static inline int nvme_tcp_queue_id(struct nvme_tcp_queue *queue)
 	return queue - queue->ctrl->queues;
 }
 
+static inline bool nvme_tcp_recv_pdu_supported(enum nvme_tcp_pdu_type type)
+{
+	switch (type) {
+	case nvme_tcp_c2h_data:
+	case nvme_tcp_r2t:
+	case nvme_tcp_rsp:
+		return true;
+	default:
+		return false;
+	}
+}
+
 static inline struct blk_mq_tags *nvme_tcp_tagset(struct nvme_tcp_queue *queue)
 {
 	u32 queue_idx = nvme_tcp_queue_id(queue);
@@ -716,6 +728,16 @@ static int nvme_tcp_recv_pdu(struct nvme_tcp_queue *queue, struct sk_buff *skb,
 		return 0;
 
 	hdr = queue->pdu;
+	if (unlikely(hdr->hlen != sizeof(struct nvme_tcp_rsp_pdu))) {
+		if (!nvme_tcp_recv_pdu_supported(hdr->type))
+			goto unsupported_pdu;
+
+		dev_err(queue->ctrl->ctrl.device,
+			"pdu type %d has unexpected header length (%d)\n",
+			hdr->type, hdr->hlen);
+		return -EPROTO;
+	}
+
 	if (queue->hdr_digest) {
 		ret = nvme_tcp_verify_hdgst(queue, queue->pdu, hdr->hlen);
 		if (unlikely(ret))
@@ -739,10 +761,13 @@ static int nvme_tcp_recv_pdu(struct nvme_tcp_queue *queue, struct sk_buff *skb,
 		nvme_tcp_init_recv_ctx(queue);
 		return nvme_tcp_handle_r2t(queue, (void *)queue->pdu);
 	default:
-		dev_err(queue->ctrl->ctrl.device,
-			"unsupported pdu type (%d)\n", hdr->type);
-		return -EINVAL;
+		goto unsupported_pdu;
 	}
+
+unsupported_pdu:
+	dev_err(queue->ctrl->ctrl.device,
+		"unsupported pdu type (%d)\n", hdr->type);
+	return -EINVAL;
 }
 
 static inline void nvme_tcp_end_request(struct request *rq, u16 status)


### PR DESCRIPTION
[LTS 9.2]
CVE-2025-21927
VULN-56028


# Problem

<https://www.cve.org/CVERecord?id=CVE-2025-21927>
> In the Linux kernel, the following vulnerability has been resolved: nvme-tcp: fix potential memory corruption in nvme\_tcp\_recv\_pdu() nvme\_tcp\_recv\_pdu() doesn't check the validity of the header length. When header digests are enabled, a target might send a packet with an invalid header length (e.g. 255), causing nvme\_tcp\_verify\_hdgst() to access memory outside the allocated area and cause memory corruptions by overwriting it with the calculated digest. Fix this by rejecting packets with an unexpected header length.


# Analysis and Solution (same as for [ciqlts8\_8](https://github.com/ctrliq/kernel-src-tree/pull/234))


## Context

NVME (Non-Volatile Memory Express) is a communication protocol designed for accessing high-speed storage media, particularly solid-state drives (SSDs). NVMe over Fabrics (NVMe-oF) is an extension of the NVMe protocol that allows NVMe commands to be sent over a network fabric, enabling remote access to NVMe storage devices. 

The "target" mentioned in CVE description is the host providing access to the local NVME device (the server). The host importing the remote NVME device is called simply a "host", or "initiator" (the client). The module implementing NVMe-oF on target's side is `nvmet-tcp`, on the initiator's side it's `nvme-tcp` - the subject of this patch.


## Applicability

All the key options related to NVMe-oF, specifically `CONFIG_NVME_TCP` enabling the `nvme-tcp` module, are enabled in `ciqlts9_2`. Per `.config` file created from `configs/kernel-x86_64-rhel.config`:

    #
    # NVME Support
    #
    CONFIG_NVME_COMMON=m
    CONFIG_NVME_CORE=m
    CONFIG_BLK_DEV_NVME=m
    CONFIG_NVME_MULTIPATH=y
    CONFIG_NVME_VERBOSE_ERRORS=y
    # CONFIG_NVME_HWMON is not set
    CONFIG_NVME_FABRICS=m
    CONFIG_NVME_RDMA=m
    CONFIG_NVME_FC=m
    CONFIG_NVME_TCP=m
    CONFIG_NVME_AUTH=y
    CONFIG_NVME_TARGET=m
    # CONFIG_NVME_TARGET_PASSTHRU is not set
    CONFIG_NVME_TARGET_LOOP=m
    CONFIG_NVME_TARGET_RDMA=m
    CONFIG_NVME_TARGET_FC=m
    CONFIG_NVME_TARGET_FCLOOP=m
    CONFIG_NVME_TARGET_TCP=m
    CONFIG_NVME_TARGET_AUTH=y
    # end of NVME Support


## Solution

The solution in the mainline kernel is provided in the ad95bab0cd28ed77c2c0d0b6e76e03e031391064 commit. It was not backported to any stable kernel older than 6.12.

Naive cherry-picking results in conflicts with git's attempt to introduce additional functions (`nvme_tcp_tls_configured`, `nvme_tcp_queue_tls`) and code branches (`nvme_tcp_c2h_term` packet type check in the `nvme_tcp_recv_pdu` function) introduced in more recent versions of the module but not related to the bug fix.

A small change was made to the `nvme_tcp_recv_pdu_supported` function introduced in the official fix ad95bab0cd28ed77c2c0d0b6e76e03e031391064 for the sake of `nvme_tcp_recv_pdu`'s behavior consistency between the scenarios of receiving a packet with a proper and an improper header - the removal of the `nvme_tcp_c2h_term` case.

Consider the behavior cases in case a packet with a proper header was received:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">&#xa0;</th>
<th scope="col" class="org-left">Packet type:</th>
<th scope="col" class="org-left">X ∈ {c2h&#95;term}</th>
<th scope="col" class="org-left">X ∈ {c2h&#95;data, rsp, r2t}</th>
<th scope="col" class="org-left">X ∉ {c2h&#95;term, c2h&#95;data, rsp, r2t}</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">a</td>
<td class="org-left">Mainline, after patch (ad95bab0)</td>
<td class="org-left">nvme&#95;tcp&#95;handle&#95;X</td>
<td class="org-left">nvme&#95;tcp&#95;handle&#95;X</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>


<tr>
<td class="org-left">b</td>
<td class="org-left">ciqlts9&#95;2, after patch, c2h&#95;term included</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
<td class="org-left">nvme&#95;tcp&#95;handle&#95;X</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>


<tr>
<td class="org-left">c</td>
<td class="org-left">ciqlts9&#95;2, after patch, c2h&#95;term excluded</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
<td class="org-left">nvme&#95;tcp&#95;handle&#95;X</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>
</tbody>
</table>

Then in case a packet with an improper header was received:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">&#xa0;</th>
<th scope="col" class="org-left">Packet type:</th>
<th scope="col" class="org-left">X ∈ {c2h&#95;term}</th>
<th scope="col" class="org-left">X ∈ {c2h&#95;data, rsp, r2t}</th>
<th scope="col" class="org-left">X ∉ {c2h&#95;term, c2h&#95;data, rsp, r2t}</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">x</td>
<td class="org-left">Mainline, after patch (ad95bab0)</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>


<tr>
<td class="org-left">y</td>
<td class="org-left">ciqlts9&#95;2, after patch, c2h&#95;term included</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>


<tr>
<td class="org-left">z</td>
<td class="org-left">ciqlts9&#95;2, after patch, c2h&#95;term excluded</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
<td class="org-left">"pdu type %d has unexpected header length", -EPROTO</td>
<td class="org-left">"unsupported pdu type …", -EINVAL</td>
</tr>
</tbody>
</table>

Solution `a` is to `x` *not* as `b` is to `y`, but as `c` is to `z`, thus the `c`, `z` pair was chosen.


# kABI check: passed

    DEBUG=1 RELAXED_DEPS=1 CVE=CVE-2025-21927 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_2-CVE-2025-21927

    [0/1] Check ABI of kernel [ciqlts9_2-CVE-2025-21927]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2025-21927/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2025-21927/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/19985376/boot-test.log>)


# Kselftests: passed relative


## Methodology

The selftests were source-compiled from the recent `ciqlts9_2` branch (commit f10433c95a305ab221118ac99f6012147916feb5). The `bpf` suite was run from the `kernel-selftests-internal` package.

The tests were run using an explicit list which omitted certain tests known to give inconsistent results. Details in the [src/run-kselftests.sh](https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/9eefc3f7cd8823dd28ab8e0eddd6978649492c8f/src/run-kselftests.sh) script of the `rocky-patching` project.


## Coverage

`bpf` (except `test_kmod.sh`, `test_progs`, `test_progs-no_alu32`, `test_sockmap`), `breakpoints`, `capabilities`, `cgroup` (except `test_memcontrol`), `clone3`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding`, `drivers/net/team`, `efivarfs`, `filesystems/binderfs`, `filesystems/epoll`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `ir`, `kcmp`, `kexec`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net` (except `reuseaddr_conflict`, `udpgso_bench.sh`), `net/forwarding` (except `sch_ets.sh`, `sch_red.sh`, `sch_tbf_ets.sh`, `sch_tbf_prio.sh`, `sch_tbf_root.sh`, `tc_police.sh`), `net/mptcp`, `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `openat2`, `pid_namespace`, `pidfd`, `proc` (except `proc-pid-vm`), `pstore`, `ptrace`, `rlimits`, `rseq`, `rtc`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `syscall_user_dispatch`, `sysctl`, `tc-testing`, `tdx`, `timens`, `timers` (except `raw_skew`), `tmpfs`, `tpm2`, `user`, `vDSO`, `vm`, `x86`, `zram`

The coverage for the patch test was a bit narrowed to get rid of inconsequntial results.


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/19985375/kselftests--ciqlts9_2--run1.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/19985374/kselftests--ciqlts9_2--run2.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run3.log](<https://github.com/user-attachments/files/19985373/kselftests--ciqlts9_2--run3.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run4.log](<https://github.com/user-attachments/files/19985372/kselftests--ciqlts9_2--run4.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-2025-21927&#x2013;run1.log](<https://github.com/user-attachments/files/19985371/kselftests--ciqlts9_2-CVE-2025-21927--run1.log>)


## Comparison

    ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2--run2.log
    Status2   kselftests--ciqlts9_2--run3.log
    Status3   kselftests--ciqlts9_2--run4.log
    Status4   kselftests--ciqlts9_2-CVE-2025-21927--run1.log
    
    TestCase                             Status0  Status1  Status2  Status3  Status4  Summary
    net/forwarding:dual_vxlan_bridge.sh  fail     pass     fail     fail              diff
    net:txtimestamp.sh                   pass     pass     fail     pass              diff
    rtc:rtctest                          fail     pass     pass     fail              diff

All differences are contained within the reference kernel. The test run for the patched kernel was done in a different batch, with the tests observed to be nondeterministic removed, including those which showed different results for the `ciqlts9_2` reference batch, thus the blank fields in the `Status4` column.


# Specific tests: suspended

See the situation for <https://github.com/ctrliq/kernel-src-tree/pull/234>.

