### PR TITLE
[FIPS 9.2 Compliant] CVEs: CVE-2023-4623, CVE-2025-21785

### DIFF
--- a/arch/arm64/kernel/cacheinfo.c
+++ b/arch/arm64/kernel/cacheinfo.c
@@ -87,16 +87,18 @@ int populate_cache_leaves(unsigned int cpu)
 	unsigned int level, idx;
 	enum cache_type type;
 	struct cpu_cacheinfo *this_cpu_ci = get_cpu_cacheinfo(cpu);
-	struct cacheinfo *this_leaf = this_cpu_ci->info_list;
+	struct cacheinfo *infos = this_cpu_ci->info_list;
 
 	for (idx = 0, level = 1; level <= this_cpu_ci->num_levels &&
-	     idx < this_cpu_ci->num_leaves; idx++, level++) {
+	     idx < this_cpu_ci->num_leaves; level++) {
 		type = get_cache_type(level);
 		if (type == CACHE_TYPE_SEPARATE) {
-			ci_leaf_init(this_leaf++, CACHE_TYPE_DATA, level);
-			ci_leaf_init(this_leaf++, CACHE_TYPE_INST, level);
+			if (idx + 1 >= this_cpu_ci->num_leaves)
+				break;
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_DATA, level);
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_INST, level);
 		} else {
-			ci_leaf_init(this_leaf++, type, level);
+			ci_leaf_init(&infos[idx++], type, level);
 		}
 	}
 	return 0;

--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -1012,6 +1012,10 @@ hfsc_change_class(struct Qdisc *sch, u32 classid, u32 parentid,
 		if (parent == NULL)
 			return -ENOENT;
 	}
+	if (!(parent->cl_flags & HFSC_FSC) && parent != &q->root) {
+		NL_SET_ERR_MSG(extack, "Invalid parent - parent class must have FSC");
+		return -EINVAL;
+	}
 
 	if (classid == 0 || TC_H_MAJ(classid ^ sch->handle) != 0)
 		return -EINVAL;


### PR DESCRIPTION
Based off previous CVEs on standard CIQ LTS kernel:
* CVE-2023-4623 - https://github.com/ctrliq/kernel-src-tree/pull/139
* CVE-2025-21785 - https://github.com/ctrliq/kernel-src-tree/pull/219
The above PR Commits and the commits in this PR are all Clean CherryPicks

## BUILD
```
$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" kbuild.{jmaple}_fips-9-compliant_5.14.0-284.30.1.log
/mnt/code/kernel-src-tree-build
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
--
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  BTF [M] sound/virtio/virtio_snd.ko
  BTF [M] sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1305s
Making Modules
  INSTALL /lib/modules/5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  STRIP   /lib/modules/5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+
[TIMER]{MODULES}: 9s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 24s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+ and Index to 1
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1305s
[TIMER]{MODULES}: 9s
[TIMER]{INSTALL}: 24s
[TIMER]{TOTAL} 1343s
Rebooting in 10 seconds
```

## Kernel SelfTests
Change in Kselftests, I'm no longer using the RPM but the last one was with the RPM.
```
 ls kernel_5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-9165dab32241+_iteration_2.log kselftest.5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+.log | while read line ; do echo $line; grep '^ok ' $line | wc -l ; done
kernel_5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-9165dab32241+_iteration_2.log
205
kselftest.5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-1766fca34c70+.log
314
```