### PR TITLE
[cbr79] Multiple Xen VULNS

### DIFF
--- a/drivers/block/xen-blkfront.c
+++ b/drivers/block/xen-blkfront.c
@@ -201,7 +201,7 @@ static int fill_grant_buffer(struct blkfront_info *info, int num)
 			goto out_of_memory;
 
 		if (info->feature_persistent) {
-			granted_page = alloc_page(GFP_NOIO);
+			granted_page = alloc_page(GFP_NOIO | __GFP_ZERO);
 			if (!granted_page) {
 				kfree(gnt_list_entry);
 				goto out_of_memory;
@@ -1707,7 +1707,8 @@ static int blkfront_setup_indirect(struct blkfront_info *info)
 
 		BUG_ON(!list_empty(&info->indirect_pages));
 		for (i = 0; i < num; i++) {
-			struct page *indirect_page = alloc_page(GFP_NOIO);
+			struct page *indirect_page = alloc_page(GFP_NOIO |
+								__GFP_ZERO);
 			if (!indirect_page)
 				goto out_of_memory;
 			list_add(&indirect_page->lru, &info->indirect_pages);

--- a/drivers/net/xen-netfront.c
+++ b/drivers/net/xen-netfront.c
@@ -266,7 +266,7 @@ static struct sk_buff *xennet_alloc_one_rx_buffer(struct netfront_queue *queue)
 	if (unlikely(!skb))
 		return NULL;
 
-	page = alloc_page(GFP_ATOMIC | __GFP_NOWARN);
+	page = alloc_page(GFP_ATOMIC | __GFP_NOWARN | __GFP_ZERO);
 	if (!page) {
 		kfree_skb(skb);
 		return NULL;

--- a/drivers/xen/xenbus/xenbus_xs.c
+++ b/drivers/xen/xenbus/xenbus_xs.c
@@ -526,6 +526,21 @@ int xenbus_scanf(struct xenbus_transaction t,
 }
 EXPORT_SYMBOL_GPL(xenbus_scanf);
 
+/* Read an (optional) unsigned value. */
+unsigned int xenbus_read_unsigned(const char *dir, const char *node,
+				  unsigned int default_val)
+{
+	unsigned int val;
+	int ret;
+
+	ret = xenbus_scanf(XBT_NIL, dir, node, "%u", &val);
+	if (ret <= 0)
+		val = default_val;
+
+	return val;
+}
+EXPORT_SYMBOL_GPL(xenbus_read_unsigned);
+
 /* Single printf and write: returns -errno or 0. */
 int xenbus_printf(struct xenbus_transaction t,
 		  const char *dir, const char *node, const char *fmt, ...)

--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -1030,6 +1030,7 @@ static inline struct sk_buff *alloc_skb_head(gfp_t priority)
 struct sk_buff *skb_morph(struct sk_buff *dst, struct sk_buff *src);
 int skb_copy_ubufs(struct sk_buff *skb, gfp_t gfp_mask);
 struct sk_buff *skb_clone(struct sk_buff *skb, gfp_t priority);
+void skb_copy_header(struct sk_buff *new, const struct sk_buff *old);
 struct sk_buff *skb_copy(const struct sk_buff *skb, gfp_t priority);
 struct sk_buff *__pskb_copy(struct sk_buff *skb, int headroom, gfp_t gfp_mask);
 

--- a/include/xen/xenbus.h
+++ b/include/xen/xenbus.h
@@ -144,6 +144,10 @@ __scanf(4, 5)
 int xenbus_scanf(struct xenbus_transaction t,
 		 const char *dir, const char *node, const char *fmt, ...);
 
+/* Read an (optional) unsigned value. */
+unsigned int xenbus_read_unsigned(const char *dir, const char *node,
+				  unsigned int default_val);
+
 /* Single printf and write: returns -errno or 0. */
 __printf(4, 5)
 int xenbus_printf(struct xenbus_transaction t,

--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -1115,7 +1115,7 @@ static void skb_headers_offset_update(struct sk_buff *skb, int off)
 	skb->inner_mac_header += off;
 }
 
-static void copy_skb_header(struct sk_buff *new, const struct sk_buff *old)
+void skb_copy_header(struct sk_buff *new, const struct sk_buff *old)
 {
 	__copy_skb_header(new, old);
 
@@ -1123,6 +1123,7 @@ static void copy_skb_header(struct sk_buff *new, const struct sk_buff *old)
 	skb_shinfo(new)->gso_segs = skb_shinfo(old)->gso_segs;
 	skb_shinfo(new)->gso_type = skb_shinfo(old)->gso_type;
 }
+EXPORT_SYMBOL(skb_copy_header);
 
 static inline int skb_alloc_rx_flag(const struct sk_buff *skb)
 {
@@ -1166,7 +1167,7 @@ struct sk_buff *skb_copy(const struct sk_buff *skb, gfp_t gfp_mask)
 	if (skb_copy_bits(skb, -headerlen, n->head, headerlen + skb->len))
 		BUG();
 
-	copy_skb_header(n, skb);
+	skb_copy_header(n, skb);
 	return n;
 }
 EXPORT_SYMBOL(skb_copy);
@@ -1225,7 +1226,7 @@ struct sk_buff *__pskb_copy(struct sk_buff *skb, int headroom, gfp_t gfp_mask)
 		skb_clone_fraglist(n);
 	}
 
-	copy_skb_header(n, skb);
+	skb_copy_header(n, skb);
 out:
 	return n;
 }
@@ -1396,7 +1397,7 @@ struct sk_buff *skb_copy_expand(const struct sk_buff *skb,
 			  skb->len + head_copy_len))
 		BUG();
 
-	copy_skb_header(n, skb);
+	skb_copy_header(n, skb);
 
 	skb_headers_offset_update(n, newheadroom - oldheadroom);
 


### PR DESCRIPTION
This is four CVE fixes all dealing with Xen and somewhat related, so I've batched them up into a single PR.  It ended up being six commits because I picked up two prereq commits to make the backporting for VULN-1439 and VULN-1039 cleaner.  Both of the prereqs are adding helper functions used by the CVE fixes.

All four of the backported CVE fixes have upstream diffs.  The first two were simple.  The other two were a bit more involved so definitely give them a good look.  There are no Xen selftests in 3.10 and I'm not very familiar with it, so if you think there is any specific testing we can do please let me know.

### VULNs
VULN-1437
VULN-1438
VULN-1439
VULN-1039

### CVEs
CVE-2022-26365
CVE-2022-33740
CVE-2022-33741
CVE-2022-33742

### Build log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqcbr7_9_xen-vulns-4944724"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  SHIPPED scripts/kconfig/zconf.hash.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf --silentoldconfig Kconfig
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_32.h

[SNIP]

  INSTALL /lib/firmware/kaweth/trigger_code.bin
  INSTALL /lib/firmware/kaweth/new_code.bin
  INSTALL /lib/firmware/kaweth/new_code_fix.bin
  INSTALL /lib/firmware/ti_3410.fw
  INSTALL /lib/firmware/kaweth/trigger_code_fix.bin
  INSTALL /lib/firmware/ti_5052.fw
  INSTALL /lib/firmware/mts_cdma.fw
  INSTALL /lib/firmware/mts_gsm.fw
  INSTALL /lib/firmware/mts_edge.fw
  INSTALL /lib/firmware/edgeport/boot.fw
  INSTALL /lib/firmware/edgeport/down.fw
  INSTALL /lib/firmware/edgeport/boot2.fw
  INSTALL /lib/firmware/edgeport/down2.fw
  INSTALL /lib/firmware/edgeport/down3.bin
  INSTALL /lib/firmware/whiteheat_loader.fw
  INSTALL /lib/firmware/whiteheat.fw
  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-bmastbergen_ciqcbr7_9_xen-vulns-4944724+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 3.10.0-bmastbergen_ciqcbr7_9_xen-vulns-4944724+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 45s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-bmastbergen_ciqcbr7_9_xen-vulns-4944724+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 503s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 45s
[TIMER]{TOTAL} 568s
Rebooting in 10 seconds

```

### Testing

The very limited number of selftests were run before and after the CVE fixes were applied

[selftest-3.10.0-1160.119.1.el7_9.ciqcbr.3.1.x86_64.log](https://github.com/user-attachments/files/20017385/selftest-3.10.0-1160.119.1.el7_9.ciqcbr.3.1.x86_64.log)

[selftest-3.10.0-bmastbergen_ciqcbr7_9_xen-vulns-4944724+.log](https://github.com/user-attachments/files/20017388/selftest-3.10.0-bmastbergen_ciqcbr7_9_xen-vulns-4944724%2B.log)

```
brett@lycia ~/ciq/xen-vulns % grep ^ok selftest-3.10.0-1160.119.1.el7_9.ciqcbr.3.1.x86_64.log | wc -l
2
brett@lycia ~/ciq/xen-vulns % grep ^ok selftest-3.10.0-bmastbergen_ciqcbr7_9_xen-vulns-4944724+.log | wc -l
2
brett@lycia ~/ciq/xen-vulns %

```