### PR TITLE
[fips-9] vsock fixes for CVE-2025-21756

### DIFF
--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -329,7 +329,10 @@ EXPORT_SYMBOL_GPL(vsock_find_connected_socket);
 
 void vsock_remove_sock(struct vsock_sock *vsk)
 {
-	vsock_remove_bound(vsk);
+	/* Transport reassignment must not remove the binding. */
+	if (sock_flag(sk_vsock(vsk), SOCK_DEAD))
+		vsock_remove_bound(vsk);
+
 	vsock_remove_connected(vsk);
 }
 EXPORT_SYMBOL_GPL(vsock_remove_sock);
@@ -806,12 +809,13 @@ static void __vsock_release(struct sock *sk, int level)
 		 */
 		lock_sock_nested(sk, level);
 
+		sock_orphan(sk);
+
 		if (vsk->transport)
 			vsk->transport->release(vsk);
 		else if (sock_type_connectible(sk->sk_type))
 			vsock_remove_sock(vsk);
 
-		sock_orphan(sk);
 		sk->sk_shutdown = SHUTDOWN_MASK;
 
 		skb_queue_purge(&sk->sk_receive_queue);

--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -809,13 +809,19 @@ static void __vsock_release(struct sock *sk, int level)
 		 */
 		lock_sock_nested(sk, level);
 
-		sock_orphan(sk);
+		/* Indicate to vsock_remove_sock() that the socket is being released and
+		 * can be removed from the bound_table. Unlike transport reassignment
+		 * case, where the socket must remain bound despite vsock_remove_sock()
+		 * being called from the transport release() callback.
+		 */
+		sock_set_flag(sk, SOCK_DEAD);
 
 		if (vsk->transport)
 			vsk->transport->release(vsk);
 		else if (sock_type_connectible(sk->sk_type))
 			vsock_remove_sock(vsk);
 
+		sock_orphan(sk);
 		sk->sk_shutdown = SHUTDOWN_MASK;
 
 		skb_queue_purge(&sk->sk_receive_queue);


### PR DESCRIPTION
VULN-53610
CVE-2025-21756

This ended up being two commits: The initial fix and a fix for that fix.

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h

[SNIP]

  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/usb/misc/snd-ua101.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/usb/snd-usb-audio.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/usb/snd-usbmidi-lib.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  DEPMOD  /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+
[TIMER]{MODULES}: 10s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 45s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1506s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 45s
[TIMER]{TOTAL} 1577s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the changes

[selftests-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log](https://github.com/user-attachments/files/20040746/selftests-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log)

[selftests-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+.log](https://github.com/user-attachments/files/20040750/selftests-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e%2B.log)

```
brett@lycia ~/ciq/vuln-53610 % grep ^ok selftests-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log | wc -l
309
brett@lycia ~/ciq/vuln-53610 % grep ^ok selftests-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-53610-e910f8fffb5e+.log | wc -l
309
brett@lycia ~/ciq/vuln-53610 %

```