### PR TITLE
[lts-94] vsock fixes for CVE-2025-21756

### DIFF
--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -334,7 +334,10 @@ EXPORT_SYMBOL_GPL(vsock_find_connected_socket);
 
 void vsock_remove_sock(struct vsock_sock *vsk)
 {
-	vsock_remove_bound(vsk);
+	/* Transport reassignment must not remove the binding. */
+	if (sock_flag(sk_vsock(vsk), SOCK_DEAD))
+		vsock_remove_bound(vsk);
+
 	vsock_remove_connected(vsk);
 }
 EXPORT_SYMBOL_GPL(vsock_remove_sock);
@@ -811,12 +814,13 @@ static void __vsock_release(struct sock *sk, int level)
 		 */
 		lock_sock_nested(sk, level);
 
+		sock_orphan(sk);
+
 		if (vsk->transport)
 			vsk->transport->release(vsk);
 		else if (sock_type_connectible(sk->sk_type))
 			vsock_remove_sock(vsk);
 
-		sock_orphan(sk);
 		sk->sk_shutdown = SHUTDOWN_MASK;
 
 		skb_queue_purge(&sk->sk_receive_queue);

--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -814,13 +814,19 @@ static void __vsock_release(struct sock *sk, int level)
 		 */
 		lock_sock_nested(sk, level);
 
-		sock_orphan(sk);
+		/* Indicate to vsock_remove_sock() that the socket is being released and
+		 * can be removed from the bound_table. Unlike transport reassignment
+		 * case, where the socket must remain bound despite vsock_remove_sock()
+		 * being called from the transport release() callback.
+		 */
+		sock_set_flag(sk, SOCK_DEAD);
 
 		if (vsk->transport)
 			vsk->transport->release(vsk);
 		else if (sock_type_connectible(sk->sk_type))
 			vsock_remove_sock(vsk);
 
+		sock_orphan(sk);
 		sk->sk_shutdown = SHUTDOWN_MASK;
 
 		skb_queue_purge(&sk->sk_receive_queue);


### PR DESCRIPTION
VULN-53609
CVE-2025-21756

This ended up being two commits: The initial fix and a fix for that fix.

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h

[SNIP]

  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/usb/snd-usbmidi-lib.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/usb/misc/snd-ua101.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/usb/snd-usbmidi-lib.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+/kernel/sound/virtio/virtio_snd.ko
  DEPMOD  /lib/modules/5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+
[TIMER]{MODULES}: 8s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 64s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1721s
[TIMER]{MODULES}: 8s
[TIMER]{INSTALL}: 64s
[TIMER]{TOTAL} 1810s
Rebooting in 10 seconds

```

### Testing

kselfests were run before and after applying the fixes

[selftests-5.14.0-427.42.1.el9_4.94ciq_lts.2.1.x86_64.log](https://github.com/user-attachments/files/20041094/selftests-5.14.0-427.42.1.el9_4.94ciq_lts.2.1.x86_64.log)

[selftests-5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+.log](https://github.com/user-attachments/files/20041097/selftests-5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc%2B.log)

```
brett@lycia ~/ciq/vuln-53609 % grep ^ok selftests-5.14.0-427.42.1.el9_4.94ciq_lts.2.1.x86_64.log | wc -l
308
brett@lycia ~/ciq/vuln-53609 % grep ^ok selftests-5.14.0-bmastbergen_ciqlts9_4_VULN-53609-9547bbd702bc+.log | wc -l
349
brett@lycia ~/ciq/vuln-53609 %

```
