### PR TITLE
[fips-8] vsock fixes for CVE-2025-21756

### DIFF
--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -792,13 +792,19 @@ static void __vsock_release(struct sock *sk, int level)
 		 */
 		lock_sock_nested(sk, level);
 
-		sock_orphan(sk);
+		/* Indicate to vsock_remove_sock() that the socket is being released and
+		 * can be removed from the bound_table. Unlike transport reassignment
+		 * case, where the socket must remain bound despite vsock_remove_sock()
+		 * being called from the transport release() callback.
+		 */
+		sock_set_flag(sk, SOCK_DEAD);
 
 		if (vsk->transport)
 			vsk->transport->release(vsk);
 		else if (sk->sk_type == SOCK_STREAM)
 			vsock_remove_sock(vsk);
 
+		sock_orphan(sk);
 		sk->sk_shutdown = SHUTDOWN_MASK;
 
 		skb_queue_purge(&sk->sk_receive_queue);

--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -328,7 +328,10 @@ EXPORT_SYMBOL_GPL(vsock_find_connected_socket);
 
 void vsock_remove_sock(struct vsock_sock *vsk)
 {
-	vsock_remove_bound(vsk);
+	/* Transport reassignment must not remove the binding. */
+	if (sock_flag(sk_vsock(vsk), SOCK_DEAD))
+		vsock_remove_bound(vsk);
+
 	vsock_remove_connected(vsk);
 }
 EXPORT_SYMBOL_GPL(vsock_remove_sock);
@@ -789,12 +792,13 @@ static void __vsock_release(struct sock *sk, int level)
 		 */
 		lock_sock_nested(sk, level);
 
+		sock_orphan(sk);
+
 		if (vsk->transport)
 			vsk->transport->release(vsk);
 		else if (sk->sk_type == SOCK_STREAM)
 			vsock_remove_sock(vsk);
 
-		sock_orphan(sk);
 		sk->sk_shutdown = SHUTDOWN_MASK;
 
 		skb_queue_purge(&sk->sk_receive_queue);


### PR DESCRIPTION
VULN-53606
CVE-2025-21756

This ended up being two commits: The initial fix and a fix for that fix.

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-8-c_4.18.0-553.16.1_VULN-53606-231158bd8156"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  UPD     include/config/kernel.release
  UPD     include/generated/uapi/linux/version.h
  UPD     include/generated/utsrelease.h
  DESCEND objtool
  DESCEND bpf/resolve_btfids
  MKDIR     /home/brett/kernel-src-tree/tools/bpf/resolve_btfids//libbpf
  MKDIR     /home/brett/kernel-src-tree/tools/bpf/resolve_btfids//libsubcmd
  HOSTCC  /home/brett/kernel-src-tree/tools/objtool/fixdep.o
  HOSTCC  /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/fixdep.o
  GEN     /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h
  HOSTLD  /home/brett/kernel-src-tree/tools/objtool/fixdep-in.o

[SNIP]

  INSTALL sound/usb/6fire/snd-usb-6fire.ko
  INSTALL sound/usb/caiaq/snd-usb-caiaq.ko
  INSTALL sound/usb/bcd2000/snd-bcd2000.ko
  INSTALL sound/usb/hiface/snd-usb-hiface.ko
  INSTALL sound/usb/line6/snd-usb-line6.ko
  INSTALL sound/usb/line6/snd-usb-pod.ko
  INSTALL sound/usb/line6/snd-usb-podhd.ko
  INSTALL sound/usb/line6/snd-usb-toneport.ko
  INSTALL sound/usb/line6/snd-usb-variax.ko
  INSTALL sound/usb/misc/snd-ua101.ko
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-53606-231158bd8156+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-53606-231158bd8156+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 91s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-53606-231158bd8156+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1661s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 91s
[TIMER]{TOTAL} 1780s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the fixes

[selftests-4.18.0-553.16.1.el8_6.ciqfips.0.7.1.x86_64.log](https://github.com/user-attachments/files/20067454/selftests-4.18.0-553.16.1.el8_6.ciqfips.0.7.1.x86_64.log)
[selftests-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-53606-231158bd8156+.log](https://github.com/user-attachments/files/20067455/selftests-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-53606-231158bd8156%2B.log)

```
brett@lycia ~/ciq/vuln-53606 % grep ^ok selftests-4.18.0-553.16.1.el8_6.ciqfips.0.7.1.x86_64.log | wc -l
231
brett@lycia ~/ciq/vuln-53606 % grep ^ok selftests-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-53606-231158bd8156+.log | wc -l
234
brett@lycia ~/ciq/vuln-53606 %

```