### PR TITLE
[LTS 8.8] arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array

### DIFF
--- a/arch/arm64/kernel/cacheinfo.c
+++ b/arch/arm64/kernel/cacheinfo.c
@@ -98,16 +98,18 @@ static int __populate_cache_leaves(unsigned int cpu)
 	unsigned int level, idx;
 	enum cache_type type;
 	struct cpu_cacheinfo *this_cpu_ci = get_cpu_cacheinfo(cpu);
-	struct cacheinfo *this_leaf = this_cpu_ci->info_list;
+	struct cacheinfo *infos = this_cpu_ci->info_list;
 
 	for (idx = 0, level = 1; level <= this_cpu_ci->num_levels &&
-	     idx < this_cpu_ci->num_leaves; idx++, level++) {
+	     idx < this_cpu_ci->num_leaves; level++) {
 		type = get_cache_type(level);
 		if (type == CACHE_TYPE_SEPARATE) {
-			ci_leaf_init(this_leaf++, CACHE_TYPE_DATA, level);
-			ci_leaf_init(this_leaf++, CACHE_TYPE_INST, level);
+			if (idx + 1 >= this_cpu_ci->num_leaves)
+				break;
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_DATA, level);
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_INST, level);
 		} else {
-			ci_leaf_init(this_leaf++, type, level);
+			ci_leaf_init(&infos[idx++], type, level);
 		}
 	}
 	return 0;


### PR DESCRIPTION
[LTS 8.8]
CVE-2025-21785
VULN-54126


# Problem

<https://www.cve.org/CVERecord?id=CVE-2025-21785>
> In the Linux kernel, the following vulnerability has been resolved: arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array The loop that detects/populates cache information already has a bounds check on the array size but does not account for cache levels with separate data/instructions cache. Fix this by incrementing the index for any populated leaf (instead of any populated level).


# Solution

The official fix in the mainline kernel is provided in the 875d742cf5327c93cba1f11e12b08d3cce7a88d2 commit

    arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array
    
    The loop that detects/populates cache information already has a bounds
    check on the array size but does not account for cache levels with
    separate data/instructions cache. Fix this by incrementing the index
    for any populated leaf (instead of any populated level).


# kABI check: passed

    DEBUG=1 RELAXED_DEPS=1 CVE=CVE-2025-21785 ./ninja.sh _kabi_checked__aarch64--test--ciqlts8_8-CVE-2025-21785

    [0/1] Check ABI of kernel [ciqlts8_8-CVE-2025-21785]
    ++ uname -m
    + python3 /home/pvts/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/check-kabi -k /home/pvts/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/Module.kabi_aarch64 -s vms/aarch64--build--ciqlts8_8/build_files/kernel-src-tree-ciqlts8_8-CVE-2025-21785/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_8-CVE-2025-21785/aarch64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20091765/boot-test.log>)


# Kselftests: passed relative


## Methodology

The tests were run using the [rocky-patching](https://gitlab.conclusive.pl/devices/rocky-patching) framework (qemu-kvm virtualization of Rocky base cloud aarch64 images) ported to the local [WHLE-LS1046A](https://conclusive.tech/products/whle-ls1-sbc/) machine, based on the [NXP Layerscape LS1046A](https://www.nxp.com/products/LS1046A) arm64 processor.

The selftests were source-compiled from the recent `ciqlts8_8` branch (commit f10433c95a305ab221118ac99f6012147916feb5).

The tests were run using an explicit list of tests to run which omitted certain tests known to give inconsistent results. Details in <https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/master/src/run-kselftests.sh?ref_type=heads>


## Coverage

`android`, `bpf` (except `test_progs`, `test_progs-no_alu32`, `test_xsk.sh`, `test_kmod.sh`, `test_sockmap`), `breakpoints`, `capabilities`, `cgroup`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/net/bonding`, `drivers/net/team`, `efivarfs`, `exec`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `mqueue`, `net/forwarding` (except `sch_tbf_ets.sh`, `sch_ets.sh`, `sch_tbf_prio.sh`, `ipip_hier_gre_keys.sh`, `sch_tbf_root.sh`, `tc_actions.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `gro.sh`, `xfrm_policy.sh`, `ip_defrag.sh`, `reuseport_addr_any.sh`, `txtimestamp.sh`, `reuseaddr_conflict`, `udpgso_bench.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `proc`, `pstore`, `ptrace`, `rseq` (except `basic_test`, `basic_percpu_ops_test`, `param_test_compare_twice`, `param_test_benchmark`, `param_test`), `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `sysctl`, `tc-testing`, `tdx`, `timens`, `timers` (except `raw_skew`), `tpm2`, `user`, `vm`, `zram`.


## Reference

[kselftests&#x2013;mix&#x2013;ciqlts8\_8&#x2013;run1.log](<https://github.com/user-attachments/files/20091763/kselftests--mix--ciqlts8_8--run1.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_8&#x2013;run2.log](<https://github.com/user-attachments/files/20091762/kselftests--mix--ciqlts8_8--run2.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_8&#x2013;run3.log](<https://github.com/user-attachments/files/20091760/kselftests--mix--ciqlts8_8--run3.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_8&#x2013;run4.log](<https://github.com/user-attachments/files/20091759/kselftests--mix--ciqlts8_8--run4.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_8&#x2013;run5.log](<https://github.com/user-attachments/files/20091758/kselftests--mix--ciqlts8_8--run5.log>)


## Patch

[kselftests&#x2013;mix&#x2013;ciqlts8\_8-CVE-2025-21785&#x2013;run1.log](<https://github.com/user-attachments/files/20091757/kselftests--mix--ciqlts8_8-CVE-2025-21785--run1.log>)
[kselftests&#x2013;mix&#x2013;ciqlts8\_8-CVE-2025-21785&#x2013;run2.log](<https://github.com/user-attachments/files/20091756/kselftests--mix--ciqlts8_8-CVE-2025-21785--run2.log>)


## Comparison

All test results are the same.

    ktests.xsh diff -d kselftests-*.log

    Column    File
    --------  ---------------------------------------------------
    Status0   kselftests--mix--ciqlts8_8--run1.log
    Status1   kselftests--mix--ciqlts8_8--run2.log
    Status2   kselftests--mix--ciqlts8_8--run3.log
    Status3   kselftests--mix--ciqlts8_8--run4.log
    Status4   kselftests--mix--ciqlts8_8--run5.log
    Status5   kselftests--mix--ciqlts8_8-CVE-2025-21785--run1.log
    Status6   kselftests--mix--ciqlts8_8-CVE-2025-21785--run2.log


# Specific tests: skipped

To be done on demand

