### PR TITLE
[fips9.2] nvme-tcp: fix potential memory corruption in nvme_tcp_recv_pdu()

### DIFF
--- a/drivers/nvme/host/tcp.c
+++ b/drivers/nvme/host/tcp.c
@@ -189,6 +189,18 @@ static inline int nvme_tcp_queue_id(struct nvme_tcp_queue *queue)
 	return queue - queue->ctrl->queues;
 }
 
+static inline bool nvme_tcp_recv_pdu_supported(enum nvme_tcp_pdu_type type)
+{
+	switch (type) {
+	case nvme_tcp_c2h_data:
+	case nvme_tcp_r2t:
+	case nvme_tcp_rsp:
+		return true;
+	default:
+		return false;
+	}
+}
+
 static inline struct blk_mq_tags *nvme_tcp_tagset(struct nvme_tcp_queue *queue)
 {
 	u32 queue_idx = nvme_tcp_queue_id(queue);
@@ -716,6 +728,16 @@ static int nvme_tcp_recv_pdu(struct nvme_tcp_queue *queue, struct sk_buff *skb,
 		return 0;
 
 	hdr = queue->pdu;
+	if (unlikely(hdr->hlen != sizeof(struct nvme_tcp_rsp_pdu))) {
+		if (!nvme_tcp_recv_pdu_supported(hdr->type))
+			goto unsupported_pdu;
+
+		dev_err(queue->ctrl->ctrl.device,
+			"pdu type %d has unexpected header length (%d)\n",
+			hdr->type, hdr->hlen);
+		return -EPROTO;
+	}
+
 	if (queue->hdr_digest) {
 		ret = nvme_tcp_verify_hdgst(queue, queue->pdu, hdr->hlen);
 		if (unlikely(ret))
@@ -739,10 +761,13 @@ static int nvme_tcp_recv_pdu(struct nvme_tcp_queue *queue, struct sk_buff *skb,
 		nvme_tcp_init_recv_ctx(queue);
 		return nvme_tcp_handle_r2t(queue, (void *)queue->pdu);
 	default:
-		dev_err(queue->ctrl->ctrl.device,
-			"unsupported pdu type (%d)\n", hdr->type);
-		return -EINVAL;
+		goto unsupported_pdu;
 	}
+
+unsupported_pdu:
+	dev_err(queue->ctrl->ctrl.device,
+		"unsupported pdu type (%d)\n", hdr->type);
+	return -EINVAL;
 }
 
 static inline void nvme_tcp_end_request(struct request *rq, u16 status)


### PR DESCRIPTION
jira VULN-56030
cve CVE-2025-21927

```
commit-author Maurizio Lombardi <mlombard@redhat.com> commit ad95bab0cd28ed77c2c0d0b6e76e03e031391064
upstream-diff Removed `nvme_tcp_c2h_term' case from
              `nvme_tcp_recv_pdu_supported' for the sake of consistency of
              `nvme_tcp_recv_pdu''s behavior relative to the upstream
              version, between the cases of proper and improper
              header. (What could be considered as "`c2h_term' type support"
              started with 84e009042d0f3dfe91bec60bcd208ee3f866cbcd commit,
              not included in `ciqlts9_2''s history, so
              `nvme_tcp_recv_pdu_supported' in `ciqlts9_2' shouldn't report
              the `nvme_tcp_c2h_term' type as supported.)

nvme_tcp_recv_pdu() doesn't check the validity of the header length. When header digests are enabled, a target might send a packet with an invalid header length (e.g. 255), causing nvme_tcp_verify_hdgst() to access memory outside the allocated area and cause memory corruptions by overwriting it with the calculated digest.

Fix this by rejecting packets with an unexpected header length.

Fixes: 3f2304f8c6d6 ("nvme-tcp: add NVMe over TCP host driver")
	Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>
	Reviewed-by: Sagi Grimberg <sagi@grimberg.me>
	Signed-off-by: Keith Busch <kbusch@kernel.org>
(cherry picked from commit ad95bab0cd28ed77c2c0d0b6e76e03e031391064)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

Same as https://github.com/ctrliq/kernel-src-tree/pull/238

### Build log

```
/home/brett/kernel-src-tree
  CLEAN   arch/x86/tools
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old
[TIMER]{MRPROPER}: 12s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h

[SNIP]

  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/misc/snd-ua101.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/snd-usbmidi-lib.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/snd-usb-audio.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/snd-usbmidi-lib.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+
[TIMER]{MODULES}: 7s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 60s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 12s
[TIMER]{BUILD}: 920s
[TIMER]{MODULES}: 7s
[TIMER]{INSTALL}: 60s
[TIMER]{TOTAL} 1019s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after adding the fix

[selfests-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log](https://github.com/user-attachments/files/20171053/selfests-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log)

[selfests-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+.log](https://github.com/user-attachments/files/20171079/selfests-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630%2B.log)

```
brett@lycia ~/ciq/vuln-56030 % grep ^ok selfests-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log | wc -l
308
brett@lycia ~/ciq/vuln-56030 % grep ^ok selfests-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-56030-aee3a9524630+.log | wc -l
310
brett@lycia ~/ciq/vuln-56030 %

```