### PR TITLE
[LTS 9.4] arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array

### DIFF
--- a/arch/arm64/kernel/cacheinfo.c
+++ b/arch/arm64/kernel/cacheinfo.c
@@ -101,16 +101,18 @@ int populate_cache_leaves(unsigned int cpu)
 	unsigned int level, idx;
 	enum cache_type type;
 	struct cpu_cacheinfo *this_cpu_ci = get_cpu_cacheinfo(cpu);
-	struct cacheinfo *this_leaf = this_cpu_ci->info_list;
+	struct cacheinfo *infos = this_cpu_ci->info_list;
 
 	for (idx = 0, level = 1; level <= this_cpu_ci->num_levels &&
-	     idx < this_cpu_ci->num_leaves; idx++, level++) {
+	     idx < this_cpu_ci->num_leaves; level++) {
 		type = get_cache_type(level);
 		if (type == CACHE_TYPE_SEPARATE) {
-			ci_leaf_init(this_leaf++, CACHE_TYPE_DATA, level);
-			ci_leaf_init(this_leaf++, CACHE_TYPE_INST, level);
+			if (idx + 1 >= this_cpu_ci->num_leaves)
+				break;
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_DATA, level);
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_INST, level);
 		} else {
-			ci_leaf_init(this_leaf++, type, level);
+			ci_leaf_init(&infos[idx++], type, level);
 		}
 	}
 	return 0;


### PR DESCRIPTION
[LTS 9.4]
CVE-2025-21785
VULN-54131


# Problem

<https://www.cve.org/CVERecord?id=CVE-2025-21785>
> In the Linux kernel, the following vulnerability has been resolved: arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array The loop that detects/populates cache information already has a bounds check on the array size but does not account for cache levels with separate data/instructions cache. Fix this by incrementing the index for any populated leaf (instead of any populated level).


# Solution

The official fix in the mainline kernel is provided in the 875d742cf5327c93cba1f11e12b08d3cce7a88d2 commit

    arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array
    
    The loop that detects/populates cache information already has a bounds
    check on the array size but does not account for cache levels with
    separate data/instructions cache. Fix this by incrementing the index
    for any populated leaf (instead of any populated level).

The 5.15 backport (closest to `ciqlts9_4` kernel version 5.14) is provided in the [88a3e6afaf002250220793df99404977d343db14](https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=88a3e6afaf002250220793df99404977d343db14) commit, and it has no differences compared to the mainline solution.


# kABI check: passed

    DEBUG=1 CVE=CVE-2025-21785 ./ninja.sh _kabi_checked__aarch64--test--ciqlts9_4-CVE-2025-21785

    ninja: Entering directory `/data/build/rocky-patching'
    [0/1] Check ABI of kernel [ciqlts9_4-CVE-2025-21785]
    ++ uname -m
    + python3 /home/pvts/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /home/pvts/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_aarch64 -s vms/aarch64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-2025-21785/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-2025-21785/aarch64/kabi_checked

(The `el-9.4` branch was missing from <https://github.com/ciq-rocky-lts/kernel>, it was added by hand on the `imports/r9/kernel-5.14.0-427.42.1.el9_4` tag from the added <https://git.rockylinux.org/staging/rpms/kernel.git> repo)


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20176321/boot-test.log>)


# Kselftests: passed relative


## Methodology

The tests were run using the [rocky-patching](https://gitlab.conclusive.pl/devices/rocky-patching) framework (qemu-kvm virtualization of Rocky base cloud aarch64 images) ported to the local [WHLE-LS1046A](https://conclusive.tech/products/whle-ls1-sbc/) machine, based on the [NXP Layerscape LS1046A](https://www.nxp.com/products/LS1046A) arm64 processor.

-   **`kernel-selftests-internal` package:** `bpf` tests.
-   **source-compiled selftests:** (commit f794e724da913666a0791d4f87db499f368977ac) all the rest.

Some specific tests were excluded, see below.


## Coverage

`bpf` (except `test_progs-no_alu32`, `test_progs`, `test_xsk.sh`, `test_kmod.sh`, `test_sockmap`), `breakpoints`, `capabilities`, `clone3`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding`, `drivers/net/team`, `efivarfs`, `exec`, `filesystems/binderfs`, `filesystems/epoll`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `hid`, `intel_pstate`, `iommu`, `ipc`, `ir`, `kcmp`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net/forwarding` (except `sch_tbf_prio.sh`, `sch_ets.sh`, `tc_actions.sh`, `sch_red.sh`, `dual_vxlan_bridge.sh`, `sch_tbf_ets.sh`, `tc_police.sh`, `sch_tbf_root.sh`, `ipip_hier_gre_keys.sh`), `net/hsr`, `net/mptcp` (except `simult_flows.sh`), `net` (except `ip_defrag.sh`, `gro.sh`, `udpgso_bench.sh`, `xfrm_policy.sh`, `reuseport_addr_any.sh`, `txtimestamp.sh`, `reuseaddr_conflict`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `pid_namespace`, `pidfd`, `proc` (except `proc-pid-vm`), `pstore`, `ptrace`, `rlimits`, `rseq`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `syscall_user_dispatch`, `sysctl`, `tc-testing`, `tdx`, `timens`, `timers`, `tmpfs`, `tpm2`, `tty`, `user`, `vDSO`, `zram`.


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/20176320/kselftests--ciqlts9_4--run1.log>)
[kselftests&#x2013;ciqlts9\_4&#x2013;run2.log](<https://github.com/user-attachments/files/20176318/kselftests--ciqlts9_4--run2.log>)
[kselftests&#x2013;ciqlts9\_4&#x2013;run3.log](<https://github.com/user-attachments/files/20176317/kselftests--ciqlts9_4--run3.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-2025-21785&#x2013;run1.log](<https://github.com/user-attachments/files/20176316/kselftests--ciqlts9_4-CVE-2025-21785--run1.log>)


## Comparison

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4--run2.log
    Status2   kselftests--ciqlts9_4--run3.log
    Status3   kselftests--ciqlts9_4-CVE-2025-21785--run1.log
    
    TestCase                                     Status0  Status1  Status2  Status3  Summary
    filesystems/epoll:epoll_wakeup_test          pass     fail     fail     fail     diff
    net/forwarding:mirror_gre_vlan_bridge_1q.sh  pass     fail     pass     pass     diff
    net/forwarding:router_bridge_1d_lag.sh       fail     pass     pass     pass     diff
    net/forwarding:router_bridge_lag.sh          pass     pass     fail     pass     diff
    net/forwarding:vxlan_bridge_1d_ipv6.sh       fail     pass     pass     pass     diff
    net:fib_nexthops.sh                          pass     pass     fail     pass     diff
    net:srv6_end_dt46_l3vpn_test.sh              fail     fail     fail     pass     diff
    net:srv6_end_dt4_l3vpn_test.sh               pass     fail     pass     fail     diff
    net:srv6_end_dt6_l3vpn_test.sh               fail     pass     pass     pass     diff

All differences are contained within the reference kernel tests, except for `net:srv6_end_dt46_l3vpn_test.sh` which passed in the patched kernel. Many `ciqlts9_4` tests reporting inconsistent results, similarly to <https://github.com/ctrliq/kernel-src-tree/pull/256>. Added to the kselftests knowledge base <https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/master/rocky.yml?ref_type=heads>


# Specific tests: skipped

To be done on demand

