### PR TITLE
[lts-9.2] veth: Fix use after free in XDP_REDIRECT

### DIFF
--- a/drivers/net/veth.c
+++ b/drivers/net/veth.c
@@ -712,7 +712,8 @@ static int veth_convert_skb_to_xdp_buff(struct veth_rq *rq,
 	u32 frame_sz;
 
 	if (skb_shared(skb) || skb_head_is_locked(skb) ||
-	    skb_shinfo(skb)->nr_frags) {
+	    skb_shinfo(skb)->nr_frags ||
+	    skb_headroom(skb) < XDP_PACKET_HEADROOM) {
 		u32 size, len, max_head_size, off;
 		struct sk_buff *nskb;
 		struct page *page;
@@ -777,9 +778,6 @@ static int veth_convert_skb_to_xdp_buff(struct veth_rq *rq,
 
 		consume_skb(skb);
 		skb = nskb;
-	} else if (skb_headroom(skb) < XDP_PACKET_HEADROOM &&
-		   pskb_expand_head(skb, VETH_XDP_HEADROOM, 0, GFP_ATOMIC)) {
-		goto drop;
 	}
 
 	/* SKB "head" area always have tailroom for skb_shared_info */


### PR DESCRIPTION
jira VULN-67448
cve CVE-2023-53107
```
commit-author Shawn Bohrer <sbohrer@cloudflare.com> commit 7c10131803e45269ddc6c817f19ed649110f3cae

Commit 718a18a0c8a6 ("veth: Rework veth_xdp_rcv_skb in order to accept non-linear skb") introduced a bug where it tried to use pskb_expand_head() if the headroom was less than XDP_PACKET_HEADROOM.  This however uses kmalloc to expand the head, which will later allow consume_skb() to free the skb while is it still in use by AF_XDP.

Previously if the headroom was less than XDP_PACKET_HEADROOM we continued on to allocate a new skb from pages so this restores that behavior.

BUG: KASAN: use-after-free in __xsk_rcv+0x18d/0x2c0 Read of size 78 at addr ffff888976250154 by task napi/iconduit-g/148640

CPU: 5 PID: 148640 Comm: napi/iconduit-g Kdump: loaded Tainted: G           O       6.1.4-cloudflare-kasan-2023.1.2 #1
Hardware name: Quanta Computer Inc. QuantaPlex T41S-2U/S2S-MB, BIOS S2S_3B10.03 06/21/2018
Call Trace:
  <TASK>
  dump_stack_lvl+0x34/0x48
  print_report+0x170/0x473
  ? __xsk_rcv+0x18d/0x2c0
  kasan_report+0xad/0x130
  ? __xsk_rcv+0x18d/0x2c0
  kasan_check_range+0x149/0x1a0
  memcpy+0x20/0x60
  __xsk_rcv+0x18d/0x2c0
  __xsk_map_redirect+0x1f3/0x490
  ? veth_xdp_rcv_skb+0x89c/0x1ba0 [veth]
  xdp_do_redirect+0x5ca/0xd60
  veth_xdp_rcv_skb+0x935/0x1ba0 [veth]
  ? __netif_receive_skb_list_core+0x671/0x920
  ? veth_xdp+0x670/0x670 [veth]
  veth_xdp_rcv+0x304/0xa20 [veth]
  ? do_xdp_generic+0x150/0x150
  ? veth_xdp_rcv_one+0xde0/0xde0 [veth]
  ? _raw_spin_lock_bh+0xe0/0xe0
  ? newidle_balance+0x887/0xe30
  ? __perf_event_task_sched_in+0xdb/0x800
  veth_poll+0x139/0x571 [veth]
  ? veth_xdp_rcv+0xa20/0xa20 [veth]
  ? _raw_spin_unlock+0x39/0x70
  ? finish_task_switch.isra.0+0x17e/0x7d0
  ? __switch_to+0x5cf/0x1070
  ? __schedule+0x95b/0x2640
  ? io_schedule_timeout+0x160/0x160
  __napi_poll+0xa1/0x440
  napi_threaded_poll+0x3d1/0x460
  ? __napi_poll+0x440/0x440
  ? __kthread_parkme+0xc6/0x1f0
  ? __napi_poll+0x440/0x440
  kthread+0x2a2/0x340
  ? kthread_complete_and_exit+0x20/0x20
  ret_from_fork+0x22/0x30
  </TASK>

Freed by task 148640:
  kasan_save_stack+0x23/0x50
  kasan_set_track+0x21/0x30
  kasan_save_free_info+0x2a/0x40
  ____kasan_slab_free+0x169/0x1d0
  slab_free_freelist_hook+0xd2/0x190
  __kmem_cache_free+0x1a1/0x2f0
  skb_release_data+0x449/0x600
  consume_skb+0x9f/0x1c0
  veth_xdp_rcv_skb+0x89c/0x1ba0 [veth]
  veth_xdp_rcv+0x304/0xa20 [veth]
  veth_poll+0x139/0x571 [veth]
  __napi_poll+0xa1/0x440
  napi_threaded_poll+0x3d1/0x460
  kthread+0x2a2/0x340
  ret_from_fork+0x22/0x30

The buggy address belongs to the object at ffff888976250000
  which belongs to the cache kmalloc-2k of size 2048
The buggy address is located 340 bytes inside of
  2048-byte region [ffff888976250000, ffff888976250800)

The buggy address belongs to the physical page:
page:00000000ae18262a refcount:2 mapcount:0 mapping:0000000000000000 index:0x0 pfn:0x976250 head:00000000ae18262a order:3 compound_mapcount:0 compound_pincount:0 flags: 0x2ffff800010200(slab|head|node=0|zone=2|lastcpupid=0x1ffff) raw: 002ffff800010200 0000000000000000 dead000000000122 ffff88810004cf00 raw: 0000000000000000 0000000080080008 00000002ffffffff 0000000000000000 page dumped because: kasan: bad access detected

Memory state around the buggy address:
  ffff888976250000: fa fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
  ffff888976250080: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
> ffff888976250100: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
                                                  ^
  ffff888976250180: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
  ffff888976250200: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb

Fixes: 718a18a0c8a6 ("veth: Rework veth_xdp_rcv_skb in order to accept non-linear skb")
	Signed-off-by: Shawn Bohrer <sbohrer@cloudflare.com>
	Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
	Acked-by: Toshiaki Makita <toshiaki.makita1@gmail.com>
	Acked-by: Toke Høiland-Jørgensen <toke@kernel.org>
Link: https://lore.kernel.org/r/20230314153351.2201328-1-sbohrer@cloudflare.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 7c10131803e45269ddc6c817f19ed649110f3cae)
	Signed-off-by: David Gomez <dgomez@ciq.com>
```

# Build Log
```
SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/line6/snd-usb-pod.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/misc/snd-ua101.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/snd-usb-audio.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/line6/snd-usb-variax.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/snd-usbmidi-lib.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/line6/snd-usb-toneport.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/line6/snd-usb-podhd.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/line6/snd-usb-variax.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/misc/snd-ua101.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/snd-usbmidi-lib.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/snd-usbmidi-lib.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/misc/snd-ua101.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/snd-usb-audio.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-dgomez_ciqlts9_2-529330ecd3ec+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-dgomez_ciqlts9_2-529330ecd3ec+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 53s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-dgomez_ciqlts9_2-529330ecd3ec+ and Index to 0
The default is /boot/loader/entries/4dff56aa51eb410080f2fadbace916a6-5.14.0-dgomez_ciqlts9_2-529330ecd3ec+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-dgomez_ciqlts9_2-529330ecd3ec+
The default is /boot/loader/entries/4dff56aa51eb410080f2fadbace916a6-5.14.0-dgomez_ciqlts9_2-529330ecd3ec+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-dgomez_ciqlts9_2-529330ecd3ec+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 21s
[TIMER]{BUILD}: 3238s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 53s
[TIMER]{TOTAL} 3339s
```

# Testing

[5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64.log](https://github.com/user-attachments/files/20198037/5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64.log)

[5.14.0-dgomez_ciqlts9_2-529330ecd3ec.log](https://github.com/user-attachments/files/20198036/5.14.0-dgomez_ciqlts9_2-529330ecd3ec.log)

```
[dgomez@r92 kernel-src-tree]$ grep ^ok 5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64.log | wc -l
247
[dgomez@r92 kernel-src-tree]$ grep ^ok 5.14.0-dgomez_ciqlts9_2-529330ecd3ec.log | wc -l
246
```