### PR TITLE
[LTS 8.8] net: tun: fix bugs for oversize packet when napi frags enabled

### DIFF
--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -1473,7 +1473,8 @@ static struct sk_buff *tun_napi_alloc_frags(struct tun_file *tfile,
 	int err;
 	int i;
 
-	if (it->nr_segs > MAX_SKB_FRAGS + 1)
+	if (it->nr_segs > MAX_SKB_FRAGS + 1 ||
+	    len > (ETH_MAX_MTU - NET_SKB_PAD - NET_IP_ALIGN))
 		return ERR_PTR(-EMSGSIZE);
 
 	local_bh_disable();


### PR DESCRIPTION
[LTS 8.8]
CVE-2023-3812
VULN-3182


# Problem

<https://www.cve.org/CVERecord?id=CVE-2023-3812>

> An out-of-bounds memory access flaw was found in the Linux kernel’s TUN/TAP device driver functionality in how a user generates a malicious (too big) networking packet when napi frags is enabled. This flaw allows a local user to crash or potentially escalate their privileges on the system.


# Applicability

The tun/tap devices are enabled in `ciqlts8_8`:

    grep '^CONFIG_TUN=' configs/*.config

    configs/kernel-aarch64-debug.config:CONFIG_TUN=m
    configs/kernel-aarch64.config:CONFIG_TUN=m
    configs/kernel-ppc64le-debug.config:CONFIG_TUN=m
    configs/kernel-ppc64le.config:CONFIG_TUN=m
    configs/kernel-s390x-debug.config:CONFIG_TUN=m
    configs/kernel-s390x.config:CONFIG_TUN=m
    configs/kernel-x86_64-debug.config:CONFIG_TUN=m
    configs/kernel-x86_64.config:CONFIG_TUN=m

The "enablement of napi frags" mentioned in CVE description doesn't relate to any kernel configuration option, but to the `IFF_NAPI_FRAGS` flag, implemented for tun/tap devices in the 90e33d45940793def6f773b2d528e9f3c84ffdc7 commit (the one introducing the bug), which can be passed to the `ioctl` call during the tun device allocation procedure done by a user (see <https://www.kernel.org/doc/Documentation/networking/tuntap.txt>), so it must be assumed it *is* enabled.


# Solution

The mainline fix is provided in the 363a5328f4b0517e59572118ccfb7c626d81dca9 commit. The official backport to the kernel version 4.19 (the closest to `ciqlts8_8`'s 4.18) was done in aa815bf32acf560dad63c3dc46bc7b98ca9a9672 without any changes. Additionaly, the fix was applied already to Rocky `ciqlts8_6` in 680bcfa440e9cc6e6aa5d85f76a749aa05e4cff9 and to Rocky `ciqlts9_4` in 3eb34f2e374f9c98e02854608917335f25b4e13d in the same form.


# kABI check: passed

    DEBUG=1 CVE=CVE-2023-3812 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_8-CVE-2023-3812

    ninja: Entering directory `/data/build/rocky-patching'
    [0/1] Check ABI of kernel [ciqlts8_8-CVE-2023-3812]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_8/build_files/kernel-src-tree-ciqlts8_8-CVE-2023-3812/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_8-CVE-2023-3812/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20217205/boot-test.log>)


# Kselftests: passed relative


## Coverage

Specific tests were skipped which proved to be unreliable in the past. See the [rocky.yml](https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/master/rocky.yml?ref_type=heads) file for details.

`android`, `bpf` (except `test_progs`, `test_progs-no_alu32`, `test_kmod.sh`, `test_xsk.sh`, `test_sockmap`), `breakpoints`, `capabilities`, `cgroup`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/net/bonding`, `drivers/net/team`, `efivarfs`, `exec`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kexec`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `mqueue`, `net/forwarding` (except `sch_tbf_root.sh`, `sch_tbf_prio.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_ets.sh`, `sch_tbf_ets.sh`, `mirror_gre_bridge_1d_vlan.sh`, `ipip_hier_gre_keys.sh`, `tc_actions.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `udpgro_fwd.sh`, `ip_defrag.sh`, `xfrm_policy.sh`, `reuseaddr_conflict`, `reuseport_addr_any.sh`, `gro.sh`, `txtimestamp.sh`, `udpgso_bench.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `pstore`, `ptrace`, `rseq`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `sync`, `sysctl`, `tc-testing`, `tdx`, `timens`, `timers` (except `raw_skew`), `tpm2`, `user`, `vm`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts8\_8&#x2013;run1.log](<https://github.com/user-attachments/files/20217203/kselftests--ciqlts8_8--run1.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run2.log](<https://github.com/user-attachments/files/20217202/kselftests--ciqlts8_8--run2.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run3.log](<https://github.com/user-attachments/files/20217201/kselftests--ciqlts8_8--run3.log>)


## Patch

[kselftests&#x2013;ciqlts8\_8-CVE-2023-3812&#x2013;run1.log](<https://github.com/user-attachments/files/20217200/kselftests--ciqlts8_8-CVE-2023-3812--run1.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2023-3812&#x2013;run2.log](<https://github.com/user-attachments/files/20217199/kselftests--ciqlts8_8-CVE-2023-3812--run2.log>)


## Comparison

The results are the same in the patched and reference kernel.

    ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ---------------------------------------------
    Status0   kselftests--ciqlts8_8--run1.log
    Status1   kselftests--ciqlts8_8--run2.log
    Status2   kselftests--ciqlts8_8--run3.log
    Status3   kselftests--ciqlts8_8-CVE-2023-3812--run1.log
    Status4   kselftests--ciqlts8_8-CVE-2023-3812--run2.log


# Specific tests: dropped

An attempt was made to replicate the bug indicated in CVE. Dropped after a while when it became clear it would require dealing with too many technicalities of programmatically setting up a tun device, not really worth it. Can be done on demand.

