### PR TITLE
[lts-9.2] tty: n_gsm: fix the UAF caused by race condition in gsm_cleanup_mux

### DIFF
--- a/drivers/tty/n_gsm.c
+++ b/drivers/tty/n_gsm.c
@@ -2037,49 +2037,35 @@ static void gsm_error(struct gsm_mux *gsm,
 	gsm->io_error++;
 }
 
-static int gsm_disconnect(struct gsm_mux *gsm)
-{
-	struct gsm_dlci *dlci = gsm->dlci[0];
-	struct gsm_control *gc;
-
-	if (!dlci)
-		return 0;
-
-	/* In theory disconnecting DLCI 0 is sufficient but for some
-	   modems this is apparently not the case. */
-	gc = gsm_control_send(gsm, CMD_CLD, NULL, 0);
-	if (gc)
-		gsm_control_wait(gsm, gc);
-
-	del_timer_sync(&gsm->t2_timer);
-	/* Now we are sure T2 has stopped */
-
-	gsm_dlci_begin_close(dlci);
-	wait_event_interruptible(gsm->event,
-				dlci->state == DLCI_CLOSED);
-
-	if (signal_pending(current))
-		return -EINTR;
-
-	return 0;
-}
-
 /**
  *	gsm_cleanup_mux		-	generic GSM protocol cleanup
  *	@gsm: our mux
+ *	@disc: disconnect link?
  *
  *	Clean up the bits of the mux which are the same for all framing
  *	protocols. Remove the mux from the mux table, stop all the timers
  *	and then shut down each device hanging up the channels as we go.
  */
 
-static void gsm_cleanup_mux(struct gsm_mux *gsm)
+static void gsm_cleanup_mux(struct gsm_mux *gsm, bool disc)
 {
 	int i;
 	struct gsm_dlci *dlci = gsm->dlci[0];
 	struct gsm_msg *txq, *ntxq;
 
 	gsm->dead = true;
+	mutex_lock(&gsm->mutex);
+
+	if (dlci) {
+		if (disc && dlci->state != DLCI_CLOSED) {
+			gsm_dlci_begin_close(dlci);
+			wait_event(gsm->event, dlci->state == DLCI_CLOSED);
+		}
+		dlci->dead = true;
+	}
+
+	/* Finish outstanding timers, making sure they are done */
+	del_timer_sync(&gsm->t2_timer);
 
 	spin_lock(&gsm_mux_lock);
 	for (i = 0; i < MAX_MUX; i++) {
@@ -2093,13 +2079,7 @@ static void gsm_cleanup_mux(struct gsm_mux *gsm)
 	if (i == MAX_MUX)
 		return;
 
-	del_timer_sync(&gsm->t2_timer);
-	/* Now we are sure T2 has stopped */
-	if (dlci)
-		dlci->dead = true;
-
 	/* Free up any link layer users */
-	mutex_lock(&gsm->mutex);
 	for (i = 0; i < NUM_DLCI; i++)
 		if (gsm->dlci[i])
 			gsm_dlci_release(gsm->dlci[i]);
@@ -2301,19 +2281,11 @@ static int gsm_config(struct gsm_mux *gsm, struct gsm_config *c)
 
 	/*
 	 * Close down what is needed, restart and initiate the new
-	 * configuration
+	 * configuration. On the first time there is no DLCI[0]
+	 * and closing or cleaning up is not necessary.
 	 */
-
-	if (need_close || need_restart) {
-		int ret;
-
-		ret = gsm_disconnect(gsm);
-
-		if (ret)
-			return ret;
-	}
-	if (need_restart)
-		gsm_cleanup_mux(gsm);
+	if (need_close || need_restart)
+		gsm_cleanup_mux(gsm, true);
 
 	gsm->initiator = c->initiator;
 	gsm->mru = c->mru;
@@ -2426,7 +2398,7 @@ static void gsmld_detach_gsm(struct tty_struct *tty, struct gsm_mux *gsm)
 		for (i = 1; i < NUM_DLCI; i++)
 			tty_unregister_device(gsm_tty_driver, base + i);
 	}
-	gsm_cleanup_mux(gsm);
+	gsm_cleanup_mux(gsm, false);
 	tty_kref_put(gsm->tty);
 	gsm->tty = NULL;
 }
@@ -2529,7 +2501,7 @@ static int gsmld_open(struct tty_struct *tty)
 
 	ret = gsmld_attach_gsm(tty, gsm);
 	if (ret != 0) {
-		gsm_cleanup_mux(gsm);
+		gsm_cleanup_mux(gsm, false);
 		mux_put(gsm);
 	}
 	return ret;

--- a/drivers/tty/n_gsm.c
+++ b/drivers/tty/n_gsm.c
@@ -2050,12 +2050,13 @@ static void gsm_error(struct gsm_mux *gsm,
 static void gsm_cleanup_mux(struct gsm_mux *gsm, bool disc)
 {
 	int i;
-	struct gsm_dlci *dlci = gsm->dlci[0];
+	struct gsm_dlci *dlci;
 	struct gsm_msg *txq, *ntxq;
 
 	gsm->dead = true;
 	mutex_lock(&gsm->mutex);
 
+	dlci = gsm->dlci[0];
 	if (dlci) {
 		if (disc && dlci->state != DLCI_CLOSED) {
 			gsm_dlci_begin_close(dlci);

--- a/drivers/tty/n_gsm.c
+++ b/drivers/tty/n_gsm.c
@@ -2081,8 +2081,10 @@ static void gsm_cleanup_mux(struct gsm_mux *gsm, bool disc)
 
 	/* Free up any link layer users and finally the control channel */
 	for (i = NUM_DLCI - 1; i >= 0; i--)
-		if (gsm->dlci[i])
+		if (gsm->dlci[i]) {
 			gsm_dlci_release(gsm->dlci[i]);
+			gsm->dlci[i] = NULL;
+		}
 	mutex_unlock(&gsm->mutex);
 	/* Now wipe the queues */
 	list_for_each_entry_safe(txq, ntxq, &gsm->tx_list, list)

--- a/drivers/tty/n_gsm.c
+++ b/drivers/tty/n_gsm.c
@@ -1429,6 +1429,8 @@ static void gsm_dlci_close(struct gsm_dlci *dlci)
 		kfifo_reset(&dlci->fifo);
 	} else
 		dlci->gsm->dead = true;
+	/* Unregister gsmtty driver,report gsmtty dev remove uevent for user */
+	tty_unregister_device(gsm_tty_driver, dlci->addr);
 	wake_up(&dlci->gsm->event);
 	/* A DLCI 0 close is a MUX termination so we need to kick that
 	   back to userspace somehow */
@@ -1450,6 +1452,8 @@ static void gsm_dlci_open(struct gsm_dlci *dlci)
 	dlci->state = DLCI_OPEN;
 	if (debug & 8)
 		pr_debug("DLCI %d goes open.\n", dlci->addr);
+	/* Register gsmtty driver,report gsmtty dev add uevent for user */
+	tty_register_device(gsm_tty_driver, dlci->addr, NULL);
 	wake_up(&dlci->gsm->event);
 }
 
@@ -2384,17 +2388,19 @@ static int gsmld_attach_gsm(struct tty_struct *tty, struct gsm_mux *gsm)
 	else {
 		/* Don't register device 0 - this is the control channel and not
 		   a usable tty interface */
-		base = mux_num_to_base(gsm); /* Base for this MUX */
-		for (i = 1; i < NUM_DLCI; i++) {
-			struct device *dev;
+		if (gsm->initiator) {
+			base = mux_num_to_base(gsm); /* Base for this MUX */
+			for (i = 1; i < NUM_DLCI; i++) {
+				struct device *dev;
 
-			dev = tty_register_device(gsm_tty_driver,
+				dev = tty_register_device(gsm_tty_driver,
 							base + i, NULL);
-			if (IS_ERR(dev)) {
-				for (i--; i >= 1; i--)
-					tty_unregister_device(gsm_tty_driver,
-								base + i);
-				return PTR_ERR(dev);
+				if (IS_ERR(dev)) {
+					for (i--; i >= 1; i--)
+						tty_unregister_device(gsm_tty_driver,
+									base + i);
+					return PTR_ERR(dev);
+				}
 			}
 		}
 	}
@@ -2416,8 +2422,10 @@ static void gsmld_detach_gsm(struct tty_struct *tty, struct gsm_mux *gsm)
 	int i;
 
 	WARN_ON(tty != gsm->tty);
-	for (i = 1; i < NUM_DLCI; i++)
-		tty_unregister_device(gsm_tty_driver, base + i);
+	if (gsm->initiator) {
+		for (i = 1; i < NUM_DLCI; i++)
+			tty_unregister_device(gsm_tty_driver, base + i);
+	}
 	gsm_cleanup_mux(gsm);
 	tty_kref_put(gsm->tty);
 	gsm->tty = NULL;

--- a/drivers/tty/n_gsm.c
+++ b/drivers/tty/n_gsm.c
@@ -2079,8 +2079,8 @@ static void gsm_cleanup_mux(struct gsm_mux *gsm, bool disc)
 	if (i == MAX_MUX)
 		return;
 
-	/* Free up any link layer users */
-	for (i = 0; i < NUM_DLCI; i++)
+	/* Free up any link layer users and finally the control channel */
+	for (i = NUM_DLCI - 1; i >= 0; i--)
 		if (gsm->dlci[i])
 			gsm_dlci_release(gsm->dlci[i]);
 	mutex_unlock(&gsm->mutex);


### PR DESCRIPTION
For more information see ticket referenced below

jira VULN-676
cve CVE-2023-6546

```
commit-author Yi Yang <yiyang13@huawei.com>
commit 3c4f8333b582487a2d1e02171f1465531cde53e3

In commit 9b9c8195f3f0 ("tty: n_gsm: fix UAF in gsm_cleanup_mux"), the UAF
problem is not completely fixed. There is a race condition in
gsm_cleanup_mux(), which caused this UAF.

The UAF problem is triggered by the following race:
task[5046]                     task[5054]
-----------------------        -----------------------
gsm_cleanup_mux();
dlci = gsm->dlci[0];
mutex_lock(&gsm->mutex);
                               gsm_cleanup_mux();
                               dlci = gsm->dlci[0]; //Didn't take the lock
gsm_dlci_release(gsm->dlci[i]);
gsm->dlci[i] = NULL;
mutex_unlock(&gsm->mutex);
                               mutex_lock(&gsm->mutex);
                               dlci->dead = true; //UAF

Fix it by assigning values after mutex_lock().

Link: https://syzkaller.appspot.com/text?tag=CrashReport&x=176188b5a80000
        Cc: stable <stable@kernel.org>
Fixes: 9b9c8195f3f0 ("tty: n_gsm: fix UAF in gsm_cleanup_mux")
Fixes: aa371e96f05d ("tty: n_gsm: fix restart handling via CLD command")
        Signed-off-by: Yi Yang <yiyang13@huawei.com>
Co-developed-by: Qiumiao Zhang <zhangqiumiao1@huawei.com>
        Signed-off-by: Qiumiao Zhang <zhangqiumiao1@huawei.com>
Link: https://lore.kernel.org/r/20230811031121.153237-1-yiyang13@huawei.com
        Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
(cherry picked from commit 3c4f8333b582487a2d1e02171f1465531cde53e3)
        Signed-off-by: David Gomez <dgomez@ciq.com>
```

# Build Log
```
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/intel/skylake/snd-soc-skl.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-acpi-intel-byt.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-acpi-intel-bdw.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/amd/snd-sof-amd-renoir.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/amd/snd-sof-amd-acp.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/amd/snd-sof-amd-renoir.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-acpi-intel-byt.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/amd/snd-sof-amd-acp.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-acpi-intel-bdw.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/snd-soc-core.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-intel-atom.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-acpi-intel-bdw.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-acpi-intel-byt.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-intel-hda-common.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-intel-atom.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-apl.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-intel-hda.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-intel-atom.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-cnl.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-icl.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-apl.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-intel-hda.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-mtl.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-cnl.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-apl.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-tgl.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-intel-hda.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-icl.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-intel-hda-common.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-tng.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-mtl.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-cnl.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-tgl.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-icl.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-mtl.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-intel-hda-common.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-tng.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-tgl.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-acpi.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-pci.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/intel/snd-sof-pci-intel-tng.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-probes.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-acpi.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-pci.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-utils.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/xtensa/snd-sof-xtensa-dsp.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-acpi.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soundcore.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-pci.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-probes.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-utils.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-probes.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/xtensa/snd-sof-xtensa-dsp.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soundcore.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof-utils.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/xtensa/snd-sof-xtensa-dsp.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/synth/emux/snd-emux-synth.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soundcore.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/synth/snd-util-mem.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/6fire/snd-usb-6fire.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/bcd2000/snd-bcd2000.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/synth/emux/snd-emux-synth.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/caiaq/snd-usb-caiaq.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/synth/snd-util-mem.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/bcd2000/snd-bcd2000.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/hiface/snd-usb-hiface.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/6fire/snd-usb-6fire.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/soc/sof/snd-sof.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/synth/snd-util-mem.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-line6.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/synth/emux/snd-emux-synth.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/caiaq/snd-usb-caiaq.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/6fire/snd-usb-6fire.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/hiface/snd-usb-hiface.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/caiaq/snd-usb-caiaq.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-line6.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/hiface/snd-usb-hiface.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-pod.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-line6.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-podhd.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/bcd2000/snd-bcd2000.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-toneport.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-pod.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-variax.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/misc/snd-ua101.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-podhd.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-toneport.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-pod.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/snd-usb-audio.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/snd-usbmidi-lib.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-toneport.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-variax.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-podhd.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/misc/snd-ua101.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/line6/snd-usb-variax.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/misc/snd-ua101.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/snd-usbmidi-lib.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/snd-usb-audio.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/snd-usbmidi-lib.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+
[TIMER]{MODULES}: 15s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 55s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+ and Index to 0
The default is /boot/loader/entries/4dff56aa51eb410080f2fadbace916a6-5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+
The default is /boot/loader/entries/4dff56aa51eb410080f2fadbace916a6-5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 21s
[TIMER]{BUILD}: 3236s
[TIMER]{MODULES}: 15s
[TIMER]{INSTALL}: 55s
[TIMER]{TOTAL} 3340s
```

# Testing
[5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64.log](https://github.com/user-attachments/files/20234214/5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64.log)
[5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea.log](https://github.com/user-attachments/files/20234208/5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea.log)

```
# Before Fix
$ grep ^ok 5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64.log | wc -l
247
# After Fix
$ grep ^ok 5.14.0-dgomez-ciqlts9_2_VULN-676-f9fa8ba6f4ea.log | wc -l
246
```