### PR TITLE
[fips-8.6] arm64: cacheinfo: Avoid out-of-bounds write to cacheinfo array

### DIFF
--- a/arch/arm64/kernel/cacheinfo.c
+++ b/arch/arm64/kernel/cacheinfo.c
@@ -101,16 +101,18 @@ static int __populate_cache_leaves(unsigned int cpu)
 	unsigned int level, idx;
 	enum cache_type type;
 	struct cpu_cacheinfo *this_cpu_ci = get_cpu_cacheinfo(cpu);
-	struct cacheinfo *this_leaf = this_cpu_ci->info_list;
+	struct cacheinfo *infos = this_cpu_ci->info_list;
 
 	for (idx = 0, level = 1; level <= this_cpu_ci->num_levels &&
-	     idx < this_cpu_ci->num_leaves; idx++, level++) {
+	     idx < this_cpu_ci->num_leaves; level++) {
 		type = get_cache_type(level);
 		if (type == CACHE_TYPE_SEPARATE) {
-			ci_leaf_init(this_leaf++, CACHE_TYPE_DATA, level);
-			ci_leaf_init(this_leaf++, CACHE_TYPE_INST, level);
+			if (idx + 1 >= this_cpu_ci->num_leaves)
+				break;
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_DATA, level);
+			ci_leaf_init(&infos[idx++], CACHE_TYPE_INST, level);
 		} else {
-			ci_leaf_init(this_leaf++, type, level);
+			ci_leaf_init(&infos[idx++], type, level);
 		}
 	}
 	return 0;


### PR DESCRIPTION
jira VULN-54128
cve CVE-2025-21785

This is an arm64 specific change, which I don't know that we strictly care about in fips branches.  But I don't think it hurts to be in there.  Since there isn't a current aarch64 fips-8.6 kernel to test against I only ran kselftest against the source built kernel under test.  See this PR for lts-8.6 for the same change to see more test results: https://github.com/ctrliq/kernel-src-tree/pull/232

```
commit-author Radu Rendec <rrendec@redhat.com>
commit 875d742cf5327c93cba1f11e12b08d3cce7a88d2

The loop that detects/populates cache information already has a bounds check on the array size but does not account for cache levels with separate data/instructions cache. Fix this by incrementing the index for any populated leaf (instead of any populated level).

Fixes: 5d425c186537 ("arm64: kernel: add support for cpu cache information")

	Signed-off-by: Radu Rendec <rrendec@redhat.com>
Link: https://lore.kernel.org/r/20250206174420.2178724-1-rrendec@redhat.com
	Signed-off-by: Will Deacon <will@kernel.org>
(cherry picked from commit 875d742cf5327c93cba1f11e12b08d3cce7a88d2)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
aarch64 architecture detected, copying config
'configs/kernel-aarch64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-8-c_4.18.0-553.16.1_VULN-54128-6ac224458284"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  UPD     include/config/kernel.release
  WRAP    arch/arm64/include/generated/uapi/asm/errno.h
  WRAP    arch/arm64/include/generated/uapi/asm/ioctl.h
  WRAP    arch/arm64/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/arm64/include/generated/uapi/asm/mman.h
  WRAP    arch/arm64/include/generated/uapi/asm/msgbuf.h
  WRAP    arch/arm64/include/generated/uapi/asm/kvm_para.h
  WRAP    arch/arm64/include/generated/uapi/asm/ioctls.h
  WRAP    arch/arm64/include/generated/uapi/asm/poll.h
  WRAP    arch/arm64/include/generated/uapi/asm/resource.h
  WRAP    arch/arm64/include/generated/uapi/asm/sembuf.h
  WRAP    arch/arm64/include/generated/uapi/asm/shmbuf.h
  WRAP    arch/arm64/include/generated/uapi/asm/socket.h
  WRAP    arch/arm64/include/generated/uapi/asm/sockios.h
  WRAP    arch/arm64/include/generated/uapi/asm/swab.h
  WRAP    arch/arm64/include/generated/uapi/asm/termbits.h
  WRAP    arch/arm64/include/generated/uapi/asm/termios.h
  WRAP    arch/arm64/include/generated/uapi/asm/siginfo.h
  WRAP    arch/arm64/include/generated/uapi/asm/types.h
  UPD     include/generated/uapi/linux/version.h
  UPD     include/generated/utsrelease.h
  DESCEND bpf/resolve_btfids
  MKDIR     /home/brett/kernel-src-tree/tools/bpf/resolve_btfids//libsubcmd
  MKDIR     /home/brett/kernel-src-tree/tools/bpf/resolve_btfids//libbpf
  HOSTCC  /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/fixdep.o
  GEN     /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h
  MKDIR   /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/
  CC      /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/libbpf.o
  HOSTLD  /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/fixdep-in.o
  MKDIR   /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/
  LINK    /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/fixdep
  CC      /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/nlattr.o
  CC      /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/btf.o
  CC      /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/libbpf_errno.o

[SNIP]

  INSTALL net/sched/sch_pie.ko
  INSTALL net/sched/sch_plug.ko
  INSTALL net/sched/sch_prio.ko
  INSTALL net/sched/sch_qfq.ko
  INSTALL net/sched/sch_red.ko
  INSTALL net/sched/sch_sfb.ko
  INSTALL net/sched/sch_sfq.ko
  INSTALL net/sched/sch_tbf.ko
  INSTALL net/sched/sch_teql.ko
  INSTALL net/sctp/sctp.ko
  INSTALL net/sctp/sctp_diag.ko
  INSTALL net/sunrpc/auth_gss/auth_rpcgss.ko
  INSTALL net/sunrpc/auth_gss/rpcsec_gss_krb5.ko
  INSTALL net/sunrpc/sunrpc.ko
  INSTALL net/sunrpc/xprtrdma/rpcrdma.ko
  INSTALL net/tipc/diag.ko
  INSTALL net/tipc/tipc.ko
  INSTALL net/tls/tls.ko
  INSTALL net/unix/unix_diag.ko
  INSTALL net/vmw_vsock/hv_sock.ko
  INSTALL net/vmw_vsock/vmw_vsock_virtio_transport.ko
  INSTALL net/vmw_vsock/vmw_vsock_virtio_transport_common.ko
  INSTALL net/vmw_vsock/vsock.ko
  INSTALL net/vmw_vsock/vsock_diag.ko
  INSTALL net/vmw_vsock/vsock_loopback.ko
  INSTALL net/xdp/xsk_diag.ko
  INSTALL net/xfrm/xfrm_interface.ko
  INSTALL net/xfrm/xfrm_ipcomp.ko
  INSTALL security/keys/encrypted-keys/encrypted-keys.ko
  INSTALL security/keys/trusted-keys/trusted.ko
  INSTALL sound/soundcore.ko
  DEPMOD  4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-54128-6ac224458284+
[TIMER]{MODULES}: 198s
Making Install
/bin/sh ./arch/arm64/boot/install.sh 4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-54128-6ac224458284+ \
arch/arm64/boot/Image System.map "/boot"
[TIMER]{INSTALL}: 1353s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-54128-6ac224458284+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 25164s
[TIMER]{MODULES}: 198s
[TIMER]{INSTALL}: 1353s
[TIMER]{TOTAL} 26970s
Rebooting in 10 seconds


```

### Testing

kselftests were run against the built kernel under test only

[selftest-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-54128-6ac224458284+.log](https://github.com/user-attachments/files/20258236/selftest-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-54128-6ac224458284%2B.log)

```
brett@lycia ~/ciq/vuln-54128 % grep ^ok selftest-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-54128-6ac224458284+.log | wc -l
167
brett@lycia ~/ciq/vuln-54128 %

```