### PR TITLE
[fips-9] net: tun: fix bugs for oversize packet when napi frags enabled

### DIFF
--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -1448,7 +1448,8 @@ static struct sk_buff *tun_napi_alloc_frags(struct tun_file *tfile,
 	int err;
 	int i;
 
-	if (it->nr_segs > MAX_SKB_FRAGS + 1)
+	if (it->nr_segs > MAX_SKB_FRAGS + 1 ||
+	    len > (ETH_MAX_MTU - NET_SKB_PAD - NET_IP_ALIGN))
 		return ERR_PTR(-EMSGSIZE);
 
 	local_bh_disable();


### PR DESCRIPTION
jira VULN-8828
cve CVE-2023-3812

```
commit-author Ziyang Xuan <william.xuanziyang@huawei.com> commit 363a5328f4b0517e59572118ccfb7c626d81dca9

Recently, we got two syzkaller problems because of oversize packet when napi frags enabled.

One of the problems is because the first seg size of the iov_iter from user space is very big, it is 2147479538 which is bigger than the threshold value for bail out early in __alloc_pages(). And skb->pfmemalloc is true, __kmalloc_reserve() would use pfmemalloc reserves without __GFP_NOWARN flag. Thus we got a warning as following:

======================================================== WARNING: CPU: 1 PID: 17965 at mm/page_alloc.c:5295 __alloc_pages+0x1308/0x16c4 mm/page_alloc.c:5295 ...
Call trace:
 __alloc_pages+0x1308/0x16c4 mm/page_alloc.c:5295
 __alloc_pages_node include/linux/gfp.h:550 [inline]
 alloc_pages_node include/linux/gfp.h:564 [inline]
 kmalloc_large_node+0x94/0x350 mm/slub.c:4038
 __kmalloc_node_track_caller+0x620/0x8e4 mm/slub.c:4545
 __kmalloc_reserve.constprop.0+0x1e4/0x2b0 net/core/skbuff.c:151
 pskb_expand_head+0x130/0x8b0 net/core/skbuff.c:1654
 __skb_grow include/linux/skbuff.h:2779 [inline]
 tun_napi_alloc_frags+0x144/0x610 drivers/net/tun.c:1477
 tun_get_user+0x31c/0x2010 drivers/net/tun.c:1835
 tun_chr_write_iter+0x98/0x100 drivers/net/tun.c:2036

The other problem is because odd IPv6 packets without NEXTHDR_NONE extension header and have big packet length, it is 2127925 which is bigger than ETH_MAX_MTU(65535). After ipv6_gso_pull_exthdrs() in ipv6_gro_receive(), network_header offset and transport_header offset are all bigger than U16_MAX. That would trigger skb->network_header and skb->transport_header overflow error, because they are all '__u16' type. Eventually, it would affect the value for __skb_push(skb, value), and make it be a big value. After __skb_push() in ipv6_gro_receive(), skb->data would less than skb->head, an out of bounds memory bug occurred. That would trigger the problem as following:

================================================================== BUG: KASAN: use-after-free in eth_type_trans+0x100/0x260 ...
Call trace:
 dump_backtrace+0xd8/0x130
 show_stack+0x1c/0x50
 dump_stack_lvl+0x64/0x7c
 print_address_description.constprop.0+0xbc/0x2e8
 print_report+0x100/0x1e4
 kasan_report+0x80/0x120
 __asan_load8+0x78/0xa0
 eth_type_trans+0x100/0x260
 napi_gro_frags+0x164/0x550
 tun_get_user+0xda4/0x1270
 tun_chr_write_iter+0x74/0x130
 do_iter_readv_writev+0x130/0x1ec
 do_iter_write+0xbc/0x1e0
 vfs_writev+0x13c/0x26c

To fix the problems, restrict the packet size less than (ETH_MAX_MTU - NET_SKB_PAD - NET_IP_ALIGN) which has considered reserved skb space in napi_alloc_skb() because transport_header is an offset from skb->head. Add len check in tun_napi_alloc_frags() simply.

Fixes: 90e33d459407 ("tun: enable napi_gro_frags() for TUN/TAP driver")
	Signed-off-by: Ziyang Xuan <william.xuanziyang@huawei.com>
	Reviewed-by: Eric Dumazet <edumazet@google.com>
Link: https://lore.kernel.org/r/20221029094101.1653855-1-william.xuanziyang@huawei.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 363a5328f4b0517e59572118ccfb7c626d81dca9)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/param.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/resource.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  WRAP    arch/x86/include/generated/uapi/asm/termbits.h
  WRAP    arch/x86/include/generated/uapi/asm/termios.h
  WRAP    arch/x86/include/generated/uapi/asm/sockios.h
  WRAP    arch/x86/include/generated/uapi/asm/types.h
  HOSTCC  arch/x86/tools/relocs_32.o
  HOSTCC  arch/x86/tools/relocs_64.o
  HOSTCC  arch/x86/tools/relocs_common.o
  UPD     include/config/kernel.release
  WRAP    arch/x86/include/generated/asm/early_ioremap.h
  WRAP    arch/x86/include/generated/asm/mcs_spinlock.h

[SNIP]

  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/misc/snd-ua101.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/snd-usb-audio.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/snd-usbmidi-lib.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/line6/snd-usb-podhd.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/line6/snd-usb-line6.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/line6/snd-usb-toneport.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/line6/snd-usb-variax.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/snd-usb-audio.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/misc/snd-ua101.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/snd-usbmidi-lib.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/line6/snd-usb-variax.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/line6/snd-usb-toneport.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/snd-usbmidi-lib.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/misc/snd-ua101.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/snd-usb-audio.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+
[TIMER]{MODULES}: 7s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 61s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 959s
[TIMER]{MODULES}: 7s
[TIMER]{INSTALL}: 61s
[TIMER]{TOTAL} 1046s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the patch

[selftest-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log](https://github.com/user-attachments/files/20348441/selftest-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log)

[selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+.log](https://github.com/user-attachments/files/20348450/selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456%2B.log)

```
brett@lycia ~/ciq/vuln-8828 % grep ^ok selftest-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log | wc -l
308
brett@lycia ~/ciq/vuln-8828 % grep ^ok selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8828-93455db36456+.log | wc -l
311
brett@lycia ~/ciq/vuln-8828 %

```