### PR TITLE
[fips-9-compliant] net/sched: cls_u32: Fix reference counter leak leading to overflow

### DIFF
--- a/net/sched/cls_u32.c
+++ b/net/sched/cls_u32.c
@@ -716,12 +716,18 @@ static int u32_set_parms(struct net *net, struct tcf_proto *tp,
 			 struct nlattr *est, u32 flags, u32 fl_flags,
 			 struct netlink_ext_ack *extack)
 {
-	int err;
+	int err, ifindex = -1;
 
 	err = tcf_exts_validate_ex(net, tp, tb, est, &n->exts, flags,
 				   fl_flags, extack);
 	if (err < 0)
 		return err;
+
+	if (tb[TCA_U32_INDEV]) {
+		ifindex = tcf_change_indev(net, tb[TCA_U32_INDEV], extack);
+		if (ifindex < 0)
+			return -EINVAL;
+	}
 
 	if (tb[TCA_U32_LINK]) {
 		u32 handle = nla_get_u32(tb[TCA_U32_LINK]);
@@ -757,13 +763,9 @@ static int u32_set_parms(struct net *net, struct tcf_proto *tp,
 		tcf_bind_filter(tp, &n->res, base);
 	}
 
-	if (tb[TCA_U32_INDEV]) {
-		int ret;
-		ret = tcf_change_indev(net, tb[TCA_U32_INDEV], extack);
-		if (ret < 0)
-			return -EINVAL;
-		n->ifindex = ret;
-	}
+	if (ifindex >= 0)
+		n->ifindex = ifindex;
+
 	return 0;
 }
 


### PR DESCRIPTION
jira VULN-8824
cve CVE-2023-3609
```
commit-author Lee Jones <lee@kernel.org>
commit 04c55383fa5689357bcdd2c8036725a55ed632bc

In the event of a failure in tcf_change_indev(), u32_set_parms() will immediately return without decrementing the recently incremented reference counter.  If this happens enough times, the counter will rollover and the reference freed, leading to a double free which can be used to do 'bad things'.

In order to prevent this, move the point of possible failure above the point where the reference counter is incremented.  Also save any meaningful return values to be applied to the return data at the appropriate point in time.

This issue was caught with KASAN.

Fixes: 705c7091262d ("net: sched: cls_u32: no need to call tcf_exts_change for newly allocated struct")
	Suggested-by: Eric Dumazet <edumazet@google.com>
	Signed-off-by: Lee Jones <lee@kernel.org>
	Reviewed-by: Eric Dumazet <edumazet@google.com>
	Acked-by: Jamal Hadi Salim <jhs@mojatatu.com>
	Signed-off-by: David S. Miller <davem@davemloft.net>
(cherry picked from commit 04c55383fa5689357bcdd2c8036725a55ed632bc)
	Signed-off-by: David Gomez <dgomez@ciq.com>
```

# Build Log
```
STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/line6/snd-usb-variax.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/line6/snd-usb-podhd.ko
  INSTALL /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/snd-usbmidi-lib.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/line6/snd-usb-pod.ko
  STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/misc/snd-ua101.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/line6/snd-usb-toneport.ko
  STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/snd-usbmidi-lib.ko
  INSTALL /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/misc/snd-ua101.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/line6/snd-usb-variax.ko
  STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/snd-usb-audio.ko
  INSTALL /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/snd-usbmidi-lib.ko
  STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/snd-usb-audio.ko
  STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+
[TIMER]{MODULES}: 14s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 56s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+ and Index to 1
The default is /boot/loader/entries/7b8cc30b1d5f42b0a4f1b1f8af928cf8-5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+
The default is /boot/loader/entries/7b8cc30b1d5f42b0a4f1b1f8af928cf8-5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 24s
[TIMER]{BUILD}: 3212s
[TIMER]{MODULES}: 14s
[TIMER]{INSTALL}: 56s
[TIMER]{TOTAL} 3321s
```

# Testing
Fixes a commit that is on the ciqlts9_2 branch https://github.com/ctrliq/kernel-src-tree/commit/705c7091262d
[5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log](https://github.com/user-attachments/files/20354955/5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log)
[5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+.log](https://github.com/user-attachments/files/20355391/5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c%2B.log)

```
# Before Fix
$ grep ^ok 5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64.log | wc -l
301
# After Fix
$ grep ^ok 5.14.0-dgomez-fips-9-compliant_VULN-8824-cdb35e46c32c+.log | wc -l
304
```

Similar to 9.2 LTS PR https://github.com/ctrliq/kernel-src-tree/pull/274