### PR TITLE
[fips-legacy-8] tun: avoid double free in tun_free_netdev

### DIFF
--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -251,12 +251,18 @@ struct tun_struct {
 	struct tun_prog __rcu *steering_prog;
 	struct tun_prog __rcu *filter_prog;
 	struct ethtool_link_ksettings link_ksettings;
+	/* init args */
+	struct file *file;
+	struct ifreq *ifr;
 };
 
 struct veth {
 	__be16 h_vlan_proto;
 	__be16 h_vlan_TCI;
 };
+
+static void tun_flow_init(struct tun_struct *tun);
+static void tun_flow_uninit(struct tun_struct *tun);
 
 static int tun_napi_receive(struct napi_struct *napi, int budget)
 {
@@ -996,6 +1002,49 @@ static int check_filter(struct tap_filter *filter, const struct sk_buff *skb)
 
 static const struct ethtool_ops tun_ethtool_ops;
 
+static int tun_net_init(struct net_device *dev)
+{
+	struct tun_struct *tun = netdev_priv(dev);
+	struct ifreq *ifr = tun->ifr;
+	int err;
+
+	tun->pcpu_stats = netdev_alloc_pcpu_stats(struct tun_pcpu_stats);
+	if (!tun->pcpu_stats)
+		return -ENOMEM;
+
+	spin_lock_init(&tun->lock);
+
+	err = security_tun_dev_alloc_security(&tun->security);
+	if (err < 0) {
+		free_percpu(tun->pcpu_stats);
+		return err;
+	}
+
+	tun_flow_init(tun);
+
+	dev->hw_features = NETIF_F_SG | NETIF_F_FRAGLIST |
+			   TUN_USER_FEATURES | NETIF_F_HW_VLAN_CTAG_TX |
+			   NETIF_F_HW_VLAN_STAG_TX;
+	dev->features = dev->hw_features | NETIF_F_LLTX;
+	dev->vlan_features = dev->features &
+			     ~(NETIF_F_HW_VLAN_CTAG_TX |
+			       NETIF_F_HW_VLAN_STAG_TX);
+
+	tun->flags = (tun->flags & ~TUN_FEATURES) |
+		      (ifr->ifr_flags & TUN_FEATURES);
+
+	INIT_LIST_HEAD(&tun->disabled);
+	err = tun_attach(tun, tun->file, false, ifr->ifr_flags & IFF_NAPI,
+			 ifr->ifr_flags & IFF_NAPI_FRAGS, false);
+	if (err < 0) {
+		tun_flow_uninit(tun);
+		security_tun_dev_free_security(tun->security);
+		free_percpu(tun->pcpu_stats);
+		return err;
+	}
+	return 0;
+}
+
 /* Net device detach from fd. */
 static void tun_net_uninit(struct net_device *dev)
 {
@@ -1274,6 +1323,7 @@ static int tun_net_change_carrier(struct net_device *dev, bool new_carrier)
 }
 
 static const struct net_device_ops tun_netdev_ops = {
+	.ndo_init		= tun_net_init,
 	.ndo_uninit		= tun_net_uninit,
 	.ndo_open		= tun_net_open,
 	.ndo_stop		= tun_net_close,
@@ -1360,6 +1410,7 @@ static int tun_xdp_tx(struct net_device *dev, struct xdp_buff *xdp)
 }
 
 static const struct net_device_ops tap_netdev_ops = {
+	.ndo_init		= tun_net_init,
 	.ndo_uninit		= tun_net_uninit,
 	.ndo_open		= tun_net_open,
 	.ndo_stop		= tun_net_close,
@@ -1403,7 +1454,7 @@ static void tun_flow_uninit(struct tun_struct *tun)
 #define MAX_MTU 65535
 
 /* Initialize net device. */
-static void tun_net_init(struct net_device *dev)
+static void tun_net_initialize(struct net_device *dev)
 {
 	struct tun_struct *tun = netdev_priv(dev);
 
@@ -2324,13 +2375,7 @@ static void tun_free_netdev(struct net_device *dev)
 	struct tun_struct *tun = netdev_priv(dev);
 
 	BUG_ON(!(list_empty(&tun->disabled)));
-
 	free_percpu(tun->pcpu_stats);
-	/* We clear pcpu_stats so that tun_set_iff() can tell if
-	 * tun_free_netdev() has been called from register_netdevice().
-	 */
-	tun->pcpu_stats = NULL;
-
 	tun_flow_uninit(tun);
 	security_tun_dev_free_security(tun->security);
 	__tun_set_ebpf(tun, &tun->steering_prog, NULL);
@@ -2825,9 +2870,6 @@ static int tun_set_iff(struct net *net, struct file *file, struct ifreq *ifr)
 
 		if (!dev)
 			return -ENOMEM;
-		err = dev_get_valid_name(net, dev, name);
-		if (err < 0)
-			goto err_free_dev;
 
 		dev_net_set(dev, net);
 		dev->rtnl_link_ops = &tun_link_ops;
@@ -2846,41 +2888,16 @@ static int tun_set_iff(struct net *net, struct file *file, struct ifreq *ifr)
 		tun->rx_batched = 0;
 		RCU_INIT_POINTER(tun->steering_prog, NULL);
 
-		tun->pcpu_stats = netdev_alloc_pcpu_stats(struct tun_pcpu_stats);
-		if (!tun->pcpu_stats) {
-			err = -ENOMEM;
-			goto err_free_dev;
-		}
+		tun->ifr = ifr;
+		tun->file = file;
 
-		spin_lock_init(&tun->lock);
-
-		err = security_tun_dev_alloc_security(&tun->security);
-		if (err < 0)
-			goto err_free_stat;
-
-		tun_net_init(dev);
-		tun_flow_init(tun);
-
-		dev->hw_features = NETIF_F_SG | NETIF_F_FRAGLIST |
-				   TUN_USER_FEATURES | NETIF_F_HW_VLAN_CTAG_TX |
-				   NETIF_F_HW_VLAN_STAG_TX;
-		dev->features = dev->hw_features | NETIF_F_LLTX;
-		dev->vlan_features = dev->features &
-				     ~(NETIF_F_HW_VLAN_CTAG_TX |
-				       NETIF_F_HW_VLAN_STAG_TX);
-
-		tun->flags = (tun->flags & ~TUN_FEATURES) |
-			      (ifr->ifr_flags & TUN_FEATURES);
-
-		INIT_LIST_HEAD(&tun->disabled);
-		err = tun_attach(tun, file, false, ifr->ifr_flags & IFF_NAPI,
-				 ifr->ifr_flags & IFF_NAPI_FRAGS, false);
-		if (err < 0)
-			goto err_free_flow;
+		tun_net_initialize(dev);
 
 		err = register_netdevice(tun->dev);
-		if (err < 0)
-			goto err_detach;
+		if (err < 0) {
+			free_netdev(dev);
+			return err;
+		}
 		/* free_netdev() won't check refcnt, to aovid race
 		 * with dev_put() we need publish tun after registration.
 		 */
@@ -2899,24 +2916,6 @@ static int tun_set_iff(struct net *net, struct file *file, struct ifreq *ifr)
 
 	strcpy(ifr->ifr_name, tun->dev->name);
 	return 0;
-
-err_detach:
-	tun_detach_all(dev);
-	/* We are here because register_netdevice() has failed.
-	 * If register_netdevice() already called tun_free_netdev()
-	 * while dealing with the error, tun->pcpu_stats has been cleared.
-	 */
-	if (!tun->pcpu_stats)
-		goto err_free_dev;
-
-err_free_flow:
-	tun_flow_uninit(tun);
-	security_tun_dev_free_security(tun->security);
-err_free_stat:
-	free_percpu(tun->pcpu_stats);
-err_free_dev:
-	free_netdev(dev);
-	return err;
 }
 
 static void tun_get_iff(struct tun_struct *tun, struct ifreq *ifr)


### PR DESCRIPTION
jira VULN-8777
cve CVE-2022-4744

```
commit-author George Kennedy <george.kennedy@oracle.com> commit 158b515f703e75e7d68289bf4d98c664e1d632df
upstream-diff Content is the same as the upstream patch except
              s/dev->tstats/tun->pcpu_stats/g becuase the switch to
              tstats (497a5757ce4e "tun: switch to net core provided
              statistics counters") isn't in this kernel.
              This matches how this change was backported to 4.19.y.

Avoid double free in tun_free_netdev() by moving the dev->tstats and tun->security allocs to a new ndo_init routine (tun_net_init()) that will be called by register_netdevice(). ndo_init is paired with the desctructor (tun_free_netdev()), so if there's an error in register_netdevice() the destructor will handle the frees.

BUG: KASAN: double-free or invalid-free in selinux_tun_dev_free_security+0x1a/0x20 security/selinux/hooks.c:5605

CPU: 0 PID: 25750 Comm: syz-executor416 Not tainted 5.16.0-rc2-syzk #1 Hardware name: Red Hat KVM, BIOS
Call Trace:
<TASK>
__dump_stack lib/dump_stack.c:88 [inline]
dump_stack_lvl+0x89/0xb5 lib/dump_stack.c:106
print_address_description.constprop.9+0x28/0x160 mm/kasan/report.c:247 kasan_report_invalid_free+0x55/0x80 mm/kasan/report.c:372 ____kasan_slab_free mm/kasan/common.c:346 [inline] __kasan_slab_free+0x107/0x120 mm/kasan/common.c:374 kasan_slab_free include/linux/kasan.h:235 [inline] slab_free_hook mm/slub.c:1723 [inline]
slab_free_freelist_hook mm/slub.c:1749 [inline]
slab_free mm/slub.c:3513 [inline]
kfree+0xac/0x2d0 mm/slub.c:4561
selinux_tun_dev_free_security+0x1a/0x20 security/selinux/hooks.c:5605 security_tun_dev_free_security+0x4f/0x90 security/security.c:2342 tun_free_netdev+0xe6/0x150 drivers/net/tun.c:2215
netdev_run_todo+0x4df/0x840 net/core/dev.c:10627
rtnl_unlock+0x13/0x20 net/core/rtnetlink.c:112
__tun_chr_ioctl+0x80c/0x2870 drivers/net/tun.c:3302 tun_chr_ioctl+0x2f/0x40 drivers/net/tun.c:3311
vfs_ioctl fs/ioctl.c:51 [inline]
__do_sys_ioctl fs/ioctl.c:874 [inline]
__se_sys_ioctl fs/ioctl.c:860 [inline]
__x64_sys_ioctl+0x19d/0x220 fs/ioctl.c:860
do_syscall_x64 arch/x86/entry/common.c:50 [inline] do_syscall_64+0x3a/0x80 arch/x86/entry/common.c:80 entry_SYSCALL_64_after_hwframe+0x44/0xae

	Reported-by: syzkaller <syzkaller@googlegroups.com>
	Signed-off-by: George Kennedy <george.kennedy@oracle.com>
	Suggested-by: Jakub Kicinski <kuba@kernel.org>
Link: https://lore.kernel.org/r/1639679132-19884-1-git-send-email-george.kennedy@oracle.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 158b515f703e75e7d68289bf4d98c664e1d632df)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-l-8-c_4.18.0-425.13.1_VULN-8777-b1c585e82d95"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  HOSTCC  scripts/basic/bin2c
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  UPD     include/config/kernel.release
  UPD     include/generated/uapi/linux/version.h
  UPD     include/generated/utsrelease.h
  DESCEND objtool
  DESCEND bpf/resolve_btfids
  MKDIR     /home/brett/kernel-src-tree/tools/bpf/resolve_btfids//libbpf
  MKDIR     /home/brett/kernel-src-tree/tools/bpf/resolve_btfids//libsubcmd
  HOSTCC  /home/brett/kernel-src-tree/tools/objtool/fixdep.o
  HOSTCC  /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/fixdep.o
  GEN     /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/bpf_helper_defs.h
  HOSTLD  /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/fixdep-in.o
  HOSTLD  /home/brett/kernel-src-tree/tools/objtool/fixdep-in.o
  LINK    /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/fixdep
  LINK    /home/brett/kernel-src-tree/tools/objtool/fixdep
  MKDIR   /home/brett/kernel-src-tree/tools/objtool/arch/x86/lib/
  CC      /home/brett/kernel-src-tree/tools/objtool/builtin-check.o
  CC      /home/brett/kernel-src-tree/tools/objtool/builtin-orc.o
  CC      /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/main.o
  CC      /home/brett/kernel-src-tree/tools/objtool/check.o
  CC      /home/brett/kernel-src-tree/tools/objtool/orc_gen.o
  CC      /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/rbtree.o
  GEN     /home/brett/kernel-src-tree/tools/objtool/arch/x86/lib/inat-tables.c
  CC      /home/brett/kernel-src-tree/tools/objtool/orc_dump.o
  MKDIR   /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/
  CC      /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libsubcmd/exec-cmd.o
  CC      /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/libbpf.o
  MKDIR   /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/
  CC      /home/brett/kernel-src-tree/tools/bpf/resolve_btfids/libbpf/staticobjs/bpf.o
  CC      /home/brett/kernel-src-tree/tools/objtool/arch/x86/decode.o
  CC      /home/brett/kernel-src-tree/tools/objtool/exec-cmd.o

[SNIP]

  INSTALL sound/soc/intel/boards/snd-soc-sst-byt-cht-es8316.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-byt-cht-da7213.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-byt-cht-nocodec.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-bytcr-rt5640.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-bytcr-rt5651.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-cht-bsw-max98090_ti.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-cht-bsw-nau8824.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-cht-bsw-rt5645.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-cht-bsw-rt5672.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-glk-rt5682_max98357a.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-haswell.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-sof-pcm512x.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-sof-wm8804.ko
  INSTALL sound/soc/intel/catpt/snd-soc-catpt.ko
  INSTALL sound/soc/intel/common/snd-soc-acpi-intel-match.ko
  INSTALL sound/soc/intel/common/snd-soc-sst-dsp.ko
  INSTALL sound/soc/intel/common/snd-soc-sst-ipc.ko
  INSTALL sound/soc/intel/skylake/snd-soc-skl-ssp-clk.ko
  INSTALL sound/soc/intel/skylake/snd-soc-skl.ko
  INSTALL sound/soc/snd-soc-acpi.ko
  INSTALL sound/soc/snd-soc-core.ko
  INSTALL sound/soc/soc-topology-test.ko
  INSTALL sound/soc/sof/amd/snd-sof-amd-acp.ko
  INSTALL sound/soc/sof/intel/snd-sof-acpi-intel-bdw.ko
  INSTALL sound/soc/sof/amd/snd-sof-amd-renoir.ko
  INSTALL sound/soc/sof/intel/snd-sof-acpi-intel-byt.ko
  INSTALL sound/soc/sof/intel/snd-sof-intel-atom.ko
  INSTALL sound/soc/sof/intel/snd-sof-intel-hda-common.ko
  INSTALL sound/soc/sof/intel/snd-sof-intel-hda.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-apl.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-cnl.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-icl.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-tgl.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-tng.ko
  INSTALL sound/soc/sof/snd-sof-acpi.ko
  INSTALL sound/soc/sof/snd-sof-pci.ko
  INSTALL sound/soc/sof/snd-sof-utils.ko
  INSTALL sound/soc/sof/snd-sof-probes.ko
  INSTALL sound/soc/sof/snd-sof.ko
  INSTALL sound/soc/sof/xtensa/snd-sof-xtensa-dsp.ko
  INSTALL sound/soundcore.ko
  INSTALL sound/synth/emux/snd-emux-synth.ko
  INSTALL sound/synth/snd-util-mem.ko
  INSTALL sound/usb/6fire/snd-usb-6fire.ko
  INSTALL sound/usb/bcd2000/snd-bcd2000.ko
  INSTALL sound/usb/caiaq/snd-usb-caiaq.ko
  INSTALL sound/usb/hiface/snd-usb-hiface.ko
  INSTALL sound/usb/line6/snd-usb-line6.ko
  INSTALL sound/usb/line6/snd-usb-pod.ko
  INSTALL sound/usb/line6/snd-usb-podhd.ko
  INSTALL sound/usb/line6/snd-usb-toneport.ko
  INSTALL sound/usb/misc/snd-ua101.ko
  INSTALL sound/usb/line6/snd-usb-variax.ko
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-b_f-l-8-c_4.18.0-425.13.1_VULN-8777-b1c585e82d95+
[TIMER]{MODULES}: 14s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-b_f-l-8-c_4.18.0-425.13.1_VULN-8777-b1c585e82d95+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 105s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-b_f-l-8-c_4.18.0-425.13.1_VULN-8777-b1c585e82d95+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 988s
[TIMER]{MODULES}: 14s
[TIMER]{INSTALL}: 105s
[TIMER]{TOTAL} 1124s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the fix

[selftest-4.18.0-425.13.1.el8.ciqfipscompliant.39.1.x86_64.log](https://github.com/user-attachments/files/20371757/selftest-4.18.0-425.13.1.el8.ciqfipscompliant.39.1.x86_64.log)

[selftest-4.18.0-b_f-l-8-c_4.18.0-425.13.1_VULN-8777-b1c585e82d95+.log](https://github.com/user-attachments/files/20371759/selftest-4.18.0-b_f-l-8-c_4.18.0-425.13.1_VULN-8777-b1c585e82d95%2B.log)

```
brett@lycia ~/ciq/vuln-8777 % grep ^ok selftest-4.18.0-425.13.1.el8.ciqfipscompliant.39.1.x86_64.log | wc -l
214
brett@lycia ~/ciq/vuln-8777 % grep ^ok selftest-4.18.0-b_f-l-8-c_4.18.0-425.13.1_VULN-8777-b1c585e82d95+.log | wc -l
215
brett@lycia ~/ciq/vuln-8777 %

```