### PR TITLE
[LTS 8.6] net/ulp: use consistent error code when blocking ULP

### DIFF
--- a/net/ipv4/inet_connection_sock.c
+++ b/net/ipv4/inet_connection_sock.c
@@ -920,6 +920,7 @@ int inet_csk_listen_start(struct sock *sk, int backlog)
 	if (unlikely(err))
 		return err;
 
+	err = -EADDRINUSE;
 	reqsk_queue_alloc(&icsk->icsk_accept_queue);
 
 	sk->sk_ack_backlog = 0;

--- a/net/ipv4/tcp_ulp.c
+++ b/net/ipv4/tcp_ulp.c
@@ -131,7 +131,7 @@ static int __tcp_set_ulp(struct sock *sk, const struct tcp_ulp_ops *ulp_ops)
 	if (icsk->icsk_ulp_ops)
 		goto out_err;
 
-	err = -EINVAL;
+	err = -ENOTCONN;
 	if (!ulp_ops->clone && sk->sk_state == TCP_LISTEN)
 		goto out_err;
 


### PR DESCRIPTION
[LTS 8.6]
CVE-2023-0461
VULN-3655


# Problem

<https://www.cve.org/CVERecord?id=CVE-2023-0461>
> There is a use-after-free vulnerability in the Linux Kernel which can be exploited to achieve local privilege escalation. To reach the vulnerability kernel configuration flag CONFIG\_TLS or CONFIG\_XFRM\_ESPINTCP has to be configured, but the operation does not require any privilege. There is a use-after-free bug of icsk\_ulp\_data of a struct inet\_connection\_sock. When CONFIG\_TLS is enabled, user can install a tls context (struct tls\_context) on a connected tcp socket. The context is not cleared if this socket is disconnected and reused as a listener. If a new socket is created from the listener, the context is inherited and vulnerable. The setsockopt TCP\_ULP operation does not require any privilege. We recommend upgrading past commit 2c02d41d71f90a5168391b6a5f2954112ba2307c


# Applicability

The `CONFIG_TLS` option mentioned as sufficient prerequisite for the bug is present in all configurations of `ciqlts8_6`:

    $ grep 'CONFIG_TLS\b' configs/kernel*.config

    configs/kernel-aarch64-debug.config:CONFIG_TLS=m
    configs/kernel-aarch64.config:CONFIG_TLS=m
    configs/kernel-ppc64le-debug.config:CONFIG_TLS=m
    configs/kernel-ppc64le.config:CONFIG_TLS=m
    configs/kernel-s390x-debug.config:CONFIG_TLS=m
    configs/kernel-s390x-zfcpdump.config:CONFIG_TLS=m
    configs/kernel-s390x.config:CONFIG_TLS=m
    configs/kernel-x86_64-debug.config:CONFIG_TLS=m
    configs/kernel-x86_64.config:CONFIG_TLS=m

However, CVE-2023-0461 has already been addressed for LTS 8.6 in the commit 68e4adc4d6d174f95e96100f60d0fb57d343f3dc, so this specific vulnerability should not apply to `ciqlts8_6` anymore. This PR was created nevertheless to close some gaps and finish the patch. See below.


# Analysis and solution


## Assessment

The patch is given in mainline in 2c02d41d71f90a5168391b6a5f2954112ba2307c commit. It was backported onto 7 stable branches which, along with the mainline, can be categorized into 3 groups based on their diffs

-   Solution A
    
    <table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
    
    
    <colgroup>
    <col  class="org-left" />
    
    <col  class="org-right" />
    </colgroup>
    <tbody>
    <tr>
    <td class="org-left">b689125d04949841337dfa730d48dd91ada9ce3a</td>
    <td class="org-right">4.14</td>
    </tr>
    
    
    <tr>
    <td class="org-left">755193f2523ce5157c2f844a4b6d16b95593f830</td>
    <td class="org-right">4.19</td>
    </tr>
    
    
    <tr>
    <td class="org-left">c6d29a5ffdbc362314853462a0e24e63330a654d</td>
    <td class="org-right">5.4</td>
    </tr>
    </tbody>
    </table>
-   Solution B
    
    <table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
    
    
    <colgroup>
    <col  class="org-left" />
    
    <col  class="org-right" />
    </colgroup>
    <tbody>
    <tr>
    <td class="org-left">f8ed0a93b5d576bbaf01639ad816473bdfd1dcb0</td>
    <td class="org-right">5.10</td>
    </tr>
    
    
    <tr>
    <td class="org-left">dadd0dcaa67d27f550131de95c8e182643d2c9d6</td>
    <td class="org-right">5.15</td>
    </tr>
    </tbody>
    </table>
-   Solution C
    
    <table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
    
    
    <colgroup>
    <col  class="org-left" />
    
    <col  class="org-right" />
    </colgroup>
    <tbody>
    <tr>
    <td class="org-left">c1b5dee463cc1e89cfa655d6beff81ec1c0c4258</td>
    <td class="org-right">6.0</td>
    </tr>
    
    
    <tr>
    <td class="org-left">7d242f4a0c8319821548c7176c09a6e0e71f223c</td>
    <td class="org-right">6.1</td>
    </tr>
    
    
    <tr>
    <td class="org-left">2c02d41d71f90a5168391b6a5f2954112ba2307c</td>
    <td class="org-right">6.2</td>
    </tr>
    </tbody>
    </table>

Additionally, the patch is present in Rocky Linux for (at least) 4 versions LTS 8.6, LTS 8.8, LTS 9.2, LTS 9.4, contained in 3 commits, each representing a class in itself.

-   Solution D
    
    <table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
    
    
    <colgroup>
    <col  class="org-left" />
    
    <col  class="org-left" />
    </colgroup>
    <tbody>
    <tr>
    <td class="org-left">68e4adc4d6d174f95e96100f60d0fb57d343f3dc</td>
    <td class="org-left">LTS 8.6 (4.18)</td>
    </tr>
    </tbody>
    </table>
-   Solution E
    
    <table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
    
    
    <colgroup>
    <col  class="org-left" />
    
    <col  class="org-left" />
    </colgroup>
    <tbody>
    <tr>
    <td class="org-left">f950f23fcd8c49d16880942a3edfb9bdf36b66ef</td>
    <td class="org-left">LTS 8.8 (4.18)</td>
    </tr>
    </tbody>
    </table>
-   Solution F
    
    <table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">
    
    
    <colgroup>
    <col  class="org-left" />
    
    <col  class="org-left" />
    </colgroup>
    <tbody>
    <tr>
    <td class="org-left">0fd4c51c87a8b01d87b2d16cb82530669f086468</td>
    <td class="org-left">LTS 9.2 (5.14), LTS 9.4</td>
    </tr>
    </tbody>
    </table>

The differences occur along four axes:

-   **W:** `inet_ulp_can_listen` function definition
    -   **1:** Lack of `icsk->icsk_ulp_ops->clone` in the condition check 
        
            static int inet_ulp_can_listen(const struct sock *sk)
            {
            	const struct inet_connection_sock *icsk = inet_csk(sk);
            
            	if (icsk->icsk_ulp_ops)
            		return -EINVAL;
            
            	return 0;
            }
    
    -   **2:** Inclusion of `icsk->icsk_ulp_ops->clone` in the condition check
        
            static int inet_ulp_can_listen(const struct sock *sk)
            {
            	const struct inet_connection_sock *icsk = inet_csk(sk);
            
            	if (icsk->icsk_ulp_ops && !icsk->icsk_ulp_ops->clone)
            		return -EINVAL;
            
            	return 0;
            }

-   **X:** `net/ipv4/tcp_ulp.c` file modification
    -   **1:** No modification
    
    -   **2:** The `EINVAL` version
        
            err = -EINVAL;
            if (!ulp_ops->clone && sk->sk_state == TCP_LISTEN)
            	goto out_err;
    
    -   **3:** The `ENOTCONN` version
        
            err = -ENOTCONN;
            if (!ulp_ops->clone && sk->sk_state == TCP_LISTEN)
            	goto out_err;

-   **Y:** Initialization of `err` in `inet_csk_listen_start`
    -   **1:** De-initialization
        
        From
        
            int err = -EADDRINUSE;
        
        to 
        
            int err;
    
    -   **2:** Left as-is: uninitialized
        
            int err;
    
    -   **3:** Left as-is: initialized to `-EADDRINUSE`
        
            int err = -EADDRINUSE;

-   **Z:** Restoration of `err` to `-EADDRINUSE` after checking `inet_ulp_can_listen`
    -   **1:** No
        
            err = inet_ulp_can_listen(sk);
            if (unlikely(err))
            	return err;
    
    -   **2:** Yes
        
            err = inet_ulp_can_listen(sk);
            if (unlikely(err))
            	return err;
            
            err = -EADDRINUSE;

The patch points are spaced as follows:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-right" />

<col  class="org-right" />

<col  class="org-right" />

<col  class="org-right" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">&#xa0;</th>
<th scope="col" class="org-right">W</th>
<th scope="col" class="org-right">X</th>
<th scope="col" class="org-right">Y</th>
<th scope="col" class="org-right">Z</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">A</td>
<td class="org-right">1</td>
<td class="org-right">1</td>
<td class="org-right">1</td>
<td class="org-right">1</td>
</tr>


<tr>
<td class="org-left">B</td>
<td class="org-right">2</td>
<td class="org-right">2</td>
<td class="org-right">1</td>
<td class="org-right">1</td>
</tr>


<tr>
<td class="org-left">C</td>
<td class="org-right">2</td>
<td class="org-right">2</td>
<td class="org-right">2</td>
<td class="org-right">1</td>
</tr>


<tr>
<td class="org-left">D</td>
<td class="org-right">2</td>
<td class="org-right">2</td>
<td class="org-right">3</td>
<td class="org-right">1</td>
</tr>


<tr>
<td class="org-left">E</td>
<td class="org-right">2</td>
<td class="org-right">3</td>
<td class="org-right">3</td>
<td class="org-right">2</td>
</tr>


<tr>
<td class="org-left">F</td>
<td class="org-right">2</td>
<td class="org-right">2</td>
<td class="org-right">3</td>
<td class="org-right">1</td>
</tr>
</tbody>
</table>


## Discussion

1.  The **W** is somewhat correlated with **X**: upstream versions 4.14-5.4 simply lack the `clone` operation in ulp\_ops, so it doesn't make sense to check for it and **W1** goes with **X1** for **A** - compare `tcp_ulp_ops` [definition](https://github.com/ctrliq/kernel-src-tree/blob/755193f2523ce5157c2f844a4b6d16b95593f830/include/net/tcp.h#L2097) from 755193f2523ce5157c2f844a4b6d16b95593f830 (4.19) with the [same struct](https://github.com/ctrliq/kernel-src-tree/blob/f8ed0a93b5d576bbaf01639ad816473bdfd1dcb0/include/net/tcp.h#L2193) in f8ed0a93b5d576bbaf01639ad816473bdfd1dcb0 (5.10). What's interesting, however, is that Rocky LTS 8.6, despite being 4.18, **does** [contain](https://github.com/ctrliq/kernel-src-tree/blob/8e48e58d5ed4da205203094a4713695aa2a5bf88/include/net/tcp.h#L2147) the `clone` ULP operation just like newer versions. (Perhaps it was backported by RedHat)
2.  Initialization of `err` (**Y3**) is pointless in any case where it occurs, as the variable is assigned `inet_ulp_can_listen(sk)` in the very next line. That was probably the reason for choosing **Y1** in official backports for pre-6.0 versions (groups **A**, **B**).
3.  The restoration of `err` to `-EADDRINUSE` (axis **Z**), however, is **not** pointless in the pre-6.0 versions, including Rocky LTS 8.6 and LTS 8.8: a potential branching path exists which would result in the returned `err` different than before the change, for the exact same inputs. While effectively ignoring the initialization of `err` to `-EADDRINUSE` was justified in upstream mainline because of the inevitable assignment at [line 1237](https://github.com/ctrliq/kernel-src-tree/blob/2c02d41d71f90a5168391b6a5f2954112ba2307c/net/ipv4/inet_connection_sock.c#L1237), the same cannot be done in the earlier versions as the initial `-EADDRINUSE` can survive in `err` up to its return from the function.
4.  The use of `-ENOTCONN` instead of `-EINVAL` (**X2** vs **X1**) is the result of applying commit 8ccc99362b60c6f27bb46f36fdaaccf4ef0303de, which was a follow-up of the mainline CVE fix 2c02d41d71f90a5168391b6a5f2954112ba2307c:
    
        The referenced commit changed the error code returned by the kernel
        when preventing a non-established socket from attaching the ktls
        ULP. Before to such a commit, the user-space got ENOTCONN instead
        of EINVAL.
        
        The existing self-tests depend on such error code, and the change
        caused a failure:
        
          RUN           global.non_established ...
         tls.c:1673:non_established:Expected errno (22) == ENOTCONN (107)
         non_established: Test failed at step #3
                  FAIL  global.non_established


## Conclusions and solution

1.  The CVE-2023-0461 fix for LTS 8.6 should include the restoration of `err` to `-EADDRINUSE` (**D**: **Z1** → **Z2**)just as it's done in LTS 8.8 (**E**: **Z2**). For the versions 9.2, 9.4 this is not required. Unless there is some reason going beyond the analysis local to the `inet_csk_listen_start` function this should probably be done to groups **A**, **B** as well, although that's outside of scope.
2.  The CVE-2023-0461 patch for LTS 8.6 should include the fix-of-the-fix 8ccc99362b60c6f27bb46f36fdaaccf4ef0303de, again, the same as it's done in LTS 8.8. **The versions LTS 9.2, LTS 9.4 should be changed as well**.
3.  The inclusion of `clone` operation checking is done properly in LTS 8.6 and should be left as it is, despite its deviation from the upstream backports.
4.  The initialization of `err` to `-EADDRINUSE` in all Rocky versions 8.6-9.4 can be left as is - it's harmless.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-2023-0461 ./ninja.sh _kabi_checked__$(uname -m)--test--ciqlts8_6-CVE-2023-0461

    [1/2] Check ABI of kernel [ciqlts8_6-CVE-2023-0461]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2023-0461/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2023-0461/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20372128/boot-test.log>)


# Kselftests: passed relative


## Coverage

`android`, `bpf` (except `test_xsk.sh`, `test_sockmap`, `test_progs-no_alu32`, `test_kmod.sh`, `test_progs`), `breakpoints`, `capabilities`, `core`, `cpu-hotplug`, `cpufreq`, `efivarfs`, `exec`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kexec`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `net/forwarding` (except `mirror_gre_vlan_bridge_1q.sh`, `tc_actions.sh`, `sch_tbf_prio.sh`, `sch_tbf_ets.sh`, `sch_tbf_root.sh`, `ipip_hier_gre_keys.sh`, `mirror_gre_bridge_1d_vlan.sh`, `sch_ets.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `udpgro_fwd.sh`, `ip_defrag.sh`, `txtimestamp.sh`, `udpgso_bench.sh`, `xfrm_policy.sh`, `reuseport_addr_any.sh`, `gro.sh`, `reuseaddr_conflict`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `proc`, `pstore`, `ptrace`, `rseq`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `tc-testing`, `timens`, `timers` (except `raw_skew`), `tpm2`, `vm`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/20372125/kselftests--ciqlts8_6--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/20372122/kselftests--ciqlts8_6--run2.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run3.log](<https://github.com/user-attachments/files/20372119/kselftests--ciqlts8_6--run3.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run4.log](<https://github.com/user-attachments/files/20372116/kselftests--ciqlts8_6--run4.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2023-0461&#x2013;run1.log](<https://github.com/user-attachments/files/20372114/kselftests--ciqlts8_6-CVE-2023-0461--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2023-0461&#x2013;run2.log](<https://github.com/user-attachments/files/20372112/kselftests--ciqlts8_6-CVE-2023-0461--run2.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2023-0461&#x2013;run3.log](<https://github.com/user-attachments/files/20372108/kselftests--ciqlts8_6-CVE-2023-0461--run3.log>)


## Comparison

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ---------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6--run2.log
    Status2   kselftests--ciqlts8_6--run3.log
    Status3   kselftests--ciqlts8_6--run4.log
    Status4   kselftests--ciqlts8_6-CVE-2023-0461--run1.log
    Status5   kselftests--ciqlts8_6-CVE-2023-0461--run2.log
    Status6   kselftests--ciqlts8_6-CVE-2023-0461--run3.log
    
    TestCase  Status0  Status1  Status2  Status3  Status4  Status5  Status6  Summary
    net:tls   fail     fail     fail     fail     pass     pass     pass     diff

The difference in test results showcase what was mentioned in the 8ccc99362b60c6f27bb46f36fdaaccf4ef0303de commit - the `net:tls` test is now passing.

    $ ktests.xsh show_groups kselftests*.log --test net:tls

    kselftests--ciqlts8_6--run1.log:
    kselftests--ciqlts8_6--run2.log:
    kselftests--ciqlts8_6--run3.log:
    kselftests--ciqlts8_6--run4.log:
    net:tls:
    …
    # #  RUN           global.non_established ...
    # # tls.c:1195:non_established:Expected errno (22) == ENOTCONN (107)
    # # non_established: Test failed at step #2
    # #          FAIL  global.non_established
    …
    # # FAILED: 90 / 91 tests passed.
    # # Totals: pass:90 fail:1 xfail:0 xpass:0 skip:0 error:0
    not ok 1 selftests: net: tls # exit=1
    
    
    kselftests--ciqlts8_6-CVE-2023-0461--run1.log:
    kselftests--ciqlts8_6-CVE-2023-0461--run2.log:
    kselftests--ciqlts8_6-CVE-2023-0461--run3.log:
    net:tls:
    …
    # #  RUN           global.non_established ...
    # #            OK  global.non_established
    # ok 1 global.non_established
    …
    # # PASSED: 91 / 91 tests passed.
    # # Totals: pass:91 fail:0 xfail:0 xpass:0 skip:0 error:0
    ok 1 selftests: net: tls


# Specific tests: skipped

