### PR TITLE
[lts-8.8] net/sched: cls_u32: Fix reference counter leak leading to overflow

### DIFF
--- a/net/sched/cls_u32.c
+++ b/net/sched/cls_u32.c
@@ -720,12 +720,18 @@ static int u32_set_parms(struct net *net, struct tcf_proto *tp,
 			 struct nlattr *est, u32 flags, u32 fl_flags,
 			 struct netlink_ext_ack *extack)
 {
-	int err;
+	int err, ifindex = -1;
 
 	err = tcf_exts_validate_ex(net, tp, tb, est, &n->exts, flags,
 				   fl_flags, extack);
 	if (err < 0)
 		return err;
+
+	if (tb[TCA_U32_INDEV]) {
+		ifindex = tcf_change_indev(net, tb[TCA_U32_INDEV], extack);
+		if (ifindex < 0)
+			return -EINVAL;
+	}
 
 	if (tb[TCA_U32_LINK]) {
 		u32 handle = nla_get_u32(tb[TCA_U32_LINK]);
@@ -761,13 +767,9 @@ static int u32_set_parms(struct net *net, struct tcf_proto *tp,
 		tcf_bind_filter(tp, &n->res, base);
 	}
 
-	if (tb[TCA_U32_INDEV]) {
-		int ret;
-		ret = tcf_change_indev(net, tb[TCA_U32_INDEV], extack);
-		if (ret < 0)
-			return -EINVAL;
-		n->ifindex = ret;
-	}
+	if (ifindex >= 0)
+		n->ifindex = ifindex;
+
 	return 0;
 }
 


### PR DESCRIPTION
jira VULN-6545
cve CVE-2023-3609
```
commit-author Lee Jones <lee@kernel.org>
commit 04c55383fa5689357bcdd2c8036725a55ed632bc

In the event of a failure in tcf_change_indev(), u32_set_parms() will immediately return without decrementing the recently incremented reference counter.  If this happens enough times, the counter will rollover and the reference freed, leading to a double free which can be used to do 'bad things'.

In order to prevent this, move the point of possible failure above the point where the reference counter is incremented.  Also save any meaningful return values to be applied to the return data at the appropriate point in time.

This issue was caught with KASAN.

Fixes: 705c7091262d ("net: sched: cls_u32: no need to call tcf_exts_change for newly allocated struct")
	Suggested-by: Eric Dumazet <edumazet@google.com>
	Signed-off-by: Lee Jones <lee@kernel.org>
	Reviewed-by: Eric Dumazet <edumazet@google.com>
	Acked-by: Jamal Hadi Salim <jhs@mojatatu.com>
	Signed-off-by: David S. Miller <davem@davemloft.net>
(cherry picked from commit 04c55383fa5689357bcdd2c8036725a55ed632bc)
	Signed-off-by: David Gomez <dgomez@ciq.com>
```

# Build Log
```
INSTALL sound/soc/intel/boards/snd-skl_nau88l25_max98357a.ko
  INSTALL sound/soc/intel/boards/snd-soc-cml_rt1011_rt5682.ko
  INSTALL sound/soc/intel/boards/snd-soc-ehl-rt5660.ko
  INSTALL sound/soc/intel/boards/snd-soc-intel-hda-dsp-common.ko
  INSTALL sound/soc/intel/boards/snd-soc-intel-sof-cirrus-common.ko
  INSTALL sound/soc/intel/boards/snd-soc-intel-sof-maxim-common.ko
  INSTALL sound/soc/intel/boards/snd-soc-intel-sof-realtek-common.ko
  INSTALL sound/soc/intel/boards/snd-soc-kbl_da7219_max98357a.ko
  INSTALL sound/soc/intel/boards/snd-soc-kbl_da7219_max98927.ko
  INSTALL sound/soc/intel/boards/snd-soc-kbl_rt5663_max98927.ko
  INSTALL sound/soc/intel/boards/snd-soc-kbl_rt5660.ko
  INSTALL sound/soc/intel/boards/snd-soc-kbl_rt5663_rt5514_max98927.ko
  INSTALL sound/soc/intel/boards/snd-soc-skl_hda_dsp.ko
  INSTALL sound/soc/intel/boards/snd-soc-skl_nau88l25_ssm4567.ko
  INSTALL sound/soc/intel/boards/snd-soc-skl_rt286.ko
  INSTALL sound/soc/intel/boards/snd-soc-sof-sdw.ko
  INSTALL sound/soc/intel/boards/snd-soc-sof-ssp-amp.ko
  INSTALL sound/soc/intel/boards/snd-soc-sof_es8336.ko
  INSTALL sound/soc/intel/boards/snd-soc-sof_da7219_max98373.ko
  INSTALL sound/soc/intel/boards/snd-soc-sof_nau8825.ko
  INSTALL sound/soc/intel/boards/snd-soc-sof_rt5682.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-bdw-rt5677-mach.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-bdw-rt5650-mach.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-broadwell.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-bxt-da7219_max98357a.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-bxt-rt298.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-byt-cht-cx2072x.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-byt-cht-da7213.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-byt-cht-es8316.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-byt-cht-nocodec.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-bytcr-rt5640.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-bytcr-rt5651.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-cht-bsw-max98090_ti.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-cht-bsw-nau8824.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-cht-bsw-rt5645.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-cht-bsw-rt5672.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-glk-rt5682_max98357a.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-haswell.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-sof-pcm512x.ko
  INSTALL sound/soc/intel/boards/snd-soc-sst-sof-wm8804.ko
  INSTALL sound/soc/intel/catpt/snd-soc-catpt.ko
  INSTALL sound/soc/intel/common/snd-soc-acpi-intel-match.ko
  INSTALL sound/soc/intel/common/snd-soc-sst-dsp.ko
  INSTALL sound/soc/intel/common/snd-soc-sst-ipc.ko
  INSTALL sound/soc/intel/skylake/snd-soc-skl-ssp-clk.ko
  INSTALL sound/soc/intel/skylake/snd-soc-skl.ko
  INSTALL sound/soc/snd-soc-acpi.ko
  INSTALL sound/soc/snd-soc-core.ko
  INSTALL sound/soc/soc-topology-test.ko
  INSTALL sound/soc/sof/amd/snd-sof-amd-renoir.ko
  INSTALL sound/soc/sof/amd/snd-sof-amd-acp.ko
  INSTALL sound/soc/sof/intel/snd-sof-acpi-intel-bdw.ko
  INSTALL sound/soc/sof/intel/snd-sof-acpi-intel-byt.ko
  INSTALL sound/soc/sof/intel/snd-sof-intel-atom.ko
  INSTALL sound/soc/sof/intel/snd-sof-intel-hda-common.ko
  INSTALL sound/soc/sof/intel/snd-sof-intel-hda.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-apl.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-cnl.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-icl.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-mtl.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-tgl.ko
  INSTALL sound/soc/sof/intel/snd-sof-pci-intel-tng.ko
  INSTALL sound/soc/sof/snd-sof-acpi.ko
  INSTALL sound/soc/sof/snd-sof-pci.ko
  INSTALL sound/soc/sof/snd-sof-probes.ko
  INSTALL sound/soc/sof/snd-sof-utils.ko
  INSTALL sound/soc/sof/snd-sof.ko
  INSTALL sound/soc/sof/xtensa/snd-sof-xtensa-dsp.ko
  INSTALL sound/soundcore.ko
  INSTALL sound/synth/emux/snd-emux-synth.ko
  INSTALL sound/synth/snd-util-mem.ko
  INSTALL sound/usb/6fire/snd-usb-6fire.ko
  INSTALL sound/usb/bcd2000/snd-bcd2000.ko
  INSTALL sound/usb/caiaq/snd-usb-caiaq.ko
  INSTALL sound/usb/hiface/snd-usb-hiface.ko
  INSTALL sound/usb/line6/snd-usb-line6.ko
  INSTALL sound/usb/line6/snd-usb-pod.ko
  INSTALL sound/usb/line6/snd-usb-podhd.ko
  INSTALL sound/usb/line6/snd-usb-toneport.ko
  INSTALL sound/usb/line6/snd-usb-variax.ko
  INSTALL sound/usb/misc/snd-ua101.ko
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a+
[TIMER]{MODULES}: 26s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 52s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a+ and Index to 0
The default is /boot/loader/entries/f2dde3625a8a4ca4ae5b8dbf8ac1890a-4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a+.conf with index 0 and kernel /boot/vmlinuz-4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a+
The default is /boot/loader/entries/f2dde3625a8a4ca4ae5b8dbf8ac1890a-4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a+.conf with index 0 and kernel /boot/vmlinuz-4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a+
Generating grub configuration file ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 25s
[TIMER]{BUILD}: 4800s
[TIMER]{MODULES}: 26s
[TIMER]{INSTALL}: 52s
[TIMER]{TOTAL} 4916s
```

# Testing
[4.18.0-477.27.1.el8_8.88ciq_lts.5.2.x86_64.log](https://github.com/user-attachments/files/20401861/4.18.0-477.27.1.el8_8.88ciq_lts.5.2.x86_64.log)
[4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a+.log](https://github.com/user-attachments/files/20401862/4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a%2B.log)
```
$ grep ^ok 4.18.0-477.27.1.el8_8.88ciq_lts.5.2.x86_64.log | wc -l
197
$ grep ^ok 4.18.0-dgomez-ciqlts8_8_VULN-6545-9d73d909329a+.log | wc -l
200
```

# Related PRs
https://github.com/ctrliq/kernel-src-tree/pull/274
https://github.com/ctrliq/kernel-src-tree/pull/278