### PR TITLE
[LTS 8.6] tipc: fix UAF in error path

### DIFF
--- a/net/tipc/msg.c
+++ b/net/tipc/msg.c
@@ -162,6 +162,11 @@ int tipc_buf_append(struct sk_buff **headbuf, struct sk_buff **buf)
 	if (!head)
 		goto err;
 
+	/* Either the input skb ownership is transferred to headskb
+	 * or the input skb is freed, clear the reference to avoid
+	 * bad access on error path.
+	 */
+	*buf = NULL;
 	if (skb_try_coalesce(head, frag, &headstolen, &delta)) {
 		kfree_skb_partial(frag, headstolen);
 	} else {
@@ -185,7 +190,6 @@ int tipc_buf_append(struct sk_buff **headbuf, struct sk_buff **buf)
 		*headbuf = NULL;
 		return 1;
 	}
-	*buf = NULL;
 	return 0;
 err:
 	kfree_skb(*buf);


### PR DESCRIPTION
[LTS 8.6]
CVE-2024-36886
VULN-5314


# Problem

<https://www.zerodayinitiative.com/advisories/ZDI-24-821/>

> This vulnerability allows remote attackers to execute arbitrary code on affected installations of Linux Kernel. Authentication is not required to exploit this vulnerability, but only systems with TIPC bearer enabled are vulnerable.

> The specific flaw exists within the processing of fragmented TIPC messages. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the kernel.


# Applicability

The vulnerability applies to `ciqlts8_6` as the `tipc` module is enabled:

`configs/kernel-x86_64.config`:

    CONFIG_TIPC=m
    CONFIG_TIPC_CRYPTO=y
    CONFIG_TIPC_DIAG=m
    CONFIG_TIPC_MEDIA_IB=y
    CONFIG_TIPC_MEDIA_UDP=y


# Solution

The bugfix is given in 080cbb890286cd794f1ee788bbc5463e2deb7c2b in the mainline. Applies to `ciqlts8_6` without any changes and surprises.


# kABI check: passed

    DEBUG=1 CVE=CVE-2024-36886 ./ninja.sh _kabi_checked__$(uname -m)--test--ciqlts8_6-CVE-2024-36886

    ninja: Entering directory `/data/build/rocky-patching'
    [0/1] Check ABI of kernel [ciqlts8_6-CVE-2024-36886]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2024-36886/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2024-36886/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20446460/boot-test.log>)


# Kselftests: passed relative


## Coverage

`android`, `bpf` (except `test_progs`, `test_kmod.sh`, `test_xsk.sh`, `test_progs-no_alu32`, `test_sockmap`), `breakpoints`, `capabilities`, `core`, `cpu-hotplug`, `cpufreq`, `efivarfs`, `exec`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kexec`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `net/forwarding` (except `mirror_gre_bridge_1d_vlan.sh`, `ipip_hier_gre_keys.sh`, `tc_actions.sh`, `sch_ets.sh`, `sch_tbf_root.sh`, `sch_tbf_ets.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_tbf_prio.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `udpgso_bench.sh`, `ip_defrag.sh`, `reuseaddr_conflict`, `udpgro_fwd.sh`, `gro.sh`, `xfrm_policy.sh`, `reuseport_addr_any.sh`, `txtimestamp.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `proc`, `pstore`, `ptrace`, `rseq`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `tc-testing`, `timens`, `timers` (except `raw_skew`), `tpm2`, `vm`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/20446456/kselftests--ciqlts8_6--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/20446455/kselftests--ciqlts8_6--run2.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run3.log](<https://github.com/user-attachments/files/20446454/kselftests--ciqlts8_6--run3.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2024-36886&#x2013;run1.log](<https://github.com/user-attachments/files/20446723/kselftests--ciqlts8_6-CVE-2024-36886--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2024-36886&#x2013;run2.log](<https://github.com/user-attachments/files/20446722/kselftests--ciqlts8_6-CVE-2024-36886--run2.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2024-36886&#x2013;run3.log](<https://github.com/user-attachments/files/20446721/kselftests--ciqlts8_6-CVE-2024-36886--run3.log>)


## Comparison

Test results for the reference and patch are the same.

    ./ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6--run2.log
    Status2   kselftests--ciqlts8_6--run3.log
    Status3   kselftests--ciqlts8_6-CVE-2024-36886--run1.log
    Status4   kselftests--ciqlts8_6-CVE-2024-36886--run2.log
    Status5   kselftests--ciqlts8_6-CVE-2024-36886--run3.log

To be fair there isn't any selftest even mentioning `tipc`, let alone testing it.

    grep -R tools/testing/selftests -i -e tipc; echo $?

    1


# Specific tests: dropped

The RedHat bug page <https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2024-36886> mentions what seems to be a discussion fragment between sam4k and someone from kernel.org:

> Summary:
> A UAF bug exists within the reassembly of fragmented TIPC messages, specifically in \`tipc\_buf\_append()\` function. The issue results due to a lack of checks in the error handling cleanup. It leads to UAF on \`struct sk\_buff\`. Note: The vulnerable path can also be reached in a very similar manner via \`TUNNEL\_PROTOCOL\` messages
> 
> The bug can be triggered in local without any permission and capability:
> 
> ./poc "127.0.0.1" l
> 
> The victim requires the below config on ubuntu in order to trigger it remotely. This enables the TIPC bearer on the interface:
> \`\`\`
> modprobe tipc
> tipc bearer enable media udp name UDP1 localip [victim IP]
> ./poc "[victim IP]" r
> \`\`\`
> 
> References:
> <https://lore.kernel.org/all/752f1ccf762223d109845365d07f55414058e5a3.1714484273.git.pabeni@redhat.com/>
> <https://lore.kernel.org/linux-cve-announce/2024053033-CVE-2024-36886-dd83@gregkh/T/#u>

An attempt was made to get this `poc` program for testing purposes. This led to finding sam4k's blog page dedicated to this very CVE: <https://sam4k.com/zdi-24-821-a-remote-use-after-free-in-the-kernels-net-tipc/>. Although the article covers every possible technical detail the key element is missing 

> Exploitation
>
> Unfortunately I haven't had the time to work on putting together an exploit for this vulnerability, though I'd love to set some time aside in the future. Sorry! :( 

If it can't be found there it's probably not on clearnet anywhere.

