### PR TITLE
[LTS 8.8] tipc: fix UAF in error path

### DIFF
--- a/net/tipc/msg.c
+++ b/net/tipc/msg.c
@@ -162,6 +162,11 @@ int tipc_buf_append(struct sk_buff **headbuf, struct sk_buff **buf)
 	if (!head)
 		goto err;
 
+	/* Either the input skb ownership is transferred to headskb
+	 * or the input skb is freed, clear the reference to avoid
+	 * bad access on error path.
+	 */
+	*buf = NULL;
 	if (skb_try_coalesce(head, frag, &headstolen, &delta)) {
 		kfree_skb_partial(frag, headstolen);
 	} else {
@@ -185,7 +190,6 @@ int tipc_buf_append(struct sk_buff **headbuf, struct sk_buff **buf)
 		*headbuf = NULL;
 		return 1;
 	}
-	*buf = NULL;
 	return 0;
 err:
 	kfree_skb(*buf);


### PR DESCRIPTION
[LTS 8.8]
CVE-2024-36886
VULN-5316


# Problem

<https://www.zerodayinitiative.com/advisories/ZDI-24-821/>

> This vulnerability allows remote attackers to execute arbitrary code on affected installations of Linux Kernel. Authentication is not required to exploit this vulnerability, but only systems with TIPC bearer enabled are vulnerable. 
> The specific flaw exists within the processing of fragmented TIPC messages. The issue results from the lack of validating the existence of an object prior to performing operations on the object. An attacker can leverage this vulnerability to execute code in the context of the kernel.


# Applicability

The vulnerability applies to `ciqlts8_8` as the `tipc` module is enabled:

`configs/kernel-x86_64.config`:

    CONFIG_TIPC=m
    CONFIG_TIPC_CRYPTO=y
    CONFIG_TIPC_DIAG=m
    CONFIG_TIPC_MEDIA_IB=y
    CONFIG_TIPC_MEDIA_UDP=y


# Solution

The bugfix is given in 080cbb890286cd794f1ee788bbc5463e2deb7c2b in the mainline. Applies to `ciqlts8_8` without any changes or surprises.


# kABI check: passed

    DEBUG=1 CVE=CVE-2024-36886 ./ninja.sh _kabi_checked__$(uname -m)--test--ciqlts8_8-CVE-2024-36886

    [0/1] Check ABI of kernel [ciqlts8_8-CVE-2024-36886]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_8/build_files/kernel-src-tree-ciqlts8_8-CVE-2024-36886/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_8-CVE-2024-36886/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20446698/boot-test.log>)


# Kselftests: passed relative


## Coverage

`android`, `bpf` (except `test_xsk.sh`, `test_progs`, `test_progs-no_alu32`, `test_sockmap`, `test_kmod.sh`), `breakpoints`, `capabilities`, `cgroup`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/net/bonding`, `drivers/net/team`, `efivarfs`, `exec`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kexec`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `mqueue`, `net/forwarding` (except `tc_actions.sh`, `sch_tbf_prio.sh`, `sch_ets.sh`, `mirror_gre_bridge_1d_vlan.sh`, `sch_tbf_ets.sh`, `sch_tbf_root.sh`, `mirror_gre_vlan_bridge_1q.sh`, `ipip_hier_gre_keys.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `ip_defrag.sh`, `udpgro_fwd.sh`, `udpgso_bench.sh`, `xfrm_policy.sh`, `gro.sh`, `reuseaddr_conflict`, `reuseport_addr_any.sh`, `txtimestamp.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `pstore`, `ptrace`, `rseq`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `tc-testing`, `tdx`, `timens`, `timers` (except `raw_skew`), `tpm2`, `vm`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts8\_8&#x2013;run1.log](<https://github.com/user-attachments/files/20446694/kselftests--ciqlts8_8--run1.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run2.log](<https://github.com/user-attachments/files/20446693/kselftests--ciqlts8_8--run2.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run3.log](<https://github.com/user-attachments/files/20446691/kselftests--ciqlts8_8--run3.log>)


## Patch

[kselftests&#x2013;ciqlts8\_8-CVE-2024-36886&#x2013;run3.log](<https://github.com/user-attachments/files/20446714/kselftests--ciqlts8_8-CVE-2024-36886--run3.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2024-36886&#x2013;run2.log](<https://github.com/user-attachments/files/20446715/kselftests--ciqlts8_8-CVE-2024-36886--run2.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2024-36886&#x2013;run1.log](<https://github.com/user-attachments/files/20446716/kselftests--ciqlts8_8-CVE-2024-36886--run1.log>)


## Comparison

Test results for the reference and patch are the same.

    ./ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_8--run1.log
    Status1   kselftests--ciqlts8_8--run2.log
    Status2   kselftests--ciqlts8_8--run3.log
    Status3   kselftests--ciqlts8_8-CVE-2024-36886--run1.log
    Status4   kselftests--ciqlts8_8-CVE-2024-36886--run2.log
    Status5   kselftests--ciqlts8_8-CVE-2024-36886--run3.log

To be fair there isn't any selftest even mentioning `tipc`, let alone testing it.

    grep -R tools/testing/selftests -i -e tipc; echo $?

    1


# Specific tests: dropped

See the respective section at <https://github.com/ctrliq/kernel-src-tree/pull/291>.

