### PR TITLE
[fips-8] tun: add missing verification for short frame

### DIFF
--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -2480,6 +2480,9 @@ static int tun_xdp_one(struct tun_struct *tun,
 	bool skb_xdp = false;
 	struct page *page;
 
+	if (unlikely(datasize < ETH_HLEN))
+		return -EINVAL;
+
 	xdp_prog = rcu_dereference(tun->xdp_prog);
 	if (xdp_prog) {
 		if (gso->gso_type) {


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-9004
cve CVE-2024-41091
commit-author Dongli Zhang <dongli.zhang@oracle.com> commit 049584807f1d797fc3078b68035450a9769eb5c3

The cited commit missed to check against the validity of the frame length in the tun_xdp_one() path, which could cause a corrupted skb to be sent downstack. Even before the skb is transmitted, the tun_xdp_one-->eth_type_trans() may access the Ethernet header although it can be less than ETH_HLEN. Once transmitted, this could either cause out-of-bound access beyond the actual length, or confuse the underlayer with incorrect or inconsistent header length in the skb metadata.

In the alternative path, tun_get_user() already prohibits short frame which has the length less than Ethernet header size from being transmitted for IFF_TAP.

This is to drop any frame shorter than the Ethernet header size just like how tun_get_user() does.

CVE: CVE-2024-41091
Inspired-by: https://lore.kernel.org/netdev/1717026141-25716-1-git-send-email-si-wei.liu@oracle.com/ Fixes: 043d222f93ab ("tuntap: accept an array of XDP buffs through sendmsg()")
	Cc: stable@vger.kernel.org
	Signed-off-by: Dongli Zhang <dongli.zhang@oracle.com>
	Reviewed-by: Si-Wei Liu <si-wei.liu@oracle.com>
	Reviewed-by: Willem de Bruijn <willemb@google.com>
	Reviewed-by: Paolo Abeni <pabeni@redhat.com>
	Reviewed-by: Jason Wang <jasowang@redhat.com>
Link: https://patch.msgid.link/20240724170452.16837-3-dongli.zhang@oracle.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 049584807f1d797fc3078b68035450a9769eb5c3)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ajain__fips-8-compliant_4.18.0-553.16.1-20f481bed"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  UPD     include/config/kernel.release
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  UPD     include/generated/uapi/linux/version.h
  UPD     include/generated/utsrelease.h
  DESCEND objtool
  HOSTCC  /home/anmol/kernel-src-tree/tools/objtool/fixdep.o
  HOSTLD  /home/anmol/kernel-src-tree/tools/objtool/fixdep-in.o
  LINK    /home/anmol/kernel-src-tree/tools/objtool/fixdep
  CC      /home/anmol/kernel-src-tree/tools/objtool/exec-cmd.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/help.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/pager.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/parse-options.o
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  CC      /home/anmol/kernel-src-tree/tools/objtool/run-command.o
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  CC      /home/anmol/kernel-src-tree/tools/objtool/sigchain.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/subcmd-config.o
  LD      /home/anmol/kernel-src-tree/tools/objtool/libsubcmd-in.o
  AR      /home/anmol/kernel-src-tree/tools/objtool/libsubcmd.a
  CC      /home/anmol/kernel-src-tree/tools/objtool/arch/x86/decode.o
  LD      /home/anmol/kernel-src-tree/tools/objtool/arch/x86/objtool-in.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/builtin-check.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/builtin-orc.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/check.o
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  DESCEND bpf/resolve_btfids
  [--snip--]
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-_ajain__fips-8-compliant_4.18.0-553.16.1-20f481bed+
[TIMER]{MODULES}: 21s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-_ajain__fips-8-compliant_4.18.0-553.16.1-20f481bed+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 32s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-_ajain__fips-8-compliant_4.18.0-553.16.1-20f481bed+ and Index to 1
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-_ajain__fips-8-compliant_4.18.0-553.16.1-20f481bed+.conf with index 1 and kernel /boot/vmlinuz-4.18.0-_ajain__fips-8-compliant_4.18.0-553.16.1-20f481bed+
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-_ajain__fips-8-compliant_4.18.0-553.16.1-20f481bed+.conf with index 1 and kernel /boot/vmlinuz-4.18.0-_ajain__fips-8-compliant_4.18.0-553.16.1-20f481bed+
Generating grub configuration file ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 3206s
[TIMER]{MODULES}: 21s
[TIMER]{INSTALL}: 32s
[TIMER]{TOTAL} 3262s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/20463562/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
220
220

$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
54
54
```
[kselftest-after.log](https://github.com/user-attachments/files/20463565/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/20463569/kselftest-before.log)



	