### PR TITLE
[LTS 8.8] igb: set max size RX buffer when store bad packet is enabled

### DIFF
--- a/drivers/net/ethernet/intel/igb/igb_main.c
+++ b/drivers/net/ethernet/intel/igb/igb_main.c
@@ -4733,6 +4733,10 @@ void igb_configure_rx_ring(struct igb_adapter *adapter,
 static void igb_set_rx_buffer_len(struct igb_adapter *adapter,
 				  struct igb_ring *rx_ring)
 {
+#if (PAGE_SIZE < 8192)
+	struct e1000_hw *hw = &adapter->hw;
+#endif
+
 	/* set build_skb and buffer size flags */
 	clear_ring_build_skb_enabled(rx_ring);
 	clear_ring_uses_large_buffer(rx_ring);
@@ -4743,10 +4747,9 @@ static void igb_set_rx_buffer_len(struct igb_adapter *adapter,
 	set_ring_build_skb_enabled(rx_ring);
 
 #if (PAGE_SIZE < 8192)
-	if (adapter->max_frame_size <= IGB_MAX_FRAME_BUILD_SKB)
-		return;
-
-	set_ring_uses_large_buffer(rx_ring);
+	if (adapter->max_frame_size > IGB_MAX_FRAME_BUILD_SKB ||
+	    rd32(E1000_RCTL) & E1000_RCTL_SBP)
+		set_ring_uses_large_buffer(rx_ring);
 #endif
 }
 


### PR DESCRIPTION
[LTS 8.8]
CVE-2023-45871
VULN-6695


# Problem

From the company which discovered the bug:

<https://www.omicronenergy.com/download/file/5ddf37266b0d79a7ba5818893202d9c1/>

> Linux Kernel vulnerability CVE-2023-45871 allows an attacker to cause memory corruption in the network driver of the \*BX device by sending special crafted network traffic. The behaviour of the system caused by memory corruption is highly unpredictable: the device is either restarted, processes crash, or a manual reboot is required.

The CVSS 3.1 scoring is somewhat inconsistent, ranging from 7.5 ([nist](https://nvd.nist.gov/vuln/detail/CVE-2023-45871)) to 9.8 (above).


# Applicability

The `igb` module is enabled in `ciqlts8_8`

`configs/kernel-x86_64.config`

    CONFIG_IGB=m
    CONFIG_IGBVF=m
    CONFIG_IGB_DCA=y
    CONFIG_IGB_HWMON=y


# Solution

The mainline fix is given in bb5ed01cd2428cd25b1c88a3a9cba87055eb289f. It was backported to [multiple](https://kernel.dance/#bb5ed01cd2428cd25b1c88a3a9cba87055eb289f) stable versions without any changes, as well as to CBR 7.9 in d3573f5e6728eeb253e7699913c0595126f65abe, LTS 8.6 in 6ef78b9735b1e61eafa3e198990c38f899dca28d and LTS 9.4 in aee509a6a4ce83b6ed49298b9ef82a1a69a91a17 (by RedHat). The commit applies to `ciqlts8_8` without any modifications as well.


# kABI check: passed

    DEBUG=1 CVE=CVE-2023-45871 ./ninja.sh _kabi_checked__$(uname -m)--test--ciqlts8_8-CVE-2023-45871

    [0/1] Check ABI of kernel [ciqlts8_8-CVE-2023-45871]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_8/build_files/kernel-src-tree-ciqlts8_8-CVE-2023-45871/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_8-CVE-2023-45871/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20491677/boot-test.log>)


# Kselftests: passed relative


## Coverage

`android`, `bpf` (except `test_progs`, `test_progs-no_alu32`, `test_xsk.sh`, `test_sockmap`, `test_kmod.sh`), `breakpoints`, `capabilities`, `cgroup`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/net/bonding`, `drivers/net/team`, `exec`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kexec`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `mqueue`, `net/forwarding` (except `mirror_gre_bridge_1d_vlan.sh`, `sch_tbf_root.sh`, `sch_tbf_ets.sh`, `sch_tbf_prio.sh`, `mirror_gre_vlan_bridge_1q.sh`, `tc_actions.sh`, `sch_ets.sh`, `ipip_hier_gre_keys.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `gro.sh`, `txtimestamp.sh`, `xfrm_policy.sh`, `ip_defrag.sh`, `udpgro_fwd.sh`, `reuseaddr_conflict`, `reuseport_addr_any.sh`, `udpgso_bench.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `pstore`, `ptrace`, `rseq`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `tc-testing`, `tdx`, `timens`, `timers` (except `raw_skew`), `tpm2`, `vm`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts8\_8&#x2013;run1.log](<https://github.com/user-attachments/files/20491675/kselftests--ciqlts8_8--run1.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run2.log](<https://github.com/user-attachments/files/20491673/kselftests--ciqlts8_8--run2.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run3.log](<https://github.com/user-attachments/files/20491671/kselftests--ciqlts8_8--run3.log>)


## Patch

[kselftests&#x2013;ciqlts8\_8-CVE-2023-45871&#x2013;run1.log](<https://github.com/user-attachments/files/20491669/kselftests--ciqlts8_8-CVE-2023-45871--run1.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2023-45871&#x2013;run2.log](<https://github.com/user-attachments/files/20491668/kselftests--ciqlts8_8-CVE-2023-45871--run2.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2023-45871&#x2013;run3.log](<https://github.com/user-attachments/files/20491667/kselftests--ciqlts8_8-CVE-2023-45871--run3.log>)


## Comparison

The test results for reference and patch are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_8--run1.log
    Status1   kselftests--ciqlts8_8--run2.log
    Status2   kselftests--ciqlts8_8--run3.log
    Status3   kselftests--ciqlts8_8-CVE-2023-45871--run1.log
    Status4   kselftests--ciqlts8_8-CVE-2023-45871--run2.log
    Status5   kselftests--ciqlts8_8-CVE-2023-45871--run3.log

Note that `igb` doesn't have any selftests defined.


# Specific tests: skipped

