### PR TITLE
[cbr79] ALSA: usb-audio: Fix out of bounds reads when finding clock sources

### DIFF
--- a/sound/usb/clock.c
+++ b/sound/usb/clock.c
@@ -35,6 +35,10 @@
 #include "clock.h"
 #include "quirks.h"
 
+/* check whether the descriptor bLength has the minimal length */
+#define DESC_LENGTH_CHECK(p) \
+	 (p->bLength >= sizeof(*p))
+
 static void *find_uac_clock_desc(struct usb_host_interface *iface, int id,
 				 bool (*validator)(void *, int), u8 type)
 {
@@ -52,36 +56,60 @@ static void *find_uac_clock_desc(struct usb_host_interface *iface, int id,
 static bool validate_clock_source_v2(void *p, int id)
 {
 	struct uac_clock_source_descriptor *cs = p;
+	if (!DESC_LENGTH_CHECK(cs))
+		return false;
 	return cs->bClockID == id;
 }
 
 static bool validate_clock_source_v3(void *p, int id)
 {
 	struct uac3_clock_source_descriptor *cs = p;
+	if (!DESC_LENGTH_CHECK(cs))
+		return false;
 	return cs->bClockID == id;
 }
 
 static bool validate_clock_selector_v2(void *p, int id)
 {
 	struct uac_clock_selector_descriptor *cs = p;
-	return cs->bClockID == id;
+	if (!DESC_LENGTH_CHECK(cs))
+		return false;
+	if (cs->bClockID != id)
+		return false;
+	/* additional length check for baCSourceID array (in bNrInPins size)
+	 * and two more fields (which sizes depend on the protocol)
+	 */
+	return cs->bLength >= sizeof(*cs) + cs->bNrInPins +
+		1 /* bmControls */ + 1 /* iClockSelector */;
 }
 
 static bool validate_clock_selector_v3(void *p, int id)
 {
 	struct uac3_clock_selector_descriptor *cs = p;
-	return cs->bClockID == id;
+	if (!DESC_LENGTH_CHECK(cs))
+		return false;
+	if (cs->bClockID != id)
+		return false;
+	/* additional length check for baCSourceID array (in bNrInPins size)
+	 * and two more fields (which sizes depend on the protocol)
+	 */
+	return cs->bLength >= sizeof(*cs) + cs->bNrInPins +
+		4 /* bmControls */ + 2 /* wCSelectorDescrStr */;
 }
 
 static bool validate_clock_multiplier_v2(void *p, int id)
 {
 	struct uac_clock_multiplier_descriptor *cs = p;
+	if (!DESC_LENGTH_CHECK(cs))
+		return false;
 	return cs->bClockID == id;
 }
 
 static bool validate_clock_multiplier_v3(void *p, int id)
 {
 	struct uac3_clock_multiplier_descriptor *cs = p;
+	if (!DESC_LENGTH_CHECK(cs))
+		return false;
 	return cs->bClockID == id;
 }
 


### PR DESCRIPTION
jira VULN-46526
cve CVE-2024-53150

This is slightly different than the other CVE-2024-53150 PRs.  Due to the age of this kernel I had to use the 5.4 stable backport version (which applied cleanly).

```
commit-author Takashi Iwai <tiwai@suse.de>
commit a3dd4d63eeb452cfb064a13862fb376ab108f6a6
upstream-diff used linux-stable LT-5.4 sha a632bdcb359fd8145e86486ff8612da98e239acd

The current USB-audio driver code doesn't check bLength of each descriptor at traversing for clock descriptors.  That is, when a device provides a bogus descriptor with a shorter bLength, the driver might hit out-of-bounds reads.

For addressing it, this patch adds sanity checks to the validator functions for the clock descriptor traversal.  When the descriptor length is shorter than expected, it's skipped in the loop.

For the clock source and clock multiplier descriptors, we can just check bLength against the sizeof() of each descriptor type. OTOH, the clock selector descriptor of UAC2 and UAC3 has an array of bNrInPins elements and two more fields at its tail, hence those have to be checked in addition to the sizeof() check.

	Reported-by: Benoît Sevens <bsevens@google.com>
	Cc: <stable@vger.kernel.org>
Link: https://lore.kernel.org/20241121140613.3651-1-bsevens@google.com Link: https://patch.msgid.link/20241125144629.20757-1-tiwai@suse.de
	Signed-off-by: Takashi Iwai <tiwai@suse.de>
(cherry picked from commit a3dd4d63eeb452cfb064a13862fb376ab108f6a6)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqcbr7_9_VULN-46526-0de07c3"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  SHIPPED scripts/kconfig/zconf.hash.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf --silentoldconfig Kconfig
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/syscalls/../include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_64.h
  HOSTCC  scripts/basic/bin2c
  WRAP    arch/x86/include/generated/asm/clkdev.h
  WRAP    arch/x86/include/generated/asm/mm-arch-hooks.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  CHK     include/generated/uapi/linux/version.h
  UPD     include/generated/uapi/linux/version.h
  CHK     include/generated/utsrelease.h
  UPD     include/generated/utsrelease.h
  CHK     include/generated/qrwlock.h
  UPD     include/generated/qrwlock.h
  CHK     include/generated/qrwlock_api_smp.h
  UPD     include/generated/qrwlock_api_smp.h
  CHK     include/generated/qrwlock_types.h
  UPD     include/generated/qrwlock_types.h
  CHK     kernel/qrwlock_gen.c
  UPD     kernel/qrwlock_gen.c
  CHK     lib/qrwlock_debug.c
  UPD     lib/qrwlock_debug.c
  HOSTCC  scripts/kallsyms
  HOSTCC  scripts/pnmtologo
  HOSTCC  scripts/recordmcount
  HOSTCC  scripts/conmakehash
  HOSTCC  scripts/asn1_compiler
  HOSTCC  scripts/sortextable
  HOSTCC  scripts/genksyms/genksyms.o
  SHIPPED scripts/genksyms/lex.lex.c
  SHIPPED scripts/genksyms/keywords.hash.c
  CC      scripts/mod/empty.o
  HOSTCC  scripts/mod/mk_elfconfig
  SHIPPED scripts/genksyms/parse.tab.h
  SHIPPED scripts/genksyms/parse.tab.c
  CC      scripts/mod/devicetable-offsets.s

[SNIP]

  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL virt/lib/irqbypass.ko
  INSTALL /lib/firmware/bnx2x/bnx2x-e1-6.2.9.0.fw
  INSTALL /lib/firmware/bnx2x/bnx2x-e1h-6.2.9.0.fw
  INSTALL /lib/firmware/bnx2x/bnx2x-e2-6.2.9.0.fw
  INSTALL /lib/firmware/bnx2/bnx2-mips-09-6.2.1a.fw
  INSTALL /lib/firmware/bnx2/bnx2-rv2p-09-6.0.17.fw
  INSTALL /lib/firmware/bnx2/bnx2-rv2p-09ax-6.0.17.fw
  INSTALL /lib/firmware/bnx2/bnx2-mips-06-6.2.1.fw
  INSTALL /lib/firmware/cxgb3/t3b_psram-1.1.0.bin
  INSTALL /lib/firmware/cxgb3/t3c_psram-1.1.0.bin
  INSTALL /lib/firmware/cxgb3/ael2005_opt_edc.bin
  INSTALL /lib/firmware/bnx2/bnx2-rv2p-06-6.0.15.fw
  INSTALL /lib/firmware/cxgb3/ael2005_twx_edc.bin
  INSTALL /lib/firmware/cxgb3/ael2020_twx_edc.bin
  INSTALL /lib/firmware/radeon/R100_cp.bin
  INSTALL /lib/firmware/radeon/R200_cp.bin
  INSTALL /lib/firmware/radeon/R300_cp.bin
  INSTALL /lib/firmware/radeon/R420_cp.bin
  INSTALL /lib/firmware/radeon/RS690_cp.bin
  INSTALL /lib/firmware/radeon/RS600_cp.bin
  INSTALL /lib/firmware/radeon/R520_cp.bin
  INSTALL /lib/firmware/radeon/R600_pfp.bin
  INSTALL /lib/firmware/radeon/R600_me.bin
  INSTALL /lib/firmware/radeon/RV610_pfp.bin
  INSTALL /lib/firmware/radeon/RV610_me.bin
  INSTALL /lib/firmware/radeon/RV630_pfp.bin
  INSTALL /lib/firmware/radeon/RV630_me.bin
  INSTALL /lib/firmware/radeon/RV620_me.bin
  INSTALL /lib/firmware/radeon/RV620_pfp.bin
  INSTALL /lib/firmware/radeon/RV635_pfp.bin
  INSTALL /lib/firmware/radeon/RV635_me.bin
  INSTALL /lib/firmware/radeon/RV670_pfp.bin
  INSTALL /lib/firmware/radeon/RV670_me.bin
  INSTALL /lib/firmware/radeon/RS780_pfp.bin
  INSTALL /lib/firmware/radeon/RS780_me.bin
  INSTALL /lib/firmware/radeon/RV770_pfp.bin
  INSTALL /lib/firmware/radeon/RV730_pfp.bin
  INSTALL /lib/firmware/radeon/RV770_me.bin
  INSTALL /lib/firmware/radeon/RV730_me.bin
  INSTALL /lib/firmware/radeon/RV710_pfp.bin
  INSTALL /lib/firmware/av7110/bootcode.bin
  INSTALL /lib/firmware/radeon/RV710_me.bin
  INSTALL /lib/firmware/ttusb-budget/dspbootcode.bin
  INSTALL /lib/firmware/qlogic/sd7220.fw
  INSTALL /lib/firmware/korg/k1212.dsp
  INSTALL /lib/firmware/ess/maestro3_assp_kernel.fw
  INSTALL /lib/firmware/ess/maestro3_assp_minisrc.fw
  INSTALL /lib/firmware/tigon/tg3.bin
  INSTALL /lib/firmware/tigon/tg3_tso5.bin
  INSTALL /lib/firmware/tigon/tg3_tso.bin
  INSTALL /lib/firmware/emi26/loader.fw
  INSTALL /lib/firmware/emi26/firmware.fw
  INSTALL /lib/firmware/emi26/bitstream.fw
  INSTALL /lib/firmware/emi62/loader.fw
  INSTALL /lib/firmware/emi62/bitstream.fw
  INSTALL /lib/firmware/emi62/spdif.fw
  INSTALL /lib/firmware/emi62/midi.fw
  INSTALL /lib/firmware/kaweth/new_code.bin
  INSTALL /lib/firmware/kaweth/trigger_code.bin
  INSTALL /lib/firmware/kaweth/new_code_fix.bin
  INSTALL /lib/firmware/kaweth/trigger_code_fix.bin
  INSTALL /lib/firmware/ti_3410.fw
  INSTALL /lib/firmware/ti_5052.fw
  INSTALL /lib/firmware/mts_cdma.fw
  INSTALL /lib/firmware/mts_gsm.fw
  INSTALL /lib/firmware/edgeport/boot.fw
  INSTALL /lib/firmware/mts_edge.fw
  INSTALL /lib/firmware/edgeport/boot2.fw
  INSTALL /lib/firmware/edgeport/down.fw
  INSTALL /lib/firmware/edgeport/down2.fw
  INSTALL /lib/firmware/edgeport/down3.bin
  INSTALL /lib/firmware/whiteheat_loader.fw
  INSTALL /lib/firmware/whiteheat.fw
  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-bmastbergen_ciqcbr7_9_VULN-46526-0de07c3+
[TIMER]{MODULES}: 14s
Making Install
sh ./arch/x86/boot/install.sh 3.10.0-bmastbergen_ciqcbr7_9_VULN-46526-0de07c3+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 43s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-bmastbergen_ciqcbr7_9_VULN-46526-0de07c3+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 497s
[TIMER]{MODULES}: 14s
[TIMER]{INSTALL}: 43s
[TIMER]{TOTAL} 561s
Rebooting in 10 seconds

```

### Testing

The very limited number of kselftests were run before and after applying the fix

[selftest-3.10.0-1160.119.1.el7_9.ciqcbr.4.1.x86_64.log](https://github.com/user-attachments/files/20526046/selftest-3.10.0-1160.119.1.el7_9.ciqcbr.4.1.x86_64.log)

[selftest-3.10.0-bmastbergen_ciqcbr7_9_VULN-46526-0de07c3+.log](https://github.com/user-attachments/files/20526047/selftest-3.10.0-bmastbergen_ciqcbr7_9_VULN-46526-0de07c3%2B.log)

```
brett@lycia ~/ciq/vuln-46526 % grep ^ok selftest-3.10.0-1160.119.1.el7_9.ciqcbr.4.1.x86_64.log | wc -l
2
brett@lycia ~/ciq/vuln-46526 % grep ^ok selftest-3.10.0-bmastbergen_ciqcbr7_9_VULN-46526-0de07c3+.log | wc -l
2
brett@lycia ~/ciq/vuln-46526 %

```