### PR TITLE
net: tls, update curr on splice as well

### DIFF
--- a/net/tls/tls_sw.c
+++ b/net/tls/tls_sw.c
@@ -1203,6 +1203,8 @@ alloc_payload:
 		}
 
 		sk_msg_page_add(msg_pl, page, copy, offset);
+		msg_pl->sg.copybreak = 0;
+		msg_pl->sg.curr = msg_pl->sg.end;
 		sk_mem_charge(sk, copy);
 
 		offset += copy;


### PR DESCRIPTION
[LTS 9.2]
CVE-2024-0646
VULN-6844


# Problem

<https://www.cve.org/CVERecord?id=CVE-2024-0646>

> An out-of-bounds memory write flaw was found in the Linux kernel’s Transport Layer Security functionality in how a user calls a function splice with a ktls socket as the destination. This flaw allows a local user to crash or potentially escalate their privileges on the system.


# Background

"Splicing" is a method

> … for moving blocks of data around inside the kernel, without continually transferring them between the kernel and user space.

<https://github.com/torvalds/linux/blob/master/Documentation/filesystems/splice.rst>


# Applicability

The `tls` module is enabled in `ciqlts9_2` for all configuration variants

    $ grep CONFIG_TLS= configs/*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_TLS=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_TLS=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_TLS=m
    configs/kernel-aarch64-rhel.config:CONFIG_TLS=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_TLS=m
    configs/kernel-ppc64le-rhel.config:CONFIG_TLS=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_TLS=m
    configs/kernel-s390x-rhel.config:CONFIG_TLS=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_TLS=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_TLS=m
    configs/kernel-x86_64-rhel.config:CONFIG_TLS=m

Although the mere `tls` enablement may not be sufficient condition to definitively say that the bug applies, the similarity between the `net/tls/tls_sw.c` file's history to that of LTS 9.4 and Linux stable 5.15 where the patch was backported strongly suggests that it does. See analysis below.


# Analysis and solution

The mainline fix is given in the c5a595000e2677e865a39f249c056bc05d6e55fd commit. However, the commit's modification subject - `net/tls/tls_sw.c` - was undergoing heavy development in the upstream and the file differs substantially from the `ciqlts9_2` version. The git's `cherry-pick`'s automatic difference resolution is meaningless.

The mainline fix boils down to adding these two lines in the procedure responsible for sending a spliced page:

    +		msg_pl->sg.copybreak = 0;
    +		msg_pl->sg.curr = msg_pl->sg.end;

In the mainline kernel the lines are added in the `tls_sw_sendmsg_splice` function, which is missing in the `ciqlts9_2` version.

To span the bridge between mainline and `ciqlts9_2` consider the following timeline of the `net/tls/tls_sw.c` file modification in mainline Kernel. The commits are given from newest to oldest, as `git log` would order them by default. (For the bird's view of the file's history in the context of upstream and Rocky Kernels see [Appendix](#orge2ce199).)

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Commit</th>
<th scope="col" class="org-left">Subject</th>
<th scope="col" class="org-left">1</th>
<th scope="col" class="org-left">2</th>
<th scope="col" class="org-left">3</th>
<th scope="col" class="org-left">4</th>
<th scope="col" class="org-left">5</th>
<th scope="col" class="org-left">6</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">c5a595000e2677e865a39f249c056bc05d6e55fd</td>
<td class="org-left">net: tls, update curr on splice as well</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">w:5</td>
<td class="org-left">m, u:6</td>
<td class="org-left">m!</td>
</tr>


<tr>
<td class="org-left">…</td>
<td class="org-left">…</td>
<td class="org-left">…</td>
<td class="org-left">…</td>
<td class="org-left">…</td>
<td class="org-left">…</td>
<td class="org-left">…</td>
<td class="org-left">…</td>
</tr>


<tr>
<td class="org-left">e22e358bbeb3256e2eb854493b46c815402087bb</td>
<td class="org-left">net/tls: handle MSG&#95;EOR for tls&#95;sw TX flow</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">w:5</td>
<td class="org-left">m, u:6</td>
<td class="org-left">m</td>
</tr>


<tr>
<td class="org-left">b848b26c6672c9b977890ba85f5a155e5eb221f0</td>
<td class="org-left">net: Kill MSG&#95;SENDPAGE&#95;NOTLAST</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">w:5</td>
<td class="org-left">m, u:6</td>
<td class="org-left">m</td>
</tr>


<tr>
<td class="org-left">dc97391e661009eab46783030d2404c9b6e6f2e7</td>
<td class="org-left">sock: Remove ->sendpage() in favour of sendmsg(MSG&#95;SPLICE&#95;PAGES)</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">w:5</td>
<td class="org-left">m, u:6</td>
<td class="org-left">m</td>
</tr>


<tr>
<td class="org-left">45e5be844ab6b2845b6d2935b61278c5ecae7d38</td>
<td class="org-left">tls/sw: Convert tls&#95;sw&#95;sendpage() to use MSG&#95;SPLICE&#95;PAGES</td>
<td class="org-left">w:4</td>
<td class="org-left">w:5</td>
<td class="org-left">-</td>
<td class="org-left">w:5</td>
<td class="org-left">m, u:6</td>
<td class="org-left">m</td>
</tr>


<tr>
<td class="org-left">fe1e81d4f73b6cbaed4fcc476960d26770642842</td>
<td class="org-left">tls/sw: Support MSG&#95;SPLICE&#95;PAGES</td>
<td class="org-left">w:3</td>
<td class="org-left">w:3</td>
<td class="org-left">m</td>
<td class="org-left">m, u:6</td>
<td class="org-left">-</td>
<td class="org-left">m</td>
</tr>


<tr>
<td class="org-left">df720d288dbb1793e82b6ccbfc670ec871e9def4</td>
<td class="org-left">tls/sw: Use splice&#95;eof() to flush</td>
<td class="org-left">w:3</td>
<td class="org-left">w:3</td>
<td class="org-left">m</td>
<td class="org-left">m</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">81840b3b91aad06053ad2712f3da5d0448eeb0e8</td>
<td class="org-left">Allow MSG&#95;SPLICE&#95;PAGES but treat it as normal sendmsg</td>
<td class="org-left">w:3</td>
<td class="org-left">w:3</td>
<td class="org-left">m</td>
<td class="org-left">m</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">8a0d57df8938e9fd2e99d47a85b7f37d86f91097</td>
<td class="org-left">tls: improve lockless access safety of tls&#95;err&#95;abort()</td>
<td class="org-left">w:3</td>
<td class="org-left">w:3</td>
<td class="org-left">m</td>
<td class="org-left">m</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>
</tbody>
</table>

Legend:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-right" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-right">Column</th>
<th scope="col" class="org-left">Function</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-right">1</td>
<td class="org-left">tls&#95;sw&#95;sendpage</td>
</tr>


<tr>
<td class="org-right">2</td>
<td class="org-left">tls&#95;sw&#95;sendpage&#95;locked</td>
</tr>


<tr>
<td class="org-right">3</td>
<td class="org-left">tls&#95;sw&#95;do&#95;sendpage</td>
</tr>


<tr>
<td class="org-right">4</td>
<td class="org-left">tls&#95;sw&#95;sendmsg</td>
</tr>


<tr>
<td class="org-right">5</td>
<td class="org-left">tls&#95;sw&#95;sendmsg&#95;locked</td>
</tr>


<tr>
<td class="org-right">6</td>
<td class="org-left">tls&#95;sw&#95;sendmsg&#95;splice</td>
</tr>
</tbody>
</table>

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Symbol</th>
<th scope="col" class="org-left">Function info</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">-</td>
<td class="org-left">Doesn't exist</td>
</tr>


<tr>
<td class="org-left">m</td>
<td class="org-left">Monolithic</td>
</tr>


<tr>
<td class="org-left">u:N</td>
<td class="org-left">Uses function N</td>
</tr>


<tr>
<td class="org-left">w:N</td>
<td class="org-left">Wraps function N (much less additional functionality compared to "u")</td>
</tr>


<tr>
<td class="org-left">!</td>
<td class="org-left">The place where the CVE patch was applied</td>
</tr>
</tbody>
</table>

Commentary:

1.  Commit fe1e81d4f73b6cbaed4fcc476960d26770642842 introduced the - later fixed - `tls_sw_sendmsg_splice` function and hooked it to `tls_sw_sendmsg`. This provided the actual splicing functionality which was included as a phony two commits before.
2.  The `tls_sw_do_sendpage` function was later removed in 45e5be844ab6b2845b6d2935b61278c5ecae7d38. The large part of `tls_sw_sendmsg` was factored out, along with the `tls_sw_sendmsg_splice`'s hook, to the `tls_sw_sendmsg_locked` function. The `tls_sw_sendpage` which was using the removed `tls_sw_do_sendpage` function was expressed using `tls_sw_sendmsg`, while `tls_sw_sendpage_locked` was expressed using the lower-level `tls_sw_sendmsg_locked` directly.
    Reverse call tree before:
    
        tls_sw_do_sendpage
        |
        |`tls_sw_sendpage
        |
         `tls_sw_sendpage_locked
    
    Reverse call tree after:
    
        tls_sw_sendmsg_locked
        |
        |`tls_sw_sendmsg
        | |
        |  `tls_sw_sendpage
         `tls_sw_sendpage_locked
3.  Functions `tls_sw_sendpage`, `tls_sw_sendpage_locked` were removed entirely a commit later (dc97391e661009eab46783030d2404c9b6e6f2e7) marking the end of last `tls_sw_do_sendpage`'s remnants in the `tls_sw.c` code.
4.  The functions layout remained unchanged up to the bugfix in c5a595000e2677e865a39f249c056bc05d6e55fd.

Compare this with the `ciqlts9_2` history spanning the fix included in this PR and the preceding commit:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Commit</th>
<th scope="col" class="org-left">Subject</th>
<th scope="col" class="org-left">1</th>
<th scope="col" class="org-left">2</th>
<th scope="col" class="org-left">3</th>
<th scope="col" class="org-left">4</th>
<th scope="col" class="org-left">5</th>
<th scope="col" class="org-left">6</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">64504ce6c7f2449a6efd21a0d9556ddc12bf98f0</td>
<td class="org-left">net: tls, update curr on splice as well</td>
<td class="org-left">u:3</td>
<td class="org-left">u:3</td>
<td class="org-left">m!</td>
<td class="org-left">m</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">dbe0e1864912d76308bfb08514d6e859cd535be2</td>
<td class="org-left">tls: rx: react to strparser initialization errors</td>
<td class="org-left">u:3</td>
<td class="org-left">u:3</td>
<td class="org-left">m</td>
<td class="org-left">m</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>
</tbody>
</table>

The timeline given before explains the continuity between the `tls_sw_do_sendpage` and the `tls_sw_sendmsg_splice` where the upstream fix was placed. The exact placing of the `msg_pl->sg.copybreak` and `msg_pl->sg.curr` fields modification was dictated by the `sk_msg_page_add` function call using the `msg_pl` struct - the new lines are introduced right after it in both the mainline fix and in this patch, be it in the `tls_sw_do_sendpage` or `tls_sw_sendmsg_splice` function:

    sk_msg_page_add(msg_pl, page, copy, offset);
    msg_pl->sg.copybreak = 0;
    msg_pl->sg.curr = msg_pl->sg.end;

The same place was picked for the CVE fix in LTS 9.4 in 8ad16a75831dbe0ec7529c525e5ecb234b4925d1 by RedHat as well as in the 5.15 stable backport in ba5efd8544fa62ae85daeb36077468bf2ce974ab. In fact, this patch is a direct cherry pick of the ba5efd8544fa62ae85daeb36077468bf2ce974ab commit.


# kABI check: passed

    DEBUG=1 CVE=CVE-2024-0646 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_2-CVE-2024-0646

    [0/1] Check ABI of kernel [ciqlts9_2-CVE-2024-0646]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2024-0646/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2024-0646/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20579356/boot-test.log>)


# Kselftests: passed relative


## Coverage

`bpf` (except `test_sockmap`, `test_progs-no_alu32`, `test_progs`, `test_kmod.sh`, `test_xsk.sh`), `breakpoints`, `capabilities`, `cgroup` (except `test_freezer`, `test_memcontrol`), `clone3`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding`, `drivers/net/team`, `filesystems/binderfs`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `ir`, `kcmp`, `kexec`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net/forwarding` (except `sch_tbf_ets.sh`, `q_in_vni.sh`, `ipip_hier_gre_keys.sh`, `dual_vxlan_bridge.sh`, `tc_police.sh`, `sch_ets.sh`, `tc_actions.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_red.sh`, `vxlan_bridge_1d_ipv6.sh`, `mirror_gre_bridge_1d_vlan.sh`, `sch_tbf_root.sh`, `sch_tbf_prio.sh`), `net/mptcp` (except `userspace_pm.sh`, `simult_flows.sh`), `net` (except `xfrm_policy.sh`, `reuseport_addr_any.sh`, `udpgso_bench.sh`, `fib_nexthops.sh`, `ip_defrag.sh`, `udpgro_fwd.sh`, `reuseaddr_conflict`, `txtimestamp.sh`, `gro.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `openat2`, `pid_namespace`, `pidfd`, `proc` (except `proc-pid-vm`, `proc-uptime-001`), `pstore`, `ptrace`, `rlimits`, `rseq`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `syscall_user_dispatch`, `tc-testing`, `tdx`, `timens`, `timers` (except `raw_skew`), `tmpfs`, `tpm2`, `vDSO`, `vm`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/20579355/kselftests--ciqlts9_2--run1.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/20579352/kselftests--ciqlts9_2--run2.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-2024-0646&#x2013;run1.log](<https://github.com/user-attachments/files/20579351/kselftests--ciqlts9_2-CVE-2024-0646--run1.log>)


## Comparison

Test results for the reference kernel and the patch are the same

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ---------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2--run2.log
    Status2   kselftests--ciqlts9_2-CVE-2024-0646--run1.log

In particular the `net:tls` test testing the modified module passed in the patched kernel

    $ ktests.xsh show --test net:tls -s kselftests--ciqlts9_2-CVE-2024-0646--run1.log

    # TAP version 13
    # 1..456
    # # Starting 456 tests from 13 test cases.
    # #  RUN           global.non_established ...
    # #            OK  global.non_established
    # ok 1 global.non_established
    # #  RUN           global.keysizes ...
    # #            OK  global.keysizes
    …
    # # PASSED: 456 / 456 tests passed.
    # # Totals: pass:456 fail:0 xfail:0 xpass:0 skip:0 error:0
    ok 1 selftests: net: tls


# Specific tests: skipped


<a id="orge2ce199"></a>

# Appendix

Below is the full history of mainline `net/tls/tls_sw.c` file (except merge commits), cross-referenced with the history of the same file in the official stable releases 5.15 and 4.19, along with the Rocky versions LTS 8.6, 8.8, 9.2 and 9.4. The `=` char next to the corresponding commit indicates that this is the exact same commit while `~` char indicates that it is a cherry-picked backport. The commits relevant to this PR are marked with numbers

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-right" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-right">0</td>
<td class="org-left">The official bugfix</td>
</tr>


<tr>
<td class="org-right">1-8</td>
<td class="org-left">Commits covered by the `net/tls/tls_sw.c` timeline for mainline Kernel</td>
</tr>


<tr>
<td class="org-right">9</td>
<td class="org-left">The commit in LTS 9.2 preceeding this PR</td>
</tr>


<tr>
<td class="org-right">10</td>
<td class="org-left">The commit marked as introducing the bug</td>
</tr>
</tbody>
</table>

    $ cve-research/git-analysis.xsh histories -C …/kernel-src-tree --file net/tls/tls_sw.c --ref-opts='--no-merges' kernel-mainline linux-5.15.y linux-4.19.y ciqlts9_4 ciqlts9_2 ciqlts8_8 ciqlts8_6

[tls\_sw-history.txt](<https://github.com/user-attachments/files/20579884/tls_sw-history.txt>)

