### PR TITLE
[lts92] net: sched: sch_qfq: prevent slab-out-of-bounds in qfq_activate_agg

### DIFF
--- a/net/sched/sch_qfq.c
+++ b/net/sched/sch_qfq.c
@@ -421,14 +421,15 @@ static int qfq_change_class(struct Qdisc *sch, u32 classid, u32 parentid,
 	} else
 		weight = 1;
 
-	if (tb[TCA_QFQ_LMAX]) {
+	if (tb[TCA_QFQ_LMAX])
 		lmax = nla_get_u32(tb[TCA_QFQ_LMAX]);
-		if (lmax < QFQ_MIN_LMAX || lmax > (1UL << QFQ_MTU_SHIFT)) {
-			pr_notice("qfq: invalid max length %u\n", lmax);
-			return -EINVAL;
-		}
-	} else
+	else
 		lmax = psched_mtu(qdisc_dev(sch));
+
+	if (lmax < QFQ_MIN_LMAX || lmax > (1UL << QFQ_MTU_SHIFT)) {
+		pr_notice("qfq: invalid max length %u\n", lmax);
+		return -EINVAL;
+	}
 
 	inv_w = ONE_FP / weight;
 	weight = ONE_FP / inv_w;


### PR DESCRIPTION
jira VULN-6471
cve CVE-2023-31436

Same as https://github.com/ctrliq/kernel-src-tree/pull/295

```
commit-author Gwangun Jung <exsociety@gmail.com>
commit 3037933448f60f9acb705997eae62013ecb81e0d

If the TCA_QFQ_LMAX value is not offered through nlattr, lmax is determined by the MTU value of the network device. The MTU of the loopback device can be set up to 2^31-1. As a result, it is possible to have an lmax value that exceeds QFQ_MIN_LMAX.

Due to the invalid lmax value, an index is generated that exceeds the QFQ_MAX_INDEX(=24) value, causing out-of-bounds read/write errors.

The following reports a oob access:

[   84.582666] BUG: KASAN: slab-out-of-bounds in qfq_activate_agg.constprop.0 (net/sched/sch_qfq.c:1027 net/sched/sch_qfq.c:1060 net/sched/sch_qfq.c:1313)
[   84.583267] Read of size 4 at addr ffff88810f676948 by task ping/301
[   84.583686]
[   84.583797] CPU: 3 PID: 301 Comm: ping Not tainted 6.3.0-rc5 #1
[   84.584164] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.15.0-1 04/01/2014
[   84.584644] Call Trace:
[   84.584787]  <TASK>
[   84.584906] dump_stack_lvl (lib/dump_stack.c:107 (discriminator 1))
[   84.585108] print_report (mm/kasan/report.c:320 mm/kasan/report.c:430)
[   84.585570] kasan_report (mm/kasan/report.c:538)
[   84.585988] qfq_activate_agg.constprop.0 (net/sched/sch_qfq.c:1027 net/sched/sch_qfq.c:1060 net/sched/sch_qfq.c:1313)
[   84.586599] qfq_enqueue (net/sched/sch_qfq.c:1255)
[   84.587607] dev_qdisc_enqueue (net/core/dev.c:3776)
[   84.587749] __dev_queue_xmit (./include/net/sch_generic.h:186 net/core/dev.c:3865 net/core/dev.c:4212)
[   84.588763] ip_finish_output2 (./include/net/neighbour.h:546 net/ipv4/ip_output.c:228)
[   84.589460] ip_output (net/ipv4/ip_output.c:430)
[   84.590132] ip_push_pending_frames (./include/net/dst.h:444 net/ipv4/ip_output.c:126 net/ipv4/ip_output.c:1586 net/ipv4/ip_output.c:1606)
[   84.590285] raw_sendmsg (net/ipv4/raw.c:649)
[   84.591960] sock_sendmsg (net/socket.c:724 net/socket.c:747)
[   84.592084] __sys_sendto (net/socket.c:2142)
[   84.593306] __x64_sys_sendto (net/socket.c:2150)
[   84.593779] do_syscall_64 (arch/x86/entry/common.c:50 arch/x86/entry/common.c:80)
[   84.593902] entry_SYSCALL_64_after_hwframe (arch/x86/entry/entry_64.S:120)
[   84.594070] RIP: 0033:0x7fe568032066
[   84.594192] Code: 0e 0d 00 f7 d8 64 89 02 48 c7 c0 ff ff ff ff eb b8 0f 1f 00 41 89 ca 64 8b 04 25 18 00 00 00 85 c09[ 84.594796] RSP: 002b:00007ffce388b4e8 EFLAGS: 00000246 ORIG_RAX: 000000000000002c

Code starting with the faulting instruction
===========================================
[   84.595047] RAX: ffffffffffffffda RBX: 00007ffce388cc70 RCX: 00007fe568032066
[   84.595281] RDX: 0000000000000040 RSI: 00005605fdad6d10 RDI: 0000000000000003
[   84.595515] RBP: 00005605fdad6d10 R08: 00007ffce388eeec R09: 0000000000000010
[   84.595749] R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000040
[   84.595984] R13: 00007ffce388cc30 R14: 00007ffce388b4f0 R15: 0000001d00000001
[   84.596218]  </TASK>
[   84.596295]
[   84.596351] Allocated by task 291:
[   84.596467] kasan_save_stack (mm/kasan/common.c:46)
[   84.596597] kasan_set_track (mm/kasan/common.c:52)
[   84.596725] __kasan_kmalloc (mm/kasan/common.c:384)
[   84.596852] __kmalloc_node (./include/linux/kasan.h:196 mm/slab_common.c:967 mm/slab_common.c:974)
[   84.596979] qdisc_alloc (./include/linux/slab.h:610 ./include/linux/slab.h:731 net/sched/sch_generic.c:938)
[   84.597100] qdisc_create (net/sched/sch_api.c:1244)
[   84.597222] tc_modify_qdisc (net/sched/sch_api.c:1680)
[   84.597357] rtnetlink_rcv_msg (net/core/rtnetlink.c:6174)
[   84.597495] netlink_rcv_skb (net/netlink/af_netlink.c:2574)
[   84.597627] netlink_unicast (net/netlink/af_netlink.c:1340 net/netlink/af_netlink.c:1365)
[   84.597759] netlink_sendmsg (net/netlink/af_netlink.c:1942)
[   84.597891] sock_sendmsg (net/socket.c:724 net/socket.c:747)
[   84.598016] ____sys_sendmsg (net/socket.c:2501)
[   84.598147] ___sys_sendmsg (net/socket.c:2557)
[   84.598275] __sys_sendmsg (./include/linux/file.h:31 net/socket.c:2586)
[   84.598399] do_syscall_64 (arch/x86/entry/common.c:50 arch/x86/entry/common.c:80)
[   84.598520] entry_SYSCALL_64_after_hwframe (arch/x86/entry/entry_64.S:120)
[   84.598688]
[   84.598744] The buggy address belongs to the object at ffff88810f674000
[   84.598744]  which belongs to the cache kmalloc-8k of size 8192
[   84.599135] The buggy address is located 2664 bytes to the right of
[   84.599135]  allocated 7904-byte region [ffff88810f674000, ffff88810f675ee0)
[   84.599544]
[   84.599598] The buggy address belongs to the physical page:
[   84.599777] page:00000000e638567f refcount:1 mapcount:0 mapping:0000000000000000 index:0x0 pfn:0x10f670
[   84.600074] head:00000000e638567f order:3 entire_mapcount:0 nr_pages_mapped:0 pincount:0
[   84.600330] flags: 0x200000000010200(slab|head|node=0|zone=2)
[   84.600517] raw: 0200000000010200 ffff888100043180 dead000000000122 0000000000000000
[   84.600764] raw: 0000000000000000 0000000080020002 00000001ffffffff 0000000000000000
[   84.601009] page dumped because: kasan: bad access detected
[   84.601187]
[   84.601241] Memory state around the buggy address:
[   84.601396]  ffff88810f676800: fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc
[   84.601620]  ffff88810f676880: fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc
[   84.601845] >ffff88810f676900: fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc
[   84.602069]                                               ^
[   84.602243]  ffff88810f676980: fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc
[   84.602468]  ffff88810f676a00: fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc fc
[   84.602693] ==================================================================
[   84.602924] Disabling lock debugging due to kernel taint

Fixes: 3015f3d2a3cd ("pkt_sched: enable QFQ to support TSO/GSO")
	Reported-by: Gwangun Jung <exsociety@gmail.com>
	Signed-off-by: Gwangun Jung <exsociety@gmail.com>
	Acked-by: Jamal Hadi Salim<jhs@mojatatu.com>
	Signed-off-by: David S. Miller <davem@davemloft.net>
(cherry picked from commit 3037933448f60f9acb705997eae62013ecb81e0d)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/param.h
  WRAP    arch/x86/include/generated/uapi/asm/resource.h
  WRAP    arch/x86/include/generated/uapi/asm/sockios.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  WRAP    arch/x86/include/generated/uapi/asm/termios.h

[SNIP]

  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/snd-usbmidi-lib.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/line6/snd-usb-pod.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/line6/snd-usb-podhd.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/line6/snd-usb-line6.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/line6/snd-usb-toneport.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/hiface/snd-usb-hiface.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/line6/snd-usb-variax.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/misc/snd-ua101.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/snd-usbmidi-lib.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/snd-usbmidi-lib.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+
[TIMER]{MODULES}: 9s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 61s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 986s
[TIMER]{MODULES}: 9s
[TIMER]{INSTALL}: 61s
[TIMER]{TOTAL} 1076s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the fix

[selftest-5.14.0-284.30.1.el9_2.92ciq_lts.6.1.x86_64.log](https://github.com/user-attachments/files/20592157/selftest-5.14.0-284.30.1.el9_2.92ciq_lts.6.1.x86_64.log)

[selftest-5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+.log](https://github.com/user-attachments/files/20592161/selftest-5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2%2B.log)

```
brett@lycia ~/ciq/vuln-6471 % grep ^ok selftest-5.14.0-284.30.1.el9_2.92ciq_lts.6.1.x86_64.log | wc -l
333
brett@lycia ~/ciq/vuln-6471 % grep ^ok selftest-5.14.0-bmastbergen_ciqlts9_2_VULN-6471-1277923dbfb2+.log | wc -l
336
brett@lycia ~/ciq/vuln-6471 %

```