### PR TITLE
[fips 9.2] netfilter: ipset: add missing range check in bitmap_ip_uadt

### DIFF
--- a/net/netfilter/ipset/ip_set_bitmap_ip.c
+++ b/net/netfilter/ipset/ip_set_bitmap_ip.c
@@ -163,11 +163,8 @@ bitmap_ip_uadt(struct ip_set *set, struct nlattr *tb[],
 		ret = ip_set_get_hostipaddr4(tb[IPSET_ATTR_IP_TO], &ip_to);
 		if (ret)
 			return ret;
-		if (ip > ip_to) {
+		if (ip > ip_to)
 			swap(ip, ip_to);
-			if (ip < map->first_ip)
-				return -IPSET_ERR_BITMAP_RANGE;
-		}
 	} else if (tb[IPSET_ATTR_CIDR]) {
 		u8 cidr = nla_get_u8(tb[IPSET_ATTR_CIDR]);
 
@@ -178,7 +175,7 @@ bitmap_ip_uadt(struct ip_set *set, struct nlattr *tb[],
 		ip_to = ip;
 	}
 
-	if (ip_to > map->last_ip)
+	if (ip < map->first_ip || ip_to > map->last_ip)
 		return -IPSET_ERR_BITMAP_RANGE;
 
 	for (; !before(ip_to, ip); ip += map->hosts) {


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-46558
cve CVE-2024-53141
commit-author Jeongjun Park <aha310510@gmail.com>
commit 35f56c554eb1b56b77b3cf197a6b00922d49033d

When tb[IPSET_ATTR_IP_TO] is not present but tb[IPSET_ATTR_CIDR] exists, the values of ip and ip_to are slightly swapped. Therefore, the range check for ip should be done later, but this part is missing and it seems that the vulnerability occurs.

So we should add missing range checks and remove unnecessary range checks.

	Cc: <stable@vger.kernel.org>
	Reported-by: syzbot+58c872f7790a4d2ac951@syzkaller.appspotmail.com
Fixes: 72205fc68bd1 ("netfilter: ipset: bitmap:ip set type support")
	Signed-off-by: Jeongjun Park <aha310510@gmail.com>
	Acked-by: Jozsef Kadlecsik <kadlec@blackhole.kfki.hu>
	Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
(cherry picked from commit 35f56c554eb1b56b77b3cf197a6b00922d49033d)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/x86/include/generated/uapi/asm/param.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/resource.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
[--snip--]
  STRIP   /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+
[TIMER]{MODULES}: 16s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 39s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+ and Index to 2
The default is /boot/loader/entries/fd07241207574cb0adb41f945c3ec0f3-5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+
The default is /boot/loader/entries/fd07241207574cb0adb41f945c3ec0f3-5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-_ajain__fips-9-compliant_5.14.0-284.30.1-c67605c76+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 2958s
[TIMER]{MODULES}: 16s
[TIMER]{INSTALL}: 39s
[TIMER]{TOTAL} 3018s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/20612796/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
313
311
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
65
67

```
[kselftest-after.log](https://github.com/user-attachments/files/20612803/kselftest-after.log)

[kselftest-before.log](https://github.com/user-attachments/files/20612806/kselftest-before.log)

