### PR TITLE
[LTS 8.6] netfilter: ipset: add missing range check in bitmap_ip_uadt

### DIFF
--- a/net/netfilter/ipset/ip_set_bitmap_ip.c
+++ b/net/netfilter/ipset/ip_set_bitmap_ip.c
@@ -166,11 +166,8 @@ bitmap_ip_uadt(struct ip_set *set, struct nlattr *tb[],
 		ret = ip_set_get_hostipaddr4(tb[IPSET_ATTR_IP_TO], &ip_to);
 		if (ret)
 			return ret;
-		if (ip > ip_to) {
+		if (ip > ip_to)
 			swap(ip, ip_to);
-			if (ip < map->first_ip)
-				return -IPSET_ERR_BITMAP_RANGE;
-		}
 	} else if (tb[IPSET_ATTR_CIDR]) {
 		u8 cidr = nla_get_u8(tb[IPSET_ATTR_CIDR]);
 
@@ -181,7 +178,7 @@ bitmap_ip_uadt(struct ip_set *set, struct nlattr *tb[],
 		ip_to = ip;
 	}
 
-	if (ip_to > map->last_ip)
+	if (ip < map->first_ip || ip_to > map->last_ip)
 		return -IPSET_ERR_BITMAP_RANGE;
 
 	for (; !before(ip_to, ip); ip += map->hosts) {


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-46551
cve CVE-2024-53141
commit-author Jeongjun Park <aha310510@gmail.com>
commit 35f56c554eb1b56b77b3cf197a6b00922d49033d

When tb[IPSET_ATTR_IP_TO] is not present but tb[IPSET_ATTR_CIDR] exists, the values of ip and ip_to are slightly swapped. Therefore, the range check for ip should be done later, but this part is missing and it seems that the vulnerability occurs.

So we should add missing range checks and remove unnecessary range checks.

	Cc: <stable@vger.kernel.org>
	Reported-by: syzbot+58c872f7790a4d2ac951@syzkaller.appspotmail.com
Fixes: 72205fc68bd1 ("netfilter: ipset: bitmap:ip set type support")
	Signed-off-by: Jeongjun Park <aha310510@gmail.com>
	Acked-by: Jozsef Kadlecsik <kadlec@blackhole.kfki.hu>
	Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
(cherry picked from commit 35f56c554eb1b56b77b3cf197a6b00922d49033d)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ajain_ciqlts8_6-cd57b1b64"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  HOSTCC  scripts/basic/bin2c
  UPD     include/config/kernel.release
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  UPD     include/generated/uapi/linux/version.h
  UPD     include/generated/utsrelease.h
  DESCEND objtool
  HOSTCC  /home/anmol/kernel-src-tree/tools/objtool/fixdep.o
  HOSTLD  /home/anmol/kernel-src-tree/tools/objtool/fixdep-in.o
  LINK    /home/anmol/kernel-src-tree/tools/objtool/fixdep
  CC      /home/anmol/kernel-src-tree/tools/objtool/exec-cmd.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/help.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/pager.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/parse-options.o
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
[--snip--]
  INSTALL sound/usb/misc/snd-ua101.ko
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-_ajain_ciqlts8_6-cd57b1b64+
[TIMER]{MODULES}: 20s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-_ajain_ciqlts8_6-cd57b1b64+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 31s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-_ajain_ciqlts8_6-cd57b1b64+ and Index to 9
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-_ajain_ciqlts8_6-cd57b1b64+.conf with index 9 and kernel /boot/vmlinuz-4.18.0-_ajain_ciqlts8_6-cd57b1b64+
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-_ajain_ciqlts8_6-cd57b1b64+.conf with index 9 and kernel /boot/vmlinuz-4.18.0-_ajain_ciqlts8_6-cd57b1b64+
Generating grub configuration file ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 2963s
[TIMER]{MODULES}: 20s
[TIMER]{INSTALL}: 31s
[TIMER]{TOTAL} 3017s
Rebooting in 10 seconds

```
[kernel-build.log](https://github.com/user-attachments/files/20615798/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
195
195
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
51
51
```

[kselftest-after.log](https://github.com/user-attachments/files/20615802/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/20615803/kselftest-before.log)
