### PR TITLE
[lts-9.2] dmaengine: idxd: Fix possible Use-After-Free in irq_process_work_list

### DIFF
--- a/drivers/dma/idxd/irq.c
+++ b/drivers/dma/idxd/irq.c
@@ -460,11 +460,13 @@ static void irq_process_work_list(struct idxd_irq_entry *irq_entry)
 
 	spin_unlock(&irq_entry->list_lock);
 
-	list_for_each_entry(desc, &flist, list) {
+	list_for_each_entry_safe(desc, n, &flist, list) {
 		/*
 		 * Check against the original status as ABORT is software defined
 		 * and 0xff, which DSA_COMP_STATUS_MASK can mask out.
 		 */
+		list_del(&desc->list);
+
 		if (unlikely(desc->completion->status == IDXD_COMP_DESC_ABORT)) {
 			idxd_dma_complete_txd(desc, IDXD_COMPLETE_ABORT, true);
 			continue;


### PR DESCRIPTION
jira VULN-8254
cve CVE-2024-40956
```
commit-author Li RongQing <lirongqing@baidu.com>
commit e3215deca4520773cd2b155bed164c12365149a7

Use list_for_each_entry_safe() to allow iterating through the list and deleting the entry in the iteration process. The descriptor is freed via idxd_desc_complete() and there's a slight chance may cause issue for the list iterator when the descriptor is reused by another thread without it being deleted from the list.

Fixes: 16e19e11228b ("dmaengine: idxd: Fix list corruption in description completion")
	Signed-off-by: Li RongQing <lirongqing@baidu.com>
	Reviewed-by: Dave Jiang <dave.jiang@intel.com>
	Reviewed-by: Fenghua Yu <fenghua.yu@intel.com>
Link: https://lore.kernel.org/r/20240603012444.11902-1-lirongqing@baidu.com
	Signed-off-by: Vinod Koul <vkoul@kernel.org>
(cherry picked from commit e3215deca4520773cd2b155bed164c12365149a7)
	Signed-off-by: David Gomez <dgomez@ciq.com>
```

# Build Log
```
INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/usb/snd-usb-audio.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/usb/snd-usbmidi-lib.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/usb/snd-usb-audio.ko
  INSTALL /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+
[TIMER]{MODULES}: 15s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 55s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+ and Index to 0
The default is /boot/loader/entries/4dff56aa51eb410080f2fadbace916a6-5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+
The default is /boot/loader/entries/4dff56aa51eb410080f2fadbace916a6-5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 20s
[TIMER]{BUILD}: 3262s
[TIMER]{MODULES}: 15s
[TIMER]{INSTALL}: 55s
[TIMER]{TOTAL} 3367s
```

# Testing
[5.14.0-284.30.1.el9_2.92ciq_lts.6.1.x86_64.log](https://github.com/user-attachments/files/20616684/5.14.0-284.30.1.el9_2.92ciq_lts.6.1.x86_64.log)
[5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+.log](https://github.com/user-attachments/files/20616686/5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18%2B.log)
```
$ ls 5.14.0-284.30.1.el9_2.92ciq_lts.6.1.x86_64.log 5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+.log | while read line; do echo $line; grep '^ok' $line | wc -l; done
5.14.0-284.30.1.el9_2.92ciq_lts.6.1.x86_64.log
247
5.14.0-dgomez_ciqlts9_2_VULN-8254-726cc5e81b18+.log
246
```

Commit that this fixes https://github.com/ctrliq/kernel-src-tree/commit/16e19e11228ba660d9e322035635e7dcf160d5c2