### PR TITLE
[LTS 8.8] net: tls, update curr on splice as well

### DIFF
--- a/net/tls/tls_sw.c
+++ b/net/tls/tls_sw.c
@@ -1213,6 +1213,8 @@ alloc_payload:
 		}
 
 		sk_msg_page_add(msg_pl, page, copy, offset);
+		msg_pl->sg.copybreak = 0;
+		msg_pl->sg.curr = msg_pl->sg.end;
 		sk_mem_charge(sk, copy);
 
 		offset += copy;


### PR DESCRIPTION
[LTS 8.8]
CVE-2024-0646
VULN-6841


# Problem

<https://access.redhat.com/security/cve/CVE-2024-0646>

> An out-of-bounds memory write flaw was found in the Linux kernel’s Transport Layer Security functionality in how a user calls a function splice with a ktls socket as the destination. This flaw allows a local user to crash or potentially escalate their privileges on the system.


# Applicability analysis

The `tls` module is enabled in `ciqlts8_8`:

    grep 'CONFIG_TLS=' configs/kernel-{x86_64,aarch64,ppc64le,s390x}.config

    configs/kernel-x86_64.config:CONFIG_TLS=m
    configs/kernel-aarch64.config:CONFIG_TLS=m
    configs/kernel-ppc64le.config:CONFIG_TLS=m
    configs/kernel-s390x.config:CONFIG_TLS=m

The commit referenced in the mainline fix c5a595000e2677e865a39f249c056bc05d6e55fd as introducing the bug is d829e9c4112b52f4f00195900fd4c685f61365ab. It's present in the history of LTS 9.4 and upstream stable Linux 5.15 where the fix was backported in 8ad16a75831dbe0ec7529c525e5ecb234b4925d1 and ba5efd8544fa62ae85daeb36077468bf2ce974ab, respectively. Similar situation for the recently merged PR <https://github.com/ctrliq/kernel-src-tree/pull/305> for LTS 9.2.

The referenced commit d829e9c4112b52f4f00195900fd4c685f61365ab is **not** present in official stable Linux 4.18, which is most probably the reason the fix wasn't backported to any stable relase older than 5.4. However, it **can** be found in the "Rebuild\_History BUILDABLE"-type commit e19ec644e33dc798b1499d8c0482e2a70dfc1b22 of Rocky LTS 8.8 (see [ciq/ciq\_backports/kernel-4.18.0-147.el8/d829e9c4.failed](https://github.com/ctrliq/kernel-src-tree/blob/ciqlts8_8/ciq/ciq_backports/kernel-4.18.0-147.el8/d829e9c4.failed)).

Based on this it was concluded that the vulnerability applies to `ciqlts8_8`.


# Solution

The solution for `ciqlts8_8` is the same as in `ciqlts9_2`, because the function `tls_sw_do_sendpage` modified in `ciqlts9_2` is exactly the same as in `ciqlts8_8`. For the explanation of the fix in `ciqlts9_2` please see <https://github.com/ctrliq/kernel-src-tree/pull/305>.


# kABI check: passed

    DEBUG=1 CVE=CVE-2024-0646 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_8-CVE-2024-0646

    [0/1] Check ABI of kernel [ciqlts8_8-CVE-2024-0646]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_8/build_files/kernel-src-tree-ciqlts8_8-CVE-2024-0646/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_8-CVE-2024-0646/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20618377/boot-test.log>)


# Kselftests


## Coverage

`android`, `bpf` (except `test_sockmap`, `test_xsk.sh`, `test_progs-no_alu32`, `test_kmod.sh`, `test_progs`), `breakpoints`, `capabilities`, `cgroup`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/net/bonding`, `drivers/net/team`, `exec`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `kexec`, `kvm`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `mqueue`, `net/forwarding` (except `sch_tbf_prio.sh`, `mirror_gre_vlan_bridge_1q.sh`, `mirror_gre_bridge_1d_vlan.sh`, `ipip_hier_gre_keys.sh`, `sch_tbf_ets.sh`, `sch_tbf_root.sh`, `tc_actions.sh`, `sch_ets.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `txtimestamp.sh`, `reuseport_addr_any.sh`, `udpgso_bench.sh`, `udpgro_fwd.sh`, `ip_defrag.sh`, `gro.sh`, `reuseaddr_conflict`, `xfrm_policy.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `pstore`, `ptrace`, `rseq`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `tc-testing`, `tdx`, `timens`, `timers` (except `raw_skew`), `tpm2`, `vm`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts8\_8&#x2013;run1.log](<https://github.com/user-attachments/files/20618376/kselftests--ciqlts8_8--run1.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run2.log](<https://github.com/user-attachments/files/20618375/kselftests--ciqlts8_8--run2.log>)


## Patch

[kselftests&#x2013;ciqlts8\_8-CVE-2024-0646&#x2013;run1.log](<https://github.com/user-attachments/files/20618374/kselftests--ciqlts8_8-CVE-2024-0646--run1.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2024-0646&#x2013;run2.log](<https://github.com/user-attachments/files/20618373/kselftests--ciqlts8_8-CVE-2024-0646--run2.log>)


## Comparison

The reference and patched kernel results are the same

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ---------------------------------------------
    Status0   kselftests--ciqlts8_8--run1.log
    Status1   kselftests--ciqlts8_8--run2.log
    Status2   kselftests--ciqlts8_8-CVE-2024-0646--run1.log
    Status3   kselftests--ciqlts8_8-CVE-2024-0646--run2.log

In particular the `net:tls` test is passing in both versions, with the same logs:

    $ ktests.xsh show_groups --test net:tls -s kselftests*.log

    kselftests--ciqlts8_8--run1.log:
    kselftests--ciqlts8_8--run2.log:
    kselftests--ciqlts8_8-CVE-2024-0646--run1.log:
    kselftests--ciqlts8_8-CVE-2024-0646--run2.log:
    net:tls:
    # TAP version 13
    # 1..91
    # # Starting 91 tests from 4 test cases.
    # #  RUN           global.non_established ...
    # #            OK  global.non_established
    # ok 1 global.non_established
    # #  RUN           global.keysizes ...
    # #            OK  global.keysizes
    …
    # ok 91 tls.13.shutdown_reuse
    # # PASSED: 91 / 91 tests passed.
    # # Totals: pass:91 fail:0 xfail:0 xpass:0 skip:0 error:0
    ok 1 selftests: net: tls


# Specific tests: skipped


# Appendix

Below is an improved version of a similar table given in the appendix of <https://github.com/ctrliq/kernel-src-tree/pull/305>, but with "Rebuild\_History BUILDABLE"-type commits included, which left no commit from the `net/tls/tls_sw.c` history for LTS 8.6, 8.8, 9.2, 9.4 not cross-referenced.

    $ cve-research/git-analysis.xsh histories -C …/kernel-src-tree \
      kernel-mainline linux-5.15.y linux-4.19.y ciqlts9_4 ciqlts9_2 ciqlts8_8 ciqlts8_6 \
      --file net/tls/tls_sw.c \
      --keys sha subject version \
      --ref-opts='--no-merges' --format-main='%h %cd %s' --format-other='%h %cd'

[tls\_sw-history.txt](<https://github.com/user-attachments/files/20618372/tls_sw-history.txt>)

Symbols:

-   **`=`:** exact same commit,
-   **`~`:** cherry-picked backport,
-   **`#`:** rebuild-type bulk commit with all the cherry-picks which failed to be `~`.

