### PR TITLE
net: tls, update curr on splice as well

### DIFF
--- a/net/tls/tls_sw.c
+++ b/net/tls/tls_sw.c
@@ -1213,6 +1213,8 @@ alloc_payload:
 		}
 
 		sk_msg_page_add(msg_pl, page, copy, offset);
+		msg_pl->sg.copybreak = 0;
+		msg_pl->sg.curr = msg_pl->sg.end;
 		sk_mem_charge(sk, copy);
 
 		offset += copy;


### PR DESCRIPTION
[LTS 8.6]
CVE-2024-0646
VULN-4133


# Problem

<https://access.redhat.com/security/cve/CVE-2024-0646>

> An out-of-bounds memory write flaw was found in the Linux kernel’s Transport Layer Security functionality in how a user calls a function splice with a ktls socket as the destination. This flaw allows a local user to crash or potentially escalate their privileges on the system.


# Applicability analysis

The affected file `net/tls/tls_sw.c` in `ciqlts8_6` has the exact same history as in `ciqlts8_8`, so the analysis provided in <https://github.com/ctrliq/kernel-src-tree/pull/317> can be transferred to this version unchanged - the vulnerability applies to `ciqlts8_6`.

(Actually the `ciqlts8_8` version has one additional commit which is missing from `ciqlts8_6` - a924d04e454b1f0c7c04a539f821134fa8e4951a. Coincidentally, it's a CVE patch backport for [CVE-2022-49094](https://www.cve.org/CVERecord?id=CVE-2022-49094), which may need to be applied to `ciqlts8_6` as well.)


# Solution

Same as for `ciqlts8_8`. See <https://github.com/ctrliq/kernel-src-tree/pull/317>.


# kABI check: passed

    DEBUG=1 CVE=CVE-2024-0646 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_6-CVE-2024-0646

    [0/1] Check ABI of kernel [ciqlts8_6-CVE-2024-0646]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2024-0646/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2024-0646/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20619467/boot-test.log>)


# Kselftests


## General tests: passed relative


### Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/20619466/kselftests--ciqlts8_6--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/20619465/kselftests--ciqlts8_6--run2.log>)


### Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2024-0646&#x2013;run1.log](<https://github.com/user-attachments/files/20619464/kselftests--ciqlts8_6-CVE-2024-0646--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2024-0646&#x2013;run2.log](<https://github.com/user-attachments/files/20619461/kselftests--ciqlts8_6-CVE-2024-0646--run2.log>)


### Comparison

The tests results for reference and patched kernel are the same

    $ ktests.xsh diff -d kselftests--ciqlts8_6*.log

    Column    File
    --------  ---------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6--run2.log
    Status2   kselftests--ciqlts8_6-CVE-2024-0646--run1.log
    Status3   kselftests--ciqlts8_6-CVE-2024-0646--run2.log


## `net:tls` tests: passed

The general selftests were run for branch `ciqlts8_6` on commit 8e48e58d5ed4da205203094a4713695aa2a5bf88, the one before fc9306dfcb8f6dd723b199a1908d06e5301718ca which fixed the `net:tls` results. As this patch applies directly to the `tls` and `net:tls` results are important the tests were re-launched on reference kernel at fc9306dfcb8f6dd723b199a1908d06e5301718ca and on the patch rebased onto it.


### Reference

[kselftests&#x2013;tls&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/20619460/kselftests--tls--ciqlts8_6--run1.log>)
[kselftests&#x2013;tls&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/20619458/kselftests--tls--ciqlts8_6--run2.log>)
[kselftests&#x2013;tls&#x2013;ciqlts8\_6&#x2013;run3.log](<https://github.com/user-attachments/files/20619457/kselftests--tls--ciqlts8_6--run3.log>)
[kselftests&#x2013;tls&#x2013;ciqlts8\_6&#x2013;run4.log](<https://github.com/user-attachments/files/20619456/kselftests--tls--ciqlts8_6--run4.log>)


### Patch

[kselftests&#x2013;tls&#x2013;ciqlts8\_6-CVE-2024-0646&#x2013;run1.log](<https://github.com/user-attachments/files/20619455/kselftests--tls--ciqlts8_6-CVE-2024-0646--run1.log>)
[kselftests&#x2013;tls&#x2013;ciqlts8\_6-CVE-2024-0646&#x2013;run2.log](<https://github.com/user-attachments/files/20619453/kselftests--tls--ciqlts8_6-CVE-2024-0646--run2.log>)
[kselftests&#x2013;tls&#x2013;ciqlts8\_6-CVE-2024-0646&#x2013;run3.log](<https://github.com/user-attachments/files/20619452/kselftests--tls--ciqlts8_6-CVE-2024-0646--run3.log>)
[kselftests&#x2013;tls&#x2013;ciqlts8\_6-CVE-2024-0646&#x2013;run4.log](<https://github.com/user-attachments/files/20619451/kselftests--tls--ciqlts8_6-CVE-2024-0646--run4.log>)


### Comparison

All tests are passing, before and after.

    $ ktests.xsh diff  kselftests--tls*.log

    Column    File
    --------  --------------------------------------------------
    Status0   kselftests--tls--ciqlts8_6--run1.log
    Status1   kselftests--tls--ciqlts8_6--run2.log
    Status2   kselftests--tls--ciqlts8_6--run3.log
    Status3   kselftests--tls--ciqlts8_6--run4.log
    Status4   kselftests--tls--ciqlts8_6-CVE-2024-0646--run1.log
    Status5   kselftests--tls--ciqlts8_6-CVE-2024-0646--run2.log
    Status6   kselftests--tls--ciqlts8_6-CVE-2024-0646--run3.log
    Status7   kselftests--tls--ciqlts8_6-CVE-2024-0646--run4.log
    
    TestCase  Status0  Status1  Status2  Status3  Status4  Status5  Status6  Status7  Summary
    net:tls   pass     pass     pass     pass     pass     pass     pass     pass     same


# Specific tests: skipped

