### PR TITLE
[lts88] nvmet-tcp: Fix a possible UAF in queue intialization setup

### DIFF
--- a/drivers/nvme/target/tcp.c
+++ b/drivers/nvme/target/tcp.c
@@ -363,6 +363,7 @@ static void nvmet_tcp_fatal_error(struct nvmet_tcp_queue *queue)
 
 static void nvmet_tcp_socket_error(struct nvmet_tcp_queue *queue, int status)
 {
+	queue->rcv_state = NVMET_TCP_RECV_ERR;
 	if (status == -EPIPE || status == -ECONNRESET)
 		kernel_sock_shutdown(queue->sock, SHUT_RDWR);
 	else
@@ -906,15 +907,11 @@ static int nvmet_tcp_handle_icreq(struct nvmet_tcp_queue *queue)
 	iov.iov_len = sizeof(*icresp);
 	ret = kernel_sendmsg(queue->sock, &msg, &iov, 1, iov.iov_len);
 	if (ret < 0)
-		goto free_crypto;
+		return ret; /* queue removal will cleanup */
 
 	queue->state = NVMET_TCP_Q_LIVE;
 	nvmet_prepare_receive_pdu(queue);
 	return 0;
-free_crypto:
-	if (queue->hdr_digest || queue->data_digest)
-		nvmet_tcp_free_crypto(queue);
-	return ret;
 }
 
 static void nvmet_tcp_handle_req_failure(struct nvmet_tcp_queue *queue,


### PR DESCRIPTION
jira VULN-3183
cve CVE-2023-5178

```
commit-author Sagi Grimberg <sagi@grimberg.me>
commit d920abd1e7c4884f9ecd0749d1921b7ab19ddfbd

From Alon:
"Due to a logical bug in the NVMe-oF/TCP subsystem in the Linux kernel, a malicious user can cause a UAF and a double free, which may lead to RCE (may also lead to an LPE in case the attacker already has local privileges)."

Hence, when a queue initialization fails after the ahash requests are allocated, it is guaranteed that the queue removal async work will be called, hence leave the deallocation to the queue removal.

Also, be extra careful not to continue processing the socket, so set queue rcv_state to NVMET_TCP_RECV_ERR upon a socket error.

	Cc: stable@vger.kernel.org
	Reported-by: Alon Zahavi <zahavi.alon@gmail.com>
	Tested-by: Alon Zahavi <zahavi.alon@gmail.com>
	Signed-off-by: Sagi Grimberg <sagi@grimberg.me>
	Reviewed-by: Christoph Hellwig <hch@lst.de>
	Reviewed-by: Chaitanya Kulkarni <kch@nvidia.com>
	Signed-off-by: Keith Busch <kbusch@kernel.org>
(cherry picked from commit d920abd1e7c4884f9ecd0749d1921b7ab19ddfbd)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqlts8_8_VULN-3183-a190583ce34e"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1125s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-bmastbergen_ciqlts8_8_VULN-3183-a190583ce34e+
[TIMER]{MODULES}: 12s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-bmastbergen_ciqlts8_8_VULN-3183-a190583ce34e+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 99s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-bmastbergen_ciqlts8_8_VULN-3183-a190583ce34e+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1125s
[TIMER]{MODULES}: 12s
[TIMER]{INSTALL}: 99s
[TIMER]{TOTAL} 1251s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the fix

[selftest-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.x86_64.log](https://github.com/user-attachments/files/20656993/selftest-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.x86_64.log)

[selftest-4.18.0-bmastbergen_ciqlts8_8_VULN-3183-a190583ce34e+.log](https://github.com/user-attachments/files/20656994/selftest-4.18.0-bmastbergen_ciqlts8_8_VULN-3183-a190583ce34e%2B.log)

```
brett@lycia ~/ciq/vuln-3183 % grep ^ok selftest-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.x86_64.log | wc -l
240
brett@lycia ~/ciq/vuln-3183 % grep ^ok selftest-4.18.0-bmastbergen_ciqlts8_8_VULN-3183-a190583ce34e+.log | wc -l
239
brett@lycia ~/ciq/vuln-3183 %

```