### PR TITLE
[LTS 8.8] netfilter: ipset: add the missing IP_SET_HASH_WITH_NET0 macro for ip_…

### DIFF
--- a/net/netfilter/ipset/ip_set_hash_netportnet.c
+++ b/net/netfilter/ipset/ip_set_hash_netportnet.c
@@ -39,6 +39,7 @@ MODULE_ALIAS("ip_set_hash:net,port,net");
 #define IP_SET_HASH_WITH_PROTO
 #define IP_SET_HASH_WITH_NETS
 #define IPSET_NET_COUNT 2
+#define IP_SET_HASH_WITH_NET0
 
 /* IPv4 variant */
 


### PR DESCRIPTION
[LTS 8.8]
CVE-2023-42753
VULN-6667


# Problem

<https://nvd.nist.gov/vuln/detail/CVE-2023-42753>

> An array indexing vulnerability was found in the netfilter subsystem of the Linux kernel. A missing macro could lead to a miscalculation of the \`h->nets\` array offset, providing attackers with the primitive to arbitrarily increment/decrement a memory buffer out-of-bound. This issue may allow a local user to crash the system or potentially escalate their privileges on the system.

Original:
<https://www.openwall.com/lists/oss-security/2023/09/22/10>


# Solution

The fix in mainline is given in 050d91c03b28ca479df13dfb02bcd2c60dd6a878. All official backports have the same form. The fix is already present in Rockys CBR 7.9 (b0f9309936a66eea6d0140d0c7baf0ddf144b0c9), LTS 8.6 (fba0aafe2c620d3af607fb6679bf36074aa6ef09) and LTS 9.4 (ab90fdc7c7bcec8627c6e7fede3e097734be7b3c, ported by RedHat), all in the same form. It applies to LTS 8.8 smoothly as well.


# kABI check: passed

    DEBUG=1 CVE=CVE-2023-42753 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_8-CVE-2023-42753

    [0/1] Check ABI of kernel [ciqlts8_8-CVE-2023-42753]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_8/build_files/kernel-src-tree-ciqlts8_8-CVE-2023-42753/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_8-CVE-2023-42753/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20658559/boot-test.log>)


# Kselftests: passed relative


## Coverage

`net` (except `reuseaddr_conflict`, `udpgso_bench.sh`, `gro.sh`, `ip_defrag.sh`, `udpgro_fwd.sh`, `reuseport_addr_any.sh`, `xfrm_policy.sh`, `txtimestamp.sh`), `netfilter` (except `nft_trans_stress.sh`)

Following the discussion on Slack, and having established already what seems to be a set of stable tests for the LTS 8.8 version (no flappy results) - the only remaining reason for running full selftests routine for the last two months - a test run was done this time for the subsystems most likely affected by the change only.


## Reference

[kselftests&#x2013;ciqlts8\_8&#x2013;run1.log](<https://github.com/user-attachments/files/20658558/kselftests--ciqlts8_8--run1.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run2.log](<https://github.com/user-attachments/files/20658557/kselftests--ciqlts8_8--run2.log>)


## Patch

[kselftests&#x2013;ciqlts8\_8-CVE-2023-42753&#x2013;run1.log](<https://github.com/user-attachments/files/20658556/kselftests--ciqlts8_8-CVE-2023-42753--run1.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2023-42753&#x2013;run2.log](<https://github.com/user-attachments/files/20658555/kselftests--ciqlts8_8-CVE-2023-42753--run2.log>)


## Comparison

The test results are the same in the reference and patched kernel (presenting full results comparison)

    $ ktests.xsh diff kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_8--run1.log
    Status1   kselftests--ciqlts8_8--run2.log
    Status2   kselftests--ciqlts8_8-CVE-2023-42753--run1.log
    Status3   kselftests--ciqlts8_8-CVE-2023-42753--run2.log
    
    TestCase                              Status0  Status1  Status2  Status3  Summary
    net:bareudp.sh                        pass     pass     pass     pass     same
    net:devlink_port_split.py             skip     skip     skip     skip     same
    net:drop_monitor_tests.sh             skip     skip     skip     skip     same
    net:fcnal-test.sh                     skip     skip     skip     skip     same
    net:fib-onlink-tests.sh               pass     pass     pass     pass     same
    net:fib_rule_tests.sh                 fail     fail     fail     fail     same
    net:fib_tests.sh                      pass     pass     pass     pass     same
    net:gre_gso.sh                        skip     skip     skip     skip     same
    net:icmp_redirect.sh                  pass     pass     pass     pass     same
    net:ip6_gre_headroom.sh               pass     pass     pass     pass     same
    net:ipv6_flowlabel.sh                 pass     pass     pass     pass     same
    net:l2tp.sh                           pass     pass     pass     pass     same
    net:msg_zerocopy.sh                   fail     fail     fail     fail     same
    net:netdevice.sh                      pass     pass     pass     pass     same
    net:pmtu.sh                           pass     pass     pass     pass     same
    net:psock_snd.sh                      pass     pass     pass     pass     same
    net:reuseport_bpf                     pass     pass     pass     pass     same
    net:reuseport_bpf_cpu                 pass     pass     pass     pass     same
    net:reuseport_bpf_numa                pass     pass     pass     pass     same
    net:reuseport_dualstack               pass     pass     pass     pass     same
    net:rps_default_mask.sh               fail     fail     fail     fail     same
    net:rtnetlink.sh                      skip     skip     skip     skip     same
    net:run_afpackettests                 pass     pass     pass     pass     same
    net:run_netsocktests                  pass     pass     pass     pass     same
    net:rxtimestamp.sh                    pass     pass     pass     pass     same
    net:so_txtime.sh                      fail     fail     fail     fail     same
    net:test_bpf.sh                       pass     pass     pass     pass     same
    net:test_vxlan_fdb_changelink.sh      pass     pass     pass     pass     same
    net:tls                               pass     pass     pass     pass     same
    net:traceroute.sh                     pass     pass     pass     pass     same
    net:udpgro.sh                         fail     fail     fail     fail     same
    net:udpgro_bench.sh                   fail     fail     fail     fail     same
    net:udpgso.sh                         pass     pass     pass     pass     same
    net:veth.sh                           fail     fail     fail     fail     same
    net:vrf-xfrm-tests.sh                 pass     pass     pass     pass     same
    netfilter:conntrack_icmp_related.sh   pass     pass     pass     pass     same
    netfilter:conntrack_tcp_unreplied.sh  fail     fail     fail     fail     same
    netfilter:ipvs.sh                     skip     skip     skip     skip     same
    netfilter:nft_flowtable.sh            fail     fail     fail     fail     same
    netfilter:nft_meta.sh                 pass     pass     pass     pass     same
    netfilter:nft_nat.sh                  fail     fail     fail     fail     same
    netfilter:nft_queue.sh                pass     pass     pass     pass     same
    netfilter:rpath.sh                    pass     pass     pass     pass     same


# Specific tests: could not replicate

An attempt was made to test the change specifically for the patched vulnerability. The CVE author included a proof of concept program at <https://www.openwall.com/lists/oss-security/2023/09/22/10/1>. Unfortunately, the reported errors could not have been reproduced using this tool. The program was compiled and run on the reference kernel for two architectures `x86_64` and `aarch64`, using kernel configuration with `CONFIG_UBSAN` enabled. What was expected were UBSAN's array-index-out-of-bounds messages similar to those given at <https://www.openwall.com/lists/oss-security/2023/09/22/10>.

    ===================== [Splash] ========================
    [    6.059960] UBSAN: array-index-out-of-bounds in net/netfilter/ipset/ip_set_hash_gen.h:344:2
    [    6.061493] index -1 is out of range for type 'struct net_prefixes[128]'
    [    6.062601] CPU: 0 PID: 452 Comm: poc Not tainted 6.5.0+ #56
    [    6.063538] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.15.0-1 04/01/2014
    [    6.064455] Call Trace:
    [    6.064570]  <TASK>
    [    6.064675]  dump_stack_lvl+0x54/0x70
    [    6.064848]  __ubsan_handle_out_of_bounds+0xd6/0x100
    ...

Instead the program was finishing without errors and the machine kept working fine. The specific tests were then abandoned.

