### PR TITLE
[LTS 9.2] netfilter: ipset: add the missing IP_SET_HASH_WITH_NET0 macro for ip_…

### DIFF
--- a/net/netfilter/ipset/ip_set_hash_netportnet.c
+++ b/net/netfilter/ipset/ip_set_hash_netportnet.c
@@ -36,6 +36,7 @@ MODULE_ALIAS("ip_set_hash:net,port,net");
 #define IP_SET_HASH_WITH_PROTO
 #define IP_SET_HASH_WITH_NETS
 #define IPSET_NET_COUNT 2
+#define IP_SET_HASH_WITH_NET0
 
 /* IPv4 variant */
 


### PR DESCRIPTION
[LTS 9.2]
CVE-2023-42753
VULN-6670


# Problem

<https://nvd.nist.gov/vuln/detail/CVE-2023-42753>

> An array indexing vulnerability was found in the netfilter subsystem of the Linux kernel. A missing macro could lead to a miscalculation of the \`h->nets\` array offset, providing attackers with the primitive to arbitrarily increment/decrement a memory buffer out-of-bound. This issue may allow a local user to crash the system or potentially escalate their privileges on the system.

Original:
<https://www.openwall.com/lists/oss-security/2023/09/22/10>


# Solution (same as <https://github.com/ctrliq/kernel-src-tree/pull/325>)

The fix in mainline is given in 050d91c03b28ca479df13dfb02bcd2c60dd6a878. All official backports have the same form. The fix is already present in Rockys CBR 7.9 (b0f9309936a66eea6d0140d0c7baf0ddf144b0c9), LTS 8.6 (fba0aafe2c620d3af607fb6679bf36074aa6ef09) and LTS 9.4 (ab90fdc7c7bcec8627c6e7fede3e097734be7b3c, ported by RedHat), all in the same form. It applies to LTS 9.2 smoothly as well.


# kABI check: passed

    DEBUG=1 CVE=CVE-2023-42753 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_2-CVE-2023-42753

    [0/1] Check ABI of kernel [ciqlts9_2-CVE-2023-42753]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2023-42753/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2023-42753/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20659236/boot-test.log>)


# Kselftests: passed relative


## Coverage

`net` (except `gro.sh`, `udpgro_fwd.sh`, `ip_defrag.sh`, `reuseport_addr_any.sh`, `fib_nexthops.sh`, `xfrm_policy.sh`, `udpgso_bench.sh`, `reuseaddr_conflict`, `txtimestamp.sh`), `netfilter` (except `nft_trans_stress.sh`)

Following the discussion on Slack, and having established already what seems to be a set of stable tests for the LTS 9.2 version (no flappy results) - the only remaining reason for running full selftests routine for the last two months - a test run was done this time for the subsystems most likely affected by the change only.


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/20659235/kselftests--ciqlts9_2--run1.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/20659234/kselftests--ciqlts9_2--run2.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-2023-42753&#x2013;run1.log](<https://github.com/user-attachments/files/20659233/kselftests--ciqlts9_2-CVE-2023-42753--run1.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-2023-42753&#x2013;run2.log](<https://github.com/user-attachments/files/20659231/kselftests--ciqlts9_2-CVE-2023-42753--run2.log>)


## Comparison

The test results are the same in the reference and patched kernel (presenting full results comparison):

    $ ktests.xsh diff kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2--run2.log
    Status2   kselftests--ciqlts9_2-CVE-2023-42753--run1.log
    Status3   kselftests--ciqlts9_2-CVE-2023-42753--run2.log
    
    TestCase                              Status0  Status1  Status2  Status3  Summary
    net:altnames.sh                       pass     pass     pass     pass     same
    net:bareudp.sh                        pass     pass     pass     pass     same
    net:cmsg_so_mark.sh                   pass     pass     pass     pass     same
    net:devlink_port_split.py             skip     skip     skip     skip     same
    net:drop_monitor_tests.sh             skip     skip     skip     skip     same
    net:fcnal-test.sh                     skip     skip     skip     skip     same
    net:fib-onlink-tests.sh               pass     pass     pass     pass     same
    net:fib_nexthop_multiprefix.sh        pass     pass     pass     pass     same
    net:fib_rule_tests.sh                 pass     pass     pass     pass     same
    net:fib_tests.sh                      fail     fail     fail     fail     same
    net:fin_ack_lat.sh                    pass     pass     pass     pass     same
    net:gre_gso.sh                        skip     skip     skip     skip     same
    net:icmp.sh                           fail     fail     fail     fail     same
    net:icmp_redirect.sh                  pass     pass     pass     pass     same
    net:ip6_gre_headroom.sh               pass     pass     pass     pass     same
    net:ipv6_flowlabel.sh                 pass     pass     pass     pass     same
    net:l2tp.sh                           pass     pass     pass     pass     same
    net:msg_zerocopy.sh                   pass     pass     pass     pass     same
    net:netdevice.sh                      pass     pass     pass     pass     same
    net:pmtu.sh                           pass     pass     pass     pass     same
    net:psock_snd.sh                      pass     pass     pass     pass     same
    net:reuseaddr_ports_exhausted.sh      pass     pass     pass     pass     same
    net:reuseport_bpf                     pass     pass     pass     pass     same
    net:reuseport_bpf_cpu                 pass     pass     pass     pass     same
    net:reuseport_bpf_numa                pass     pass     pass     pass     same
    net:reuseport_dualstack               pass     pass     pass     pass     same
    net:route_localnet.sh                 pass     pass     pass     pass     same
    net:rps_default_mask.sh               fail     fail     fail     fail     same
    net:rtnetlink.sh                      skip     skip     skip     skip     same
    net:run_afpackettests                 pass     pass     pass     pass     same
    net:run_netsocktests                  pass     pass     pass     pass     same
    net:rxtimestamp.sh                    pass     pass     pass     pass     same
    net:so_txtime.sh                      pass     pass     pass     pass     same
    net:stress_reuseport_listen.sh        pass     pass     pass     pass     same
    net:tcp_fastopen_backup_key.sh        pass     pass     pass     pass     same
    net:test_blackhole_dev.sh             fail     fail     fail     fail     same
    net:test_bpf.sh                       pass     pass     pass     pass     same
    net:test_vxlan_fdb_changelink.sh      pass     pass     pass     pass     same
    net:test_vxlan_under_vrf.sh           pass     pass     pass     pass     same
    net:tls                               pass     pass     pass     pass     same
    net:traceroute.sh                     pass     pass     pass     pass     same
    net:udpgro.sh                         fail     fail     fail     fail     same
    net:udpgro_bench.sh                   fail     fail     fail     fail     same
    net:udpgso.sh                         pass     pass     pass     pass     same
    net:unicast_extensions.sh             pass     pass     pass     pass     same
    net:veth.sh                           fail     fail     fail     fail     same
    net:vrf-xfrm-tests.sh                 pass     pass     pass     pass     same
    net:vrf_route_leaking.sh              fail     fail     fail     fail     same
    net:vrf_strict_mode_test.sh           pass     pass     pass     pass     same
    netfilter:bridge_brouter.sh           skip     skip     skip     skip     same
    netfilter:conntrack_icmp_related.sh   pass     pass     pass     pass     same
    netfilter:conntrack_tcp_unreplied.sh  fail     fail     fail     fail     same
    netfilter:conntrack_vrf.sh            fail     fail     fail     fail     same
    netfilter:ipip-conntrack-mtu.sh       skip     skip     skip     skip     same
    netfilter:ipvs.sh                     skip     skip     skip     skip     same
    netfilter:nf_nat_edemux.sh            skip     skip     skip     skip     same
    netfilter:nft_concat_range.sh         fail     fail     fail     fail     same
    netfilter:nft_conntrack_helper.sh     skip     skip     skip     skip     same
    netfilter:nft_fib.sh                  pass     pass     pass     pass     same
    netfilter:nft_flowtable.sh            fail     fail     fail     fail     same
    netfilter:nft_meta.sh                 pass     pass     pass     pass     same
    netfilter:nft_nat.sh                  fail     fail     fail     fail     same
    netfilter:nft_queue.sh                pass     pass     pass     pass     same
    netfilter:rpath.sh                    pass     pass     pass     pass     same


# Specific tests: skipped

After the fiasko of replicating the bug in version `ciqlts8_8` using POC provided by the CVE author (<https://github.com/ctrliq/kernel-src-tree/pull/325>) the plan to repeat it in version `ciqlts9_2` was abandoned. Can be resumed on request.

