### PR TITLE
[fips-9] net: tls, update curr on splice as well

### DIFF
--- a/net/tls/tls_sw.c
+++ b/net/tls/tls_sw.c
@@ -1203,6 +1203,8 @@ alloc_payload:
 		}
 
 		sk_msg_page_add(msg_pl, page, copy, offset);
+		msg_pl->sg.copybreak = 0;
+		msg_pl->sg.curr = msg_pl->sg.end;
 		sk_mem_charge(sk, copy);
 
 		offset += copy;


### PR DESCRIPTION
jira VULN-8917
cve CVE-2024-0646

Same as https://github.com/ctrliq/kernel-src-tree/pull/317

```
commit-author John Fastabend <john.fastabend@gmail.com> commit c5a595000e2677e865a39f249c056bc05d6e55fd
upstream-diff used linux-stable LT-5.15 sha ba5efd8544fa62ae85daeb36077468bf2ce974ab

commit c5a595000e2677e865a39f249c056bc05d6e55fd upstream.

The curr pointer must also be updated on the splice similar to how we do this for other copy types.

Fixes: d829e9c4112b ("tls: convert to generic sk_msg interface")
	Signed-off-by: John Fastabend <john.fastabend@gmail.com>
	Reported-by: Jann Horn <jannh@google.com>
Link: https://lore.kernel.org/r/20231206232706.374377-2-john.fastabend@gmail.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
	Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
(cherry picked from commit ba5efd8544fa62ae85daeb36077468bf2ce974ab)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
  CLEAN   arch/x86/tools
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old
[TIMER]{MRPROPER}: 12s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
--
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] virt/lib/irqbypass.ko
  BTF [M] sound/xen/snd_xen_front.ko
[TIMER]{BUILD}: 919s
Making Modules
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+/kernel/arch/x86/crypto/camellia-x86_64.ko
--
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+
[TIMER]{MODULES}: 7s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 56s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 12s
[TIMER]{BUILD}: 919s
[TIMER]{MODULES}: 7s
[TIMER]{INSTALL}: 56s
[TIMER]{TOTAL} 1013s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the fix

[selftest-5.14.0-284.30.1.el9_2.ciqfips.0.12.3.x86_64.log](https://github.com/user-attachments/files/20677288/selftest-5.14.0-284.30.1.el9_2.ciqfips.0.12.3.x86_64.log)

[selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+.log](https://github.com/user-attachments/files/20677291/selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29%2B.log)

```
brett@lycia ~/ciq/vuln-8917 % grep ^ok selftest-5.14.0-284.30.1.el9_2.ciqfips.0.12.3.x86_64.log | wc -l
331
brett@lycia ~/ciq/vuln-8917 % grep ^ok selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8917-9c20d49bed29+.log | wc -l
335
brett@lycia ~/ciq/vuln-8917 %

```