### PR TITLE
Partial revert of "In essiv_aead_setkey(), use the same logic as crypto_authenc_esn_setkey() to zeroize keys on exit."

### DIFF
--- a/crypto/essiv.c
+++ b/crypto/essiv.c
@@ -119,9 +119,11 @@ static int essiv_aead_setkey(struct crypto_aead *tfm, const u8 *key,
 	crypto_cipher_clear_flags(tctx->essiv_cipher, CRYPTO_TFM_REQ_MASK);
 	crypto_cipher_set_flags(tctx->essiv_cipher, crypto_aead_get_flags(tfm) &
 						    CRYPTO_TFM_REQ_MASK);
+	err = crypto_cipher_setkey(tctx->essiv_cipher, salt,
+				   crypto_shash_digestsize(tctx->hash));
 out:
 	memzero_explicit(&keys, sizeof(keys));
-    return err;
+	return err;
 }
 
 static int essiv_aead_setauthsize(struct crypto_aead *tfm,


### PR DESCRIPTION
Fix a FIPS bug that got into the FIPS 9.2 code by mistake. This *only* affects the 9.2 FIPS kernel, no other kernel.

A bug was introduced while updating the kernel per atsec’s request. When key zeroization was added, setting the crypto algorithm key was removed in error. This re-adds the code to set the crypto key.

We can only fix this in compliant, as it touches the crypto code that is frozen in certified.

See this ticket for details:

https://ciqinc.atlassian.net/browse/LE-3197

Tested under non-FIPS and FIPS mode. NB. This bug only causes the algorithm to be unusable and an error message returned to users. No corruption or insecure algorithm use is allowed.
