### PR TITLE
[fipslegacy-8.6] net: sched: Fix use after free in red_enqueue()

### DIFF
--- a/net/sched/sch_red.c
+++ b/net/sched/sch_red.c
@@ -76,6 +76,7 @@ static int red_enqueue(struct sk_buff *skb, struct Qdisc *sch,
 {
 	struct red_sched_data *q = qdisc_priv(sch);
 	struct Qdisc *child = q->qdisc;
+	unsigned int len;
 	int ret;
 
 	q->vars.qavg = red_calc_qavg(&q->parms,
@@ -130,9 +131,10 @@ static int red_enqueue(struct sk_buff *skb, struct Qdisc *sch,
 		break;
 	}
 
+	len = qdisc_pkt_len(skb);
 	ret = qdisc_enqueue(skb, child, to_free);
 	if (likely(ret == NET_XMIT_SUCCESS)) {
-		qdisc_qstats_backlog_inc(sch, skb);
+		sch->qstats.backlog += len;
 		sch->q.qlen++;
 	} else if (net_xmit_drop_count(ret)) {
 		q->stats.pdrop++;


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-66500
cve CVE-2022-49921
commit-author Dan Carpenter <dan.carpenter@oracle.com> commit 8bdc2acd420c6f3dd1f1c78750ec989f02a1e2b9

We can't use "skb" again after passing it to qdisc_enqueue().  This is basically identical to commit 2f09707d0c97 ("sch_sfb: Also store skb len before calling child enqueue").

Fixes: d7f4f332f082 ("sch_red: update backlog as well")
	Signed-off-by: Dan Carpenter <dan.carpenter@oracle.com>
	Reviewed-by: Eric Dumazet <edumazet@google.com>
	Signed-off-by: David S. Miller <davem@davemloft.net>
(cherry picked from commit 8bdc2acd420c6f3dd1f1c78750ec989f02a1e2b9)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
  CLEAN    resolve_btfids
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   include/config include/generated arch/x86/include/generated
  CLEAN   .config .config.old
[TIMER]{MRPROPER}: 2s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-ajain__fips-legacy-8-compliant_4.18.0-425.13.1-46dfc96bb"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  HOSTCC  scripts/basic/bin2c
  UPD     include/config/kernel.release
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  UPD     include/generated/uapi/linux/version.h
  UPD     include/generated/utsrelease.h
  DESCEND objtool
  HOSTCC  /home/anmol/kernel-src-tree/tools/objtool/fixdep.o
  HOSTLD  /home/anmol/kernel-src-tree/tools/objtool/fixdep-in.o
  LINK    /home/anmol/kernel-src-tree/tools/objtool/fixdep
[--snip--]
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL virt/lib/irqbypass.ko
  INSTALL sound/xen/snd_xen_front.ko
  DEPMOD  4.18.0-ajain__fips-legacy-8-compliant_4.18.0-425.13.1-46dfc96bb+
[TIMER]{MODULES}: 20s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-ajain__fips-legacy-8-compliant_4.18.0-425.13.1-46dfc96bb+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 31s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-ajain__fips-legacy-8-compliant_4.18.0-425.13.1-f45f0226d+ and Index to 9
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-ajain__fips-legacy-8-compliant_4.18.0-425.13.1-f45f0226d+.conf with index 9 and kernel /boot/vmlinuz-4.18.0-ajain__fips-legacy-8-compliant_4.18.0-425.13.1-f45f0226d+
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-ajain__fips-legacy-8-compliant_4.18.0-425.13.1-f45f0226d+.conf with index 9 and kernel /boot/vmlinuz-4.18.0-ajain__fips-legacy-8-compliant_4.18.0-425.13.1-f45f0226d+
Generating grub configuration file ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 2s
[TIMER]{BUILD}: 3008s
[TIMER]{MODULES}: 20s
[TIMER]{INSTALL}: 31s
[TIMER]{TOTAL} 3065s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/20694660/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
204
204
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
53
53
```
[kselftest-after.log](https://github.com/user-attachments/files/20694661/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/20694662/kselftest-before.log)
