### PR TITLE
ktests wiki: breakpoints: basic description, compilation tips

### DIFF
--- a/kselftests/breakpoints/README.rst
+++ b/kselftests/breakpoints/README.rst
@@ -1,0 +1,256 @@
+About
+=====
+
+This collection tests the ``ptrace()`` system call, specifically the
+ability of a tracer to set breakpoints (on functions) and watchpoints
+(on variables) in the tracee and whether they are correctly triggered
+when tracee hits them.
+
+The ``breakpoint_test`` test from the collection is chronologically the
+very first kernel selftest.
+
+Tests suite compilation and running
+===================================
+
+The suite generally contains two tests:
+
+#. ``breakpoint_test`` (on x86\* platforms) or ``breakpoint_test_arm64``
+   (on the arm64 platforms),
+#. ``step_after_suspend_test``.
+
+For other platforms than x86\* and arm64 the suite contains only
+``step_after_suspend_test``.
+
+``breakpoint_test``
+-------------------
+
+When compiling the ``breakpoints`` collection on *x86_64* beware not to
+set the ``ARCH`` variable explicitly, or the ``breakpoint_test`` test
+won't be produced. So, if your ``uname -m`` reports ``x86_64`` then this
+is ok:
+
+.. code:: shell
+
+   make -C tools/testing/selftests TARGETS=breakpoints
+
+and this is **not** ok:
+
+.. code:: shell
+
+   make ARCH=x86_64 -C tools/testing/selftests TARGETS=breakpoints
+
+It's obviously a bug in the
+``tools/testing/selftests/breakpoints/Makefile`` file, precisely in the
+way the ``ARCH`` variable is normalized with ``sed``, with this
+normalization being bound to setting default ``ARCH`` value instead of
+being general,
+
+.. code:: makefile
+
+   ARCH ?= $(shell echo $(uname_M) | sed -e s/i.86/x86/ -e s/x86_64/x86/)
+
+yet the conditional compilation of ``breakpoint_test`` assuming this
+normalization in all cases.
+
+If compiled successfully the test is expected to pass on all versions
+with a message similar to
+
+::
+
+   TAP version 13
+   1..1
+   # timeout set to 45
+   # selftests: breakpoints: breakpoint_test
+   # TAP version 13
+   # 1..110
+   # ok 1 Test breakpoint 0 with local: 0 global: 1
+   # ok 2 Test breakpoint 1 with local: 0 global: 1
+   # ok 3 Test breakpoint 2 with local: 0 global: 1
+   # ok 4 Test breakpoint 3 with local: 0 global: 1
+   # ok 5 Test breakpoint 0 with local: 1 global: 0
+   # ok 6 Test breakpoint 1 with local: 1 global: 0
+   …
+   # ok 104 Test read watchpoint 3 with len: 8 local: 1 global: 0
+   # ok 105 Test read watchpoint 0 with len: 8 local: 1 global: 1
+   # ok 106 Test read watchpoint 1 with len: 8 local: 1 global: 1
+   # ok 107 Test read watchpoint 2 with len: 8 local: 1 global: 1
+   # ok 108 Test read watchpoint 3 with len: 8 local: 1 global: 1
+   # ok 109 Test icebp
+   # ok 110 Test int 3 trap
+   # # Totals: pass:110 fail:0 xfail:0 xpass:0 skip:0 error:0
+   ok 1 selftests: breakpoints: breakpoint_test
+
+``breakpoint_test_arm64``
+-------------------------
+
+On versions ``ciqlts8_6``, ``ciqlts8_8`` the test contains a bug which
+prevents it from being compiled successfully for ``arm64``:
+
+::
+
+   gcc     breakpoint_test_arm64.c /mnt/build_files/kernel-src-tree-kselftests-ciqlts8_8/tools/testing/selftests/kselftest_harness.h /mnt/build_files/kernel-src-tree-kselftests-ciqlts8_8/tools/testing/selftests/kselftest.h  -o /mnt/build_files/kernel-src-tree-kselftests-ciqlts8_8/tools/testing/selftests/breakpoints/breakpoint_test_arm64
+   breakpoint_test_arm64.c: In function ‘main’:
+   breakpoint_test_arm64.c:226:14: warning: implicit declaration of function ‘run_test’; did you mean ‘arun_test’? [-Wimplicit-function-declaration]
+        result = run_test(size, MIN(size, 8), wr, wp);
+                 ^~~~~~~~
+                 arun_test
+   /tmp/cc5dMu7r.o: In function `main':
+   breakpoint_test_arm64.c:(.text+0xb08): undefined reference to `run_test'
+   breakpoint_test_arm64.c:(.text+0xc10): undefined reference to `run_test'
+   collect2: error: ld returned 1 exit status
+
+This bug was fixed in the mainline with the
+``5b06eeae52c02dd0d9bc8488275a1207d410870b`` commit. It's in the process
+of backporting to ``ciqlts8_6``, ``ciqlts8_8`` at the time of this
+writing.
+
+Additionally, when compiling the test on base cloud images for
+``ciqlts8_6`` and ``ciqlts8_8``\  [1]_, and using Mountain-provided
+repositories, the following error may be encountered:
+
+::
+
+   breakpoint_test_arm64.c: In function ‘run_test’:
+   breakpoint_test_arm64.c:188:25: error: ‘TRAP_HWBKPT’ undeclared (first use in this function); did you mean ‘TRAP_BRKPT’?
+     if (siginfo.si_code != TRAP_HWBKPT) {
+                            ^~~~~~~~~~~
+                            TRAP_BRKPT
+   breakpoint_test_arm64.c:188:25: note: each undeclared identifier is reported only once for each function it appears in
+
+The ``TRAP_BRKPT`` constant is searched for in the
+``/usr/include/bits/siginfo-consts.h`` file, which in versions ≥ 9.2
+contains
+
+.. code:: c
+
+   /* `si_code' values for SIGTRAP signal.  */
+   enum
+   {
+     TRAP_BRKPT = 1,       /* Process breakpoint.  */
+   #  define TRAP_BRKPT    TRAP_BRKPT
+     TRAP_TRACE,           /* Process trace trap.  */
+   #  define TRAP_TRACE    TRAP_TRACE
+     TRAP_BRANCH,          /* Process taken branch trap.  */
+   #  define TRAP_BRANCH   TRAP_BRANCH
+     TRAP_HWBKPT,          /* Hardware breakpoint/watchpoint.  */
+   #  define TRAP_HWBKPT   TRAP_HWBKPT
+     TRAP_UNK          /* Undiagnosed trap.  */
+   #  define TRAP_UNK  TRAP_UNK
+   };
+   # endif
+
+while in versions < 9.2 contains
+
+.. code:: c
+
+   /* `si_code' values for SIGTRAP signal.  */
+   enum
+   {
+     TRAP_BRKPT = 1,       /* Process breakpoint.  */
+   #  define TRAP_BRKPT    TRAP_BRKPT
+     TRAP_TRACE            /* Process trace trap.  */
+   #  define TRAP_TRACE    TRAP_TRACE
+   };
+   # endif
+
+If the ``TRAP_HWBKPT`` constant can't be included in
+``/usr/include/bits/siginfo-consts.h`` in some civilised manner then
+simply expanding the set of known ``TRAP_*`` codes in the system to
+match those on ≥ 9.2 should work:
+
+.. code:: shell
+
+   sudo sed -e '144 d' -e 's/#  define TRAP_TRACE\tTRAP_TRACE/  TRAP_TRACE,\n#  define TRAP_TRACE\tTRAP_TRACE\n  TRAP_BRANCH,\n#  define TRAP_BRANCH\tTRAP_BRANCH\n  TRAP_HWBKPT,\n#  define TRAP_HWBKPT\tTRAP_HWBKPT\n  TRAP_UNK\n#  define TRAP_UNK\tTRAP_UNK/g' -i /usr/include/bits/siginfo-consts.h
+
+No compilation problems for ``breakpoint_test_arm64`` were encountered
+on versions ``ciqlts9_2`` and ``ciqlts9_4``.
+
+If the test compiled successfully it's expected to pass with the message
+similar to the following
+
+::
+
+   # TAP version 13
+   # 1..213
+   # # child did not single-step
+   # ok 1 Test size = 1 write offset = 0 watchpoint offset = -1
+   # ok 2 Test size = 1 write offset = 0 watchpoint offset = 0
+   # # child did not single-step
+   # ok 3 Test size = 1 write offset = 0 watchpoint offset = 1
+   # # child did not single-step
+   # ok 4 Test size = 1 write offset = 1 watchpoint offset = 0
+   # ok 5 Test size = 1 write offset = 1 watchpoint offset = 1
+   …
+   # ok 206 Test size = 32 write offset = 32 watchpoint offset = 32
+   # # child did not single-step
+   # ok 207 Test size = 32 write offset = 32 watchpoint offset = 64
+   # ok 208 Test size = 1 write offset = -1 watchpoint offset = -8
+   # ok 209 Test size = 2 write offset = -2 watchpoint offset = -8
+   # ok 210 Test size = 4 write offset = -4 watchpoint offset = -8
+   # ok 211 Test size = 8 write offset = -8 watchpoint offset = -8
+   # ok 212 Test size = 16 write offset = -16 watchpoint offset = -8
+   # ok 213 Test size = 32 write offset = -32 watchpoint offset = -8
+   # # Totals: pass:213 fail:0 xfail:0 xpass:0 skip:0 error:0
+   ok 1 selftests: breakpoints: breakpoint_test_arm64
+
+``step_after_suspend_test``
+---------------------------
+
+No problems were encountered when compiling this test, on any of the
+versions ``ciqlts8_6``, ``ciqlts8_8``, ``ciqlts9_2``, ``ciqlts9_4``,
+archs ``x86_64``, ``aarch64``. However, for the test to run the system
+must provide the ability to suspend it, as it would be done with
+
+::
+
+   root@…# echo mem > /sys/power/state
+
+Can be checked with this command directly, that's what
+``step_after_suspend_test`` is doing internally. Unfortunately on the
+qemu-kvm virtual machines this fails with the ``virtio-pci`` device (the
+one connecting the machine with the hypervisor) refusing to cooperate:
+
+::
+
+   [root@ciqlts-9-2 pvts]# echo mem > /sys/power/state
+   [   24.434434] PM: suspend entry (s2idle)
+   [   24.498974] Filesystems sync: 0.062 seconds
+   [   24.501574] Freezing user space processes ... (elapsed 0.001 seconds) done.
+   [   24.507156] OOM killer disabled.
+   [   24.509062] Freezing remaining freezable tasks ... (elapsed 0.001 seconds) done.
+   [   24.514480] printk: Suspending console(s) (use no_console_suspend to debug)
+   [   24.540895] virtio-fs: suspend/resume not yet supported
+   [   24.540906] virtio-pci 0000:03:00.0: PM: pci_pm_suspend(): virtio_pci_freeze+0x0/0x50 returns -95
+   [   24.540970] virtio-pci 0000:03:00.0: PM: dpm_run_callback(): pci_pm_suspend+0x0/0x170 returns -95
+   [   24.541011] virtio-pci 0000:03:00.0: PM: failed to suspend async: error -95
+   [   24.554785] PM: Some devices failed to suspend, or early wake event detected
+   [   24.686487] OOM killer enabled.
+   [   24.687385] Restarting tasks ... done.
+   [   24.689834] PM: suspend exit
+   bash: echo: write error: Operation not supported
+   [root@ciqlts-9-2 pvts]# [   24.886811] ata3: SATA link down (SStatus 0 SControl 300)
+   [   24.889470] ata5: SATA link down (SStatus 0 SControl 300)
+   [   24.892095] ata2: SATA link down (SStatus 0 SControl 300)
+   [   24.894956] ata4: SATA link down (SStatus 0 SControl 300)
+   [   24.897717] ata6: SATA link down (SStatus 0 SControl 300)
+
+When running selftests in qemu-kvm it's therefore best to omit this
+test, or else it will keep scaring with failures like
+
+::
+
+   # selftests: breakpoints: step_after_suspend_test
+   # TAP version 13
+   # Bail out! Failed to enter Suspend state
+   # # Totals: pass:0 fail:0 xfail:0 xpass:0 skip:0 error:0
+   not ok 1 selftests: breakpoints: step_after_suspend_test # exit=1
+
+(Probably a better behavior would be for the test to ``# SKIP`` in this
+case.)
+
+.. [1]
+   Referring to the images available at
+   https://download.rockylinux.org/vault/rocky/8.6/images/Rocky-8-GenericCloud-8.6.20220702.0.aarch64.qcow2
+   for ``ciqlts8_6`` and at
+   https://download.rockylinux.org/vault/rocky/8.8/images/aarch64/Rocky-8-GenericCloud-Base-8.8-20230518.0.aarch64.qcow2
+   for ``ciqlts8_8``, to be precise.


### PR DESCRIPTION
Another tests collection to expose: `breakpoints`.

TLDR: There are only two tests. The `step_after_suspend_test` won't work when run in qemu so it can (and should) be skipped. The `breakpoint_test` (and its arm64 equivalent `breakpoint_test_arm64`) has some compilation gimmicks but once built it should run fine and always pass. Moreover, it's testing  a rather important functionality of the kernel as well as being quick and straightforward, so it's a good candidate to be included in the sanity checks.


# Sidenote

I'll need to systematize this effort a bit or nothing productive will come out of it as there are too many tests (~200-300) and at the current speed dictated by the stolen time between CVEs covering them all will take me years.

The overarching goal is to define a good sanity check tests suite. 

For this it makes sense to pick the tests in the order of how essential the subsystems are which they test. In this way a good sanity tests suite should be found way before all the tests are examined. Finding out which tests are essential is part of examining them though, so I'll use a small heuristic and research the tests in the order of when they were introduced to the code base chronologically. Hopefully the kernel devs were testing the essential features first, too.

Here's a table of all makefiles from the `tools/testing/selftests/` trunk, ordered by their creation commit date. It should be of use if anyone else wished to join the effort of examining the selftests so that we know what we're actually doing:

    | Makefile                                                                           | Date       |
    |------------------------------------------------------------------------------------+------------|
    | tools/testing/selftests/Makefile                                                   | 2012-01-12 |
    | tools/testing/selftests/breakpoints/Makefile                                       | 2012-01-12 |
    | tools/testing/selftests/kcmp/Makefile                                              | 2012-05-31 |
    | tools/testing/selftests/mqueue/Makefile                                            | 2012-05-31 |
    | tools/testing/selftests/cpu-hotplug/Makefile                                       | 2012-07-30 |
    | tools/testing/selftests/memory-hotplug/Makefile                                    | 2012-07-30 |
    | tools/testing/selftests/ipc/Makefile                                               | 2013-01-04 |
    | tools/testing/selftests/efivarfs/Makefile                                          | 2013-02-27 |
    | tools/testing/selftests/net/Makefile                                               | 2013-03-20 |
    | tools/testing/selftests/ptrace/Makefile                                            | 2013-04-30 |
    | tools/testing/selftests/timers/Makefile                                            | 2013-07-03 |
    | tools/testing/selftests/powerpc/Makefile                                           | 2013-08-14 |
    | tools/testing/selftests/powerpc/pmu/Makefile                                       | 2013-08-14 |
    | tools/testing/selftests/user/Makefile                                              | 2014-01-23 |
    | tools/testing/selftests/powerpc/copyloops/Makefile                                 | 2014-03-07 |
    | tools/testing/selftests/powerpc/mm/Makefile                                        | 2014-06-06 |
    | tools/testing/selftests/sysctl/Makefile                                            | 2014-06-06 |
    | tools/testing/selftests/powerpc/tm/Makefile                                        | 2014-06-11 |
    | tools/testing/selftests/powerpc/pmu/ebb/Makefile                                   | 2014-06-11 |
    | tools/testing/selftests/firmware/Makefile                                          | 2014-07-17 |
    | tools/testing/selftests/mount/Makefile                                             | 2014-07-31 |
    | tools/testing/selftests/memfd/Makefile                                             | 2014-08-08 |
    | tools/testing/selftests/ftrace/Makefile                                            | 2014-09-23 |
    | tools/testing/selftests/powerpc/primitives/Makefile                                | 2014-09-30 |
    | tools/testing/selftests/size/Makefile                                              | 2014-12-03 |
    | tools/testing/selftests/exec/Makefile                                              | 2014-12-13 |
    | tools/testing/selftests/powerpc/stringloops/Makefile                               | 2015-01-23 |
    | tools/testing/selftests/powerpc/vphn/Makefile                                      | 2015-03-18 |
    | tools/testing/selftests/powerpc/switch_endian/Makefile                             | 2015-03-28 |
    | tools/testing/selftests/x86/Makefile                                               | 2015-04-08 |
    | tools/testing/selftests/futex/Makefile                                             | 2015-05-26 |
    | tools/testing/selftests/futex/functional/Makefile                                  | 2015-05-26 |
    | tools/testing/selftests/powerpc/dscr/Makefile                                      | 2015-06-07 |
    | tools/testing/selftests/seccomp/Makefile                                           | 2015-06-17 |
    | tools/testing/selftests/static_keys/Makefile                                       | 2015-08-03 |
    | tools/testing/selftests/zram/Makefile                                              | 2015-08-27 |
    | tools/testing/selftests/capabilities/Makefile                                      | 2015-09-04 |
    | tools/testing/selftests/membarrier/Makefile                                        | 2015-09-11 |
    | tools/testing/selftests/powerpc/benchmarks/Makefile                                | 2015-10-01 |
    | tools/testing/selftests/powerpc/syscalls/Makefile                                  | 2015-10-15 |
    | tools/testing/selftests/pstore/Makefile                                            | 2015-10-15 |
    | tools/testing/selftests/lib/Makefile                                               | 2015-11-06 |
    | tools/testing/selftests/intel_pstate/Makefile                                      | 2015-11-23 |
    | tools/testing/selftests/media_tests/Makefile                                       | 2016-02-25 |
    | tools/testing/selftests/powerpc/math/Makefile                                      | 2016-03-02 |
    | tools/testing/selftests/sigaltstack/Makefile                                       | 2016-05-03 |
    | tools/testing/selftests/powerpc/alignment/Makefile                                 | 2016-07-05 |
    | tools/testing/selftests/filesystems/Makefile                                       | 2016-09-20 |
    | tools/testing/selftests/vDSO/Makefile                                              | 2016-09-20 |
    | tools/testing/selftests/ia64/Makefile                                              | 2016-09-20 |
    | tools/testing/selftests/prctl/Makefile                                             | 2016-09-20 |
    | tools/testing/selftests/watchdog/Makefile                                          | 2016-09-20 |
    | tools/testing/selftests/ptp/Makefile                                               | 2016-09-20 |
    | tools/testing/selftests/nsfs/Makefile                                              | 2016-09-22 |
    | tools/testing/selftests/powerpc/signal/Makefile                                    | 2016-10-04 |
    | tools/testing/selftests/bpf/Makefile                                               | 2016-10-18 |
    | tools/testing/selftests/powerpc/ptrace/Makefile                                    | 2016-11-17 |
    | tools/testing/selftests/sync/Makefile                                              | 2016-12-01 |
    | tools/testing/selftests/gpio/Makefile                                              | 2016-12-13 |
    | tools/testing/selftests/cpufreq/Makefile                                           | 2017-01-19 |
    | tools/testing/selftests/rcutorture/formal/srcu-cbmc/tests/store_buffering/Makefile | 2017-01-25 |
    | tools/testing/selftests/rcutorture/formal/srcu-cbmc/Makefile                       | 2017-01-25 |
    | tools/testing/selftests/splice/Makefile                                            | 2017-02-18 |
    | tools/testing/selftests/powerpc/cache_shape/Makefile                               | 2017-03-20 |
    | tools/testing/selftests/kmod/Makefile                                              | 2017-07-14 |
    | tools/testing/selftests/kvm/Makefile                                               | 2018-04-04 |
    | tools/testing/selftests/proc/Makefile                                              | 2018-04-11 |
    | tools/testing/selftests/uevent/Makefile                                            | 2018-05-23 |
    | tools/testing/selftests/locking/Makefile                                           | 2018-05-30 |
    | tools/testing/selftests/cgroup/Makefile                                            | 2018-05-30 |
    | tools/testing/selftests/rtc/Makefile                                               | 2018-05-30 |
    | tools/testing/selftests/sparc64/Makefile                                           | 2018-06-05 |
    | tools/testing/selftests/sparc64/drivers/Makefile                                   | 2018-06-05 |
    | tools/testing/selftests/rseq/Makefile                                              | 2018-06-06 |
    | tools/testing/selftests/drivers/dma-buf/Makefile                                   | 2018-09-03 |
    | tools/testing/selftests/powerpc/security/Makefile                                  | 2018-10-20 |
    | tools/testing/selftests/ir/Makefile                                                | 2018-11-06 |
    | tools/testing/selftests/netfilter/Makefile                                         | 2018-11-12 |
    | tools/testing/selftests/livepatch/Makefile                                         | 2019-01-11 |
    | tools/testing/selftests/filesystems/binderfs/Makefile                              | 2019-01-30 |
    | tools/testing/selftests/tpm2/Makefile                                              | 2019-02-08 |
    | tools/testing/selftests/safesetid/Makefile                                         | 2019-02-12 |
    | tools/testing/selftests/pidfd/Makefile                                             | 2019-03-05 |
    | tools/testing/selftests/tmpfs/Makefile                                             | 2019-03-05 |
    | tools/testing/selftests/kexec/Makefile                                             | 2019-04-17 |
    | tools/testing/selftests/rcutorture/Makefile                                        | 2019-05-28 |
    | tools/testing/selftests/arm64/Makefile                                             | 2019-08-06 |
    | tools/testing/selftests/powerpc/eeh/Makefile                                       | 2019-09-05 |
    | tools/testing/selftests/clone3/Makefile                                            | 2019-10-21 |
    | tools/testing/selftests/dmabuf-heaps/Makefile                                      | 2019-10-25 |
    | tools/testing/selftests/arm64/tags/Makefile                                        | 2019-11-08 |
    | tools/testing/selftests/arm64/signal/Makefile                                      | 2019-11-08 |
    | tools/testing/selftests/filesystems/epoll/Makefile                                 | 2019-12-04 |
    | tools/testing/selftests/wireguard/qemu/Makefile                                    | 2019-12-16 |
    | tools/testing/selftests/lkdtm/Makefile                                             | 2020-01-10 |
    | tools/testing/selftests/timens/Makefile                                            | 2020-01-14 |
    | tools/testing/selftests/openat2/Makefile                                           | 2020-01-18 |
    | tools/testing/selftests/net/mptcp/Makefile                                         | 2020-01-24 |
    | tools/testing/selftests/resctrl/Makefile                                           | 2020-02-10 |
    | tools/testing/selftests/net/forwarding/Makefile                                    | 2020-03-23 |
    | tools/testing/selftests/pid_namespace/Makefile                                     | 2020-03-25 |
    | tools/testing/selftests/powerpc/nx-gzip/Makefile                                   | 2020-04-21 |
    | tools/testing/selftests/core/Makefile                                              | 2020-06-17 |
    | tools/testing/selftests/fpu/Makefile                                               | 2020-06-29 |
    | tools/testing/selftests/tc-testing/Makefile                                        | 2020-07-20 |
    | tools/testing/selftests/mincore/Makefile                                           | 2020-08-07 |
    | tools/testing/selftests/arm64/pauth/Makefile                                       | 2020-09-18 |
    | tools/testing/selftests/arm64/fp/Makefile                                          | 2020-09-18 |
    | tools/testing/selftests/arm64/mte/Makefile                                         | 2020-10-05 |
    | tools/testing/selftests/sgx/Makefile                                               | 2020-11-18 |
    | tools/testing/selftests/dma/Makefile                                               | 2020-11-27 |
    | tools/testing/selftests/syscall_user_dispatch/Makefile                             | 2020-12-02 |
    | tools/testing/selftests/bpf/bpf_testmod/Makefile                                   | 2020-12-03 |
    | tools/testing/selftests/mount_setattr/Makefile                                     | 2021-01-24 |
    | tools/testing/selftests/nci/Makefile                                               | 2021-01-29 |
    | tools/testing/selftests/arm64/bti/Makefile                                         | 2021-03-24 |
    | tools/testing/selftests/perf_events/Makefile                                       | 2021-04-16 |
    | tools/testing/selftests/landlock/Makefile                                          | 2021-04-22 |
    | tools/testing/selftests/rlimits/Makefile                                           | 2021-04-30 |
    | tools/testing/selftests/sched/Makefile                                             | 2021-05-12 |
    | tools/testing/selftests/damon/Makefile                                             | 2021-11-29 |
    | tools/testing/selftests/powerpc/papr_attributes/Makefile                           | 2022-03-30 |
    | tools/testing/selftests/powerpc/mce/Makefile                                       | 2022-04-07 |
    | tools/testing/selftests/powerpc/pmu/sampling_tests/Makefile                        | 2022-05-26 |
    | tools/testing/selftests/drivers/net/bonding/Makefile                               | 2022-12-08 |
    | tools/testing/selftests/drivers/net/team/Makefile                                  | 2022-12-08 |
    | tools/testing/selftests/tdx/Makefile                                               | 2023-01-19 |
    | tools/testing/selftests/iommu/Makefile                                             | 2023-03-09 |
    | tools/testing/selftests/hid/Makefile                                               | 2023-06-19 |
    | tools/testing/selftests/net/hsr/Makefile                                           | 2023-07-26 |
    | tools/testing/selftests/powerpc/dexcr/Makefile                                     | 2023-10-09 |
    | tools/testing/selftests/tty/Makefile                                               | 2023-10-13 |
    | tools/testing/selftests/mm/Makefile                                                | 2024-01-19 |

