### PR TITLE
[LTS 8.6] selftests: breakpoints: Fix a typo of function name

### DIFF
--- a/tools/testing/selftests/breakpoints/breakpoint_test_arm64.c
+++ b/tools/testing/selftests/breakpoints/breakpoint_test_arm64.c
@@ -118,7 +118,7 @@ static bool set_watchpoint(pid_t pid, int size, int wp)
 	return false;
 }
 
-static bool arun_test(int wr_size, int wp_size, int wr, int wp)
+static bool run_test(int wr_size, int wp_size, int wr, int wp)
 {
 	int status;
 	siginfo_t siginfo;


### PR DESCRIPTION
[LTS 8.6]


# About

This commit fixes the problem with the compilation of `breakpoints:breakpoint_test_arm64` test on `aarch64` architecture.

The situation is exactly the same as in <https://github.com/ctrliq/kernel-src-tree/pull/330> (The `ciqlts8_6` and `ciqlts8_8` have the same history for the files in `tools/testing/selftests/breakpoints`. Also the same issue with `TRAP_HWBKPT` as in `ciqlts8_8`). See also associated <https://github.com/ctrliq/kernel-src-tree/pull/336>.

