### PR TITLE
[lts86] mptcp: fix race on unaccepted mptcp sockets

### DIFF
--- a/net/mptcp/protocol.c
+++ b/net/mptcp/protocol.c
@@ -2263,6 +2263,11 @@ static void __mptcp_close_ssk(struct sock *sk, struct sock *ssk,
 		kfree_rcu(subflow, rcu);
 	} else {
 		/* otherwise tcp will dispose of the ssk and subflow ctx */
+		if (ssk->sk_state == TCP_LISTEN) {
+			tcp_set_state(ssk, TCP_CLOSE);
+			mptcp_subflow_queue_clean(ssk);
+			inet_csk_listen_stop(ssk);
+		}
 		__tcp_close(ssk, 0);
 
 		/* close acquired an extra ref */

--- a/net/mptcp/protocol.h
+++ b/net/mptcp/protocol.h
@@ -261,6 +261,7 @@ struct mptcp_sock {
 
 	u32 setsockopt_seq;
 	char		ca_name[TCP_CA_NAME_MAX];
+	struct mptcp_sock	*dl_next;
 };
 
 #define mptcp_lock_sock(___sk, cb) do {					\
@@ -549,6 +550,7 @@ void mptcp_close_ssk(struct sock *sk, struct sock *ssk,
 		     struct mptcp_subflow_context *subflow);
 void mptcp_subflow_send_ack(struct sock *ssk);
 void mptcp_subflow_reset(struct sock *ssk);
+void mptcp_subflow_queue_clean(struct sock *ssk);
 void mptcp_sock_graft(struct sock *sk, struct socket *parent);
 struct socket *__mptcp_nmpc_socket(const struct mptcp_sock *msk);
 

--- a/net/mptcp/subflow.c
+++ b/net/mptcp/subflow.c
@@ -1514,6 +1514,58 @@ static void subflow_state_change(struct sock *sk)
 	}
 }
 
+void mptcp_subflow_queue_clean(struct sock *listener_ssk)
+{
+	struct request_sock_queue *queue = &inet_csk(listener_ssk)->icsk_accept_queue;
+	struct mptcp_sock *msk, *next, *head = NULL;
+	struct request_sock *req;
+
+	/* build a list of all unaccepted mptcp sockets */
+	spin_lock_bh(&queue->rskq_lock);
+	for (req = queue->rskq_accept_head; req; req = req->dl_next) {
+		struct mptcp_subflow_context *subflow;
+		struct sock *ssk = req->sk;
+		struct mptcp_sock *msk;
+
+		if (!sk_is_mptcp(ssk))
+			continue;
+
+		subflow = mptcp_subflow_ctx(ssk);
+		if (!subflow || !subflow->conn)
+			continue;
+
+		/* skip if already in list */
+		msk = mptcp_sk(subflow->conn);
+		if (msk->dl_next || msk == head)
+			continue;
+
+		msk->dl_next = head;
+		head = msk;
+	}
+	spin_unlock_bh(&queue->rskq_lock);
+	if (!head)
+		return;
+
+	/* can't acquire the msk socket lock under the subflow one,
+	 * or will cause ABBA deadlock
+	 */
+	release_sock(listener_ssk);
+
+	for (msk = head; msk; msk = next) {
+		struct sock *sk = (struct sock *)msk;
+		bool slow;
+
+		slow = lock_sock_fast_nested(sk);
+		next = msk->dl_next;
+		msk->first = NULL;
+		msk->dl_next = NULL;
+		unlock_sock_fast(sk, slow);
+	}
+
+	/* we are still under the listener msk socket lock */
+	lock_sock_nested(listener_ssk, SINGLE_DEPTH_NESTING);
+}
+
 static int subflow_ulp_init(struct sock *sk)
 {
 	struct inet_connection_sock *icsk = inet_csk(sk);


### PR DESCRIPTION
jira VULN-52916
cve CVE-2022-49669

```
commit-author Paolo Abeni <pabeni@redhat.com>
commit 6aeed9045071f2252ff4e98fc13d1e304f33e5b0

When the listener socket owning the relevant request is closed, it frees the unaccepted subflows and that causes later deletion of the paired MPTCP sockets.

The mptcp socket's worker can run in the time interval between such delete operations. When that happens, any access to msk->first will cause an UaF access, as the subflow cleanup did not cleared such field in the mptcp socket.

Address the issue explicitly traversing the listener socket accept queue at close time and performing the needed cleanup on the pending msk.

Note that the locking is a bit tricky, as we need to acquire the msk socket lock, while still owning the subflow socket one.

Fixes: 86e39e04482b ("mptcp: keep track of local endpoint still available for each msk")
	Signed-off-by: Paolo Abeni <pabeni@redhat.com>
	Signed-off-by: Mat Martineau <mathew.j.martineau@linux.intel.com>
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 6aeed9045071f2252ff4e98fc13d1e304f33e5b0)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqlts8_6_VULN-52916-9ef683bb2a64"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 957s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-bmastbergen_ciqlts8_6_VULN-52916-9ef683bb2a64+
[TIMER]{MODULES}: 11s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-bmastbergen_ciqlts8_6_VULN-52916-9ef683bb2a64+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 105s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-bmastbergen_ciqlts8_6_VULN-52916-9ef683bb2a64+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 957s
[TIMER]{MODULES}: 11s
[TIMER]{INSTALL}: 105s
[TIMER]{TOTAL} 1090s
Rebooting in 10 seconds
```

### Testing

kselftests were run before and after applying the fix

[selftest-4.18.0-372.32.1.el8_6.86ciq_lts.11.1.x86_64.log](https://github.com/user-attachments/files/20713489/selftest-4.18.0-372.32.1.el8_6.86ciq_lts.11.1.x86_64.log)

[selftest-4.18.0-bmastbergen_ciqlts8_6_VULN-52916-9ef683bb2a64+.log](https://github.com/user-attachments/files/20713492/selftest-4.18.0-bmastbergen_ciqlts8_6_VULN-52916-9ef683bb2a64%2B.log)

```
brett@lycia ~/ciq/vuln-52916 % grep ^ok selftest-4.18.0-372.32.1.el8_6.86ciq_lts.11.1.x86_64.log | wc -l
176
brett@lycia ~/ciq/vuln-52916 % grep ^ok selftest-4.18.0-bmastbergen_ciqlts8_6_VULN-52916-9ef683bb2a64+.log | wc -l
178
brett@lycia ~/ciq/vuln-52916 %

```