### PR TITLE
[LTS 9.2] netdevsim: Fix memory leak of nsim_dev->fa_cookie

### DIFF
--- a/drivers/net/netdevsim/dev.c
+++ b/drivers/net/netdevsim/dev.c
@@ -1675,6 +1675,7 @@ void nsim_drv_remove(struct nsim_bus_dev *nsim_bus_dev)
 				  ARRAY_SIZE(nsim_devlink_params));
 	devl_resources_unregister(devlink);
 	kfree(nsim_dev->vfconfigs);
+	kfree(nsim_dev->fa_cookie);
 	devl_unlock(devlink);
 	devlink_free(devlink);
 	dev_set_drvdata(&nsim_bus_dev->dev, NULL);


### PR DESCRIPTION
[LTS 9.2]
CVE-2022-49803
VULN-65792


# Problem

<https://www.cve.org/CVERecord?id=CVE-2022-49803>
> In the Linux kernel, the following vulnerability has been resolved
>
>  netdevsim: Fix memory leak of nsim\_dev->fa\_cookie
>  
>  kmemleak reports this issue:
>  
>  unreferenced object 0xffff8881bac872d0 (size 8):
>    comm "sh", pid 58603, jiffies 4481524462 (age 68.065s)
>    hex dump (first 8 bytes):
>      04 00 00 00 de ad be ef                          &#x2026;&#x2026;..
>    backtrace:
>      [<00000000c80b8577>] \_\_kmalloc+0x49/0x150
>      [<000000005292b8c6>] nsim\_dev\_trap\_fa\_cookie\_write+0xc1/0x210 [netdevsim]
>      [<0000000093d78e77>] full\_proxy\_write+0xf3/0x180
>      [<000000005a662c16>] vfs\_write+0x1c5/0xaf0
>      [<000000007aabf84a>] ksys\_write+0xed/0x1c0
>      [<000000005f1d2e47>] do\_syscall\_64+0x3b/0x90
>      [<000000006001c6ec>] entry\_SYSCALL\_64\_after\_hwframe+0x63/0xcd


# Background

The `netdevsim` is a module simulating a network device in Linux. It's a developer testing tool that can be used to test various control path networking APIs.

The memory leak described in CVE occurs after unloading the module, provided that some data was written through *debugfs* to the "flow action cookie" metadata storage associated with the simulated device.

This CVE appears to be one of the retroactive CVEs, filed for bugs which were fixed long before (fix commit 064bc7312bd09a48798418663090be0c776183db date 2022-11-16 vs CVE publication date 2025-05-01).


# Applicability

The `netdevsim` module is enabled by the `CONFIG_NETDEVSIM` option which is `m` in all configurations of LTS 9.2:

    $ grep CONFIG_NETDEVSIM configs/kernel-*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-aarch64-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-ppc64le-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-s390x-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_NETDEVSIM=m
    configs/kernel-x86_64-rhel.config:CONFIG_NETDEVSIM=m

The d3cbb907ae57fe5da314b51d949b617b538bdeae commit identified in the fix commit 064bc7312bd09a48798418663090be0c776183db as introducing the bug is present in `ciqlts9_2` history, literally

    $ git --no-pager branch ciqlts9_2 --contains d3cbb907ae57fe5da314b51d949b617b538bdeae

    * ciqlts9_2

The fix commit 064bc7312bd09a48798418663090be0c776183db (1) is not present in the history and neither it's backported.

    $ cve-research/git-analysis.xsh \
        histories \
        -C …/kernel-src-tree \
        --file drivers/net/netdevsim/dev.c \
        --log-opts-main='--since=2022-03-18 --date=short' \
        --ref-opts='--no-merges' \
        kernel-mainline ciqlts9_2

    kernel-mainline                                                         ciqlts9_2
    ----------------------------------------------------------------------  ----------------------
    a1494d532 2024-10-15 netdevsim: use cond_resched() in nsim_dev_trap_r…
    ba5e12721 2024-02-02 netdevsim: avoid potential loop in nsim_dev_trap…
    f72207a5c 2023-07-12 netdevsim: fix uninitialized data in nsim_dev_tr…
    fb8421a94 2023-01-30 devlink: remove devlink features                
    075935f0a 2023-01-27 devlink: protect devlink param list by instance …
    82a3aef2e 2023-01-06 netdevsim: move devlink registration under the i…
    5c5ea1d09 2023-01-06 netdevsim: rename a label                       
    226bf9805 2022-11-30 net: devlink: let the core report the driver nam…
    f2fc15e27 2022-11-17 devlink: Allow to set up parent in devl_rate_lea…
    064bc7312 2022-11-16 netdevsim: Fix memory leak of nsim_dev->fa_cooki…                         (1)
    ac73d4bf2 2022-11-03 net: make drivers to use SET_NETDEV_DEVLINK_PORT…
    a6aa8d0ce 2022-10-27 netdevsim: remove dir in nsim_dev_debugfs_init()…
    6b1da9f71 2022-10-27 netdevsim: fix memory leak in nsim_drv_probe() w…
    5603072e0 2022-09-01 netdevsim: remove redundant variable ret        
    f94b60632 2022-08-25 net: devlink: limit flash component name to matc…  ~ ff020891f 2023-01-18
    0c1989754 2022-08-25 netdevsim: add version fw.mgmt info info_get() a…  ~ fbb5e9da6 2023-01-18
    644a66c60 2022-08-01 net: devlink: convert reload command to take imp…  ~ 31a499f90 2023-01-18
    012ec02ae 2022-07-18 netdevsim: convert driver to use unlocked devlin…  ~ 57497ee6e 2023-01-18
    14e426bf1 2022-03-21 devlink: hold the instance lock during eswitch_m…  ~ 24b38c8b0 2022-08-22
    aff3a9250 2022-03-21 netdevsim: replace vfs_lock with devlink instanc…  ~ 6742a09c4 2022-08-22
    76eea6c2e 2022-03-21 netdevsim: replace port_list_lock with devlink i…  ~ 6d57a616e 2022-08-22

The [bug's replication](#org0c9683d) on `ciqlts9_2` confirms the applicability.


# Solution

As mentioned before, the mainline fix is in the 064bc7312bd09a48798418663090be0c776183db commit. It applies with cherry-pick to `ciqlts9_2` without modifications.


# kABI check: passed

    $ CVE=CVE-2022-49803 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_2-CVE-2022-49803

    …
    [4/5] Check ABI of kernel [ciqlts9_2-CVE-2022-49803]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2022-49803/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2022-49803/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20731468/boot-test.log>)


# Kselftests: passed relative


## Coverage

All net-related tests (except the unstable ones):

`net/forwarding` (except `mirror_gre_bridge_1d_vlan.sh`, `ipip_hier_gre_keys.sh`, `sch_ets.sh`, `sch_tbf_prio.sh`, `sch_tbf_ets.sh`, `q_in_vni.sh`, `tc_police.sh`, `mirror_gre_vlan_bridge_1q.sh`, `dual_vxlan_bridge.sh`, `tc_actions.sh`, `sch_tbf_root.sh`, `sch_red.sh`, `vxlan_bridge_1d_ipv6.sh`), `net/mptcp` (except `simult_flows.sh`, `userspace_pm.sh`), `net` (except `gro.sh`, `txtimestamp.sh`, `xfrm_policy.sh`, `udpgro_fwd.sh`, `fib_nexthops.sh`, `udpgso_bench.sh`, `reuseport_addr_any.sh`, `reuseaddr_conflict`, `ip_defrag.sh`), `netfilter` (except `nft_trans_stress.sh`)


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/20731467/kselftests--ciqlts9_2--run1.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/20731466/kselftests--ciqlts9_2--run2.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run3.log](<https://github.com/user-attachments/files/20731465/kselftests--ciqlts9_2--run3.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-2022-49803&#x2013;run1.log](<https://github.com/user-attachments/files/20731464/kselftests--ciqlts9_2-CVE-2022-49803--run1.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-2022-49803&#x2013;run2.log](<https://github.com/user-attachments/files/20731463/kselftests--ciqlts9_2-CVE-2022-49803--run2.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-2022-49803&#x2013;run3.log](<https://github.com/user-attachments/files/20731462/kselftests--ciqlts9_2-CVE-2022-49803--run3.log>)


## Comparison

The results for the reference and patched kernel are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2--run2.log
    Status2   kselftests--ciqlts9_2--run3.log
    Status3   kselftests--ciqlts9_2-CVE-2022-49803--run1.log
    Status4   kselftests--ciqlts9_2-CVE-2022-49803--run2.log
    Status5   kselftests--ciqlts9_2-CVE-2022-49803--run3.log


<a id="org0c9683d"></a>

# Specific tests: passed

The bug replication steps are hinted in the fix commit 064bc7312bd09a48798418663090be0c776183db message:

    The issue occurs in the following scenarios:
    
    nsim_dev_trap_fa_cookie_write()
      kmalloc() fa_cookie
      nsim_dev->fa_cookie = fa_cookie
    ..
    nsim_drv_remove()


## Reference

The bug was successfully replicated on `ciqlts9_2` compiled with the `CONFIG_DEBUG_KMEMLEAK` option set. The steps:

1.  Load the `netdevsim` module
    
        # modprobe netdevsim
2.  Create a new *netdevsim* device with index 0
    
        # echo "0 1 1" > /sys/bus/netdevsim/new_device
3.  Write "abc" encoded in hex to the flow action cookie
    
        # echo "616263" > /sys/kernel/debug/netdevsim/netdevsim0/trap_flow_action_cookie
4.  Remove the device
    
        # echo 0 > /sys/bus/netdevsim/del_device
5.  Unload the `netdevsim` module
    
        # rmmod netdevsim
6.  Trigger memory leaks scan
    
        # echo scan > /sys/kernel/debug/kmemleak
7.  Check the leaks report
    
        # cat /sys/kernel/debug/kmemleak
    
        unreferenced object 0xffff954a00cd54e8 (size 8):
          comm "bash", pid 2044, jiffies 4354161471 (age 215.438s)
          hex dump (first 8 bytes):
            03 00 00 00 61 62 63 d3                          ....abc.
          backtrace:
            [<00000000f3b0c80b>] nsim_dev_trap_fa_cookie_write+0x83/0x130 [netdevsim]
            [<00000000cdd405a5>] full_proxy_write+0x50/0x80
            [<00000000349ec0c3>] vfs_write+0xb2/0x280
            [<000000003290ff1e>] ksys_write+0x5f/0xe0
            [<000000005b589185>] do_syscall_64+0x59/0x90
            [<000000009081b09f>] entry_SYSCALL_64_after_hwframe+0x63/0xcd


## Patch

The same steps as done on the reference kernel produced no memory leak logs on the patched kernel.

    [root@ciqlts-9-2 pvts]# modprobe netdevsim
    [root@ciqlts-9-2 pvts]# echo "0 1 1" > /sys/bus/netdevsim/new_device
    [root@ciqlts-9-2 pvts]# echo "616263" > /sys/kernel/debug/netdevsim/netdevsim0/trap_flow_action_cookie
    [root@ciqlts-9-2 pvts]# echo 0 > /sys/bus/netdevsim/del_device
    [root@ciqlts-9-2 pvts]# rmmod netdevsim
    [root@ciqlts-9-2 pvts]# echo scan > /sys/kernel/debug/kmemleak
    [root@ciqlts-9-2 pvts]# cat /sys/kernel/debug/kmemleak
    [root@ciqlts-9-2 pvts]#

