### PR TITLE
[LTS 8.8] netdevsim: Fix memory leak of nsim_dev->fa_cookie

### DIFF
--- a/drivers/net/netdevsim/dev.c
+++ b/drivers/net/netdevsim/dev.c
@@ -1647,6 +1647,7 @@ void nsim_drv_remove(struct nsim_bus_dev *nsim_bus_dev)
 				  ARRAY_SIZE(nsim_devlink_params));
 	devl_resources_unregister(devlink);
 	kfree(nsim_dev->vfconfigs);
+	kfree(nsim_dev->fa_cookie);
 	devl_unlock(devlink);
 	devlink_free(devlink);
 	dev_set_drvdata(&nsim_bus_dev->dev, NULL);


### PR DESCRIPTION
[LTS 8.8]
CVE-2022-49803
VULN-65788


# Problem

<https://www.cve.org/CVERecord?id=CVE-2022-49803>
> In the Linux kernel, the following vulnerability has been resolved
>
>  netdevsim: Fix memory leak of nsim\_dev->fa\_cookie
>  
>  kmemleak reports this issue:
>  
>  unreferenced object 0xffff8881bac872d0 (size 8):
>    comm "sh", pid 58603, jiffies 4481524462 (age 68.065s)
>    hex dump (first 8 bytes):
>      04 00 00 00 de ad be ef                          &#x2026;&#x2026;..
>    backtrace:
>      [<00000000c80b8577>] \_\_kmalloc+0x49/0x150
>      [<000000005292b8c6>] nsim\_dev\_trap\_fa\_cookie\_write+0xc1/0x210 [netdevsim]
>      [<0000000093d78e77>] full\_proxy\_write+0xf3/0x180
>      [<000000005a662c16>] vfs\_write+0x1c5/0xaf0
>      [<000000007aabf84a>] ksys\_write+0xed/0x1c0
>      [<000000005f1d2e47>] do\_syscall\_64+0x3b/0x90
>      [<000000006001c6ec>] entry\_SYSCALL\_64\_after\_hwframe+0x63/0xcd


# Background

The `netdevsim` is a module simulating a network device in Linux. It's a developer testing tool that can be used to test various control path networking APIs.

The memory leak described in CVE occurs after unloading the module, provided that some data was written through *debugfs* to the "flow action cookie" metadata storage associated with the simulated device.

This CVE appears to be one of the retroactive CVEs, filed for bugs which were fixed long before (fix commit 064bc7312bd09a48798418663090be0c776183db date 2022-11-16 vs CVE publication date 2025-05-01).


# Applicability

The `netdevsim` module is enabled by the `CONFIG_NETDEVSIM` option which is `m` in all configurations of LTS 8.8:

    $ grep CONFIG_NETDEVSIM configs/kernel-*.config

    configs/kernel-aarch64-debug.config:CONFIG_NETDEVSIM=m
    configs/kernel-aarch64.config:CONFIG_NETDEVSIM=m
    configs/kernel-ppc64le-debug.config:CONFIG_NETDEVSIM=m
    configs/kernel-ppc64le.config:CONFIG_NETDEVSIM=m
    configs/kernel-s390x-debug.config:CONFIG_NETDEVSIM=m
    configs/kernel-s390x-zfcpdump.config:CONFIG_NETDEVSIM=m
    configs/kernel-s390x.config:CONFIG_NETDEVSIM=m
    configs/kernel-x86_64-debug.config:CONFIG_NETDEVSIM=m
    configs/kernel-x86_64.config:CONFIG_NETDEVSIM=m

The d3cbb907ae57fe5da314b51d949b617b538bdeae commit identified in the fix commit 064bc7312bd09a48798418663090be0c776183db as introducing the bug is present in `ciqlts8_8` history, backported in the centos8 history rebuild commit a1c405ca16baa1afc756c1d4ccbcc0c3a00cb453 (1). The fix commit 064bc7312bd09a48798418663090be0c776183db is not present and neither it's backported (2)

    $ cve-research/git-analysis.xsh \
        histories \
        -C …/ctrliq-github/kernel-src-tree \
        --file drivers/net/netdevsim/dev.c \
        --log-opts-main='--date=short' \
        --ref-opts="--no-merges" \
        kernel-mainline ciqlts8_8

    kernel-mainline                                                                 ciqlts8_8
    ----------------------------------------------------------------------------…-  ----------------------
    a1494d532 2024-10-15 netdevsim: use cond_resched() in nsim_dev_trap_report_w…
    ba5e12721 2024-02-02 netdevsim: avoid potential loop in nsim_dev_trap_report…
    f72207a5c 2023-07-12 netdevsim: fix uninitialized data in nsim_dev_trap_fa_c…
    fb8421a94 2023-01-30 devlink: remove devlink features                        
    075935f0a 2023-01-27 devlink: protect devlink param list by instance lock    
    82a3aef2e 2023-01-06 netdevsim: move devlink registration under the instance…
    5c5ea1d09 2023-01-06 netdevsim: rename a label                               
    226bf9805 2022-11-30 net: devlink: let the core report the driver name inste…
    f2fc15e27 2022-11-17 devlink: Allow to set up parent in devl_rate_leaf_creat…
    064bc7312 2022-11-16 netdevsim: Fix memory leak of nsim_dev->fa_cookie                                  (2)
    ac73d4bf2 2022-11-03 net: make drivers to use SET_NETDEV_DEVLINK_PORT to set…
    a6aa8d0ce 2022-10-27 netdevsim: remove dir in nsim_dev_debugfs_init() when c…
    6b1da9f71 2022-10-27 netdevsim: fix memory leak in nsim_drv_probe() when nsi…
    5603072e0 2022-09-01 netdevsim: remove redundant variable ret                
    f94b60632 2022-08-25 net: devlink: limit flash component name to match versi…
    0c1989754 2022-08-25 netdevsim: add version fw.mgmt info info_get() and mark…
    644a66c60 2022-08-01 net: devlink: convert reload command to take implicit d…
    012ec02ae 2022-07-18 netdevsim: convert driver to use unlocked devlink API d…
    14e426bf1 2022-03-21 devlink: hold the instance lock during eswitch_mode cal…   ~ 62a6e952c 2024-09-11
    aff3a9250 2022-03-21 netdevsim: replace vfs_lock with devlink instance lock     ~ a3e5f81a5 2024-09-11
    76eea6c2e 2022-03-21 netdevsim: replace port_list_lock with devlink instance…   ~ ddecfa099 2024-09-11
    1a6d7ae7d 2022-03-15 netdevsim: Introduce support for L3 offload xstats      
    4c897cfc4 2021-11-30 devlink: Simplify devlink resources unregister call        # 0f82fb2ad 2024-09-11
    047304d0b 2021-11-01 netdevsim: fix uninit value in nsim_drv_configure_vfs()…   # 69c49eed1 2024-09-11
    a66f64b80 2021-11-01 netdevsim: rename 'driver' entry points                    # 69c49eed1 2024-09-11
    a3353ec32 2021-11-01 netdevsim: move max vf config to dev                       # 69c49eed1 2024-09-11
    1c401078b 2021-11-01 netdevsim: move details of vf config to dev                # 69c49eed1 2024-09-11
    5e388f3dc 2021-11-01 netdevsim: move vfconfig to nsim_dev                       # 69c49eed1 2024-09-11
    ba064e4cf 2021-10-29 netdevsim: remove max_vfs dentry                           ~ e71f7c227 2024-09-11
    82465bec3 2021-10-12 devlink: Delete reload enable/disable interface            # 0f82fb2ad 2024-09-11
    bd032e35c 2021-10-12 devlink: Allow control devlink ops behavior through fea…   # 0f82fb2ad 2024-09-11
    71c1b5259 2021-09-27 netdevsim: Move devlink registration to be last devlink…   # 0f82fb2ad 2024-09-11
    db4278c55 2021-09-22 devlink: Make devlink_register to be void               
    919d13a7e 2021-08-09 devlink: Set device as early as possible                   # 0f82fb2ad 2024-09-11
    5c0418ed1 2021-08-06 netdevsim: Protect both reload_down and reload_up paths…   ~ 9a35f96c9 2024-09-11
    23809a726 2021-08-05 netdevsim: Forbid devlink reload when adding or deletin…   ~ 2546a4b8d 2024-09-11
    267134550 2021-07-30 devlink: Allocate devlink directly in requested net nam…   ~ 3eb46f10f 2024-09-11
    275b51c27 2021-06-18 drivers: net: netdevsim: fix devlink_trap selftests fai…   ~ 5042e35fb 2024-09-11
    a7b3527a4 2021-06-14 drivers: net: netdevsim: add devlink trap_drop_counter_…   ~ a75609afe 2024-09-11
    4e744cb81 2021-06-09 netdevsim: delete unnecessary debugfs checking             ~ 30da8632f 2024-09-11
    f3d101b48 2021-06-02 netdevsim: Allow setting parent node of rate objects       ~ 5d4d34580 2024-09-11
    885226f56 2021-06-02 netdevsim: Implement support for devlink rate nodes        ~ dc2ebab11 2024-09-11
    605c4f8f1 2021-06-02 netdevsim: Implement devlink rate leafs tx rate support…   ~ c2079675a 2024-09-11
    885dfe121 2021-06-02 netdevsim: Register devlink rate leaf objects per VF       ~ b0d029fd4 2024-09-11
    160dc373e 2021-06-02 netdevsim: Implement legacy/switchdev mode for VFs         ~ 55200f25f 2024-09-11
    92ba1f29e 2021-06-02 netdevsim: Implement VFs                                   ~ f4a156b23 2024-09-11
    814b9ce65 2021-06-02 netdevsim: Implement port types and indexing               ~ 6e7fc5ed8 2024-09-11
    32ac15d8f 2021-06-02 netdevsim: Disable VFs on nsim_dev_reload_destroy() cal…   ~ b8789580e 2024-09-11
    d39538190 2021-06-02 netdevsim: Add max_vfs to bus_dev                          ~ cb165b0fc 2024-09-11
    a8700c3dd 2021-03-14 netdevsim: Add dummy psample implementation                ~ 0f8a4f7ca 2024-09-11
    f57ab5b75 2021-02-08 netdevsim: dev: Initialize FIB module after debugfs        ~ fd9c211e2 2024-09-11
    52cc5f3a1 2020-11-19 devlink: move flash end and begin to core devlink          # 8f0086a84 2024-09-11
    a5bbcbf29 2020-11-17 netdevsim: set .owner to THIS_MODULE                       ~ ff1bc2863 2024-09-11
    35266255d 2020-11-06 netdevsim: Add devlink resource for nexthops            
    dc64cc7c6 2020-10-09 devlink: Add devlink reload limit option                   # 8f0086a84 2024-09-11
    ccdf07219 2020-10-09 devlink: Add reload action option to devlink reload com…   # 8f0086a84 2024-09-11
    cbb58368f 2020-09-25 netdevsim: add support for flash_update overwrite mask     # 8f0086a84 2024-09-11
    bc75c054f 2020-09-25 devlink: convert flash_update to use params structure      # 8f0086a84 2024-09-11
    22ec3d232 2020-09-25 devlink: check flash_update parameter support in net co…   # 8f0086a84 2024-09-11
    d4602a9f4 2020-09-18 net: devlink: region: Pass the region ops to the snapsh…   ~ 5d9b882f8 2024-09-11
    b311b001d 2020-09-18 netdevsim: devlink flash timeout message                   ~ b9d32b731 2024-09-11
    c88e11e04 2020-08-03 devlink: Pass extack when setting trap's action and gro…   ~ 58fa41d7c 2024-09-11
    424be63ad 2020-07-10 netdevsim: add UDP tunnel port offload support             ~ e401e0830 2024-09-11
    71ad8d55f 2020-07-09 devlink: Replace devlink_port_attrs_set parameters with…   # 604239d6f 2024-09-11
    189793674 2020-06-01 netdevsim: Register control traps                          ~ 707990f21 2024-09-11
    85176f19f 2020-06-01 netdevsim: Move layer 3 exceptions to exceptions trap g…   ~ 3247df565 2024-09-11
    be43224fc 2020-05-22 netdevsim: Ensure policer drop counter always increases…   # a1c405ca1 2024-09-11
    3902baf9a 2020-03-30 netdevsim: dev: Fix memory leak in nsim_dev_take_snapsh…   ~ 3d08288f4 2024-09-11
    0dc8249a2 2020-03-30 netdevsim: Add support for setting of packet trap group…   # a1c405ca1 2024-09-11
    f9f54392d 2020-03-30 devlink: Add packet trap group parameters support          # a1c405ca1 2024-09-11
    ad188458d 2020-03-30 netdevsim: Add devlink-trap policer support                # a1c405ca1 2024-09-11
    3fe0fd531 2020-03-26 netdevsim: support taking immediate snapshot via devlin…   # a1c405ca1 2024-09-11
    12102436a 2020-03-26 devlink: track snapshot id usage count using an xarray     # a1c405ca1 2024-09-11
    7ef19d3b1 2020-03-26 devlink: report error once U32_MAX snapshot ids have be…   ~ 53c7dd125 2024-09-11
    a0a09f6bb 2020-03-26 devlink: convert snapshot destructor callback to region…   ~ 5eb672e5f 2024-09-11
    e89376817 2020-03-26 devlink: prepare to support region operations              ~ 2c1ef171d 2024-09-11
    107f16789 2020-03-23 devlink: Only pass packet trap group identifier in trap…   # a1c405ca1 2024-09-11
    b29545d84 2020-03-23 netdevsim: Explicitly register packet trap groups          ~ 7c39e2ba9 2024-09-11
    d3cbb907a 2020-02-25 netdevsim: add ACL trap reporting cookie as a metadata     # a1c405ca1 2024-09-11  (1)
    …

The [bug replication](#orge45f4ba) confirms the applicability.


# Solution

As mentioned before, the mainline fix is in the 064bc7312bd09a48798418663090be0c776183db commit. It applies with cherry-pick to `ciqlts8_8` without modifications.


# kABI check: passed

    RELAXED_DEPS=1 DEBUG=1 CVE=CVE-2022-49803 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_8-CVE-2022-49803

    [1/2] Check ABI of kernel [ciqlts8_8-CVE-2022-49803]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_8/build_files/kernel-src-tree-ciqlts8_8-CVE-2022-49803/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_8-CVE-2022-49803/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20732981/boot-test.log>)


# Kselftests: passed relative


## Coverage

All net-related tests (except the unstable ones):

`net/forwarding` (except `sch_tbf_ets.sh`, `tc_actions.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_tbf_prio.sh`, `sch_tbf_root.sh`, `ipip_hier_gre_keys.sh`, `sch_ets.sh`, `mirror_gre_bridge_1d_vlan.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `txtimestamp.sh`, `udpgso_bench.sh`, `ip_defrag.sh`, `gro.sh`, `xfrm_policy.sh`, `udpgro_fwd.sh`, `reuseport_addr_any.sh`, `reuseaddr_conflict`), `netfilter` (except `nft_trans_stress.sh`)


## Reference

[kselftests&#x2013;ciqlts8\_8&#x2013;run1.log](<https://github.com/user-attachments/files/20732980/kselftests--ciqlts8_8--run1.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run2.log](<https://github.com/user-attachments/files/20732979/kselftests--ciqlts8_8--run2.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run3.log](<https://github.com/user-attachments/files/20732978/kselftests--ciqlts8_8--run3.log>)


## Patch

[kselftests&#x2013;ciqlts8\_8-CVE-2022-49803&#x2013;run1.log](<https://github.com/user-attachments/files/20732977/kselftests--ciqlts8_8-CVE-2022-49803--run1.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2022-49803&#x2013;run2.log](<https://github.com/user-attachments/files/20732976/kselftests--ciqlts8_8-CVE-2022-49803--run2.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2022-49803&#x2013;run3.log](<https://github.com/user-attachments/files/20732975/kselftests--ciqlts8_8-CVE-2022-49803--run3.log>)


## Comparison

The results for the reference and patched kernel are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_8--run1.log
    Status1   kselftests--ciqlts8_8--run2.log
    Status2   kselftests--ciqlts8_8--run3.log
    Status3   kselftests--ciqlts8_8-CVE-2022-49803--run1.log
    Status4   kselftests--ciqlts8_8-CVE-2022-49803--run2.log
    Status5   kselftests--ciqlts8_8-CVE-2022-49803--run3.log


# Specific tests: passed


<a id="orge45f4ba"></a>

## Reference

The bug was successfully replicated on `ciqlts8_8` compiled with the `CONFIG_DEBUG_KMEMLEAK` option set. Same steps were used as in <https://github.com/ctrliq/kernel-src-tree/pull/340>

    [root@ciqlts-8-8 pvts]# cat /sys/kernel/debug/kmemleak

    …
    unreferenced object 0xffff915fc3cfe300 (size 8):
      comm "bash", pid 1515, jiffies 4294782879 (age 87.180s)
      hex dump (first 8 bytes):
        03 00 00 00 61 62 63 4e                          ....abcN
      backtrace:
        [<0000000031cec1ef>] __kmalloc+0x10d/0x250
        [<00000000376091fa>] 0xffffffffc09911c2
        [<000000000dd2a281>] full_proxy_write+0x53/0x80
        [<000000005f7e970b>] vfs_write+0xa5/0x1b0
        [<00000000199e01de>] ksys_write+0x4f/0xb0
        [<00000000c978bcde>] do_syscall_64+0x5b/0x1b0
        [<00000000b8de3e29>] entry_SYSCALL_64_after_hwframe+0x61/0xc6


## Patch

The same steps repeated on the patched kernel produced no memory leaks logs.

    [root@ciqlts-8-8 pvts]# modprobe netdevsim
    [root@ciqlts-8-8 pvts]# echo "0 1 1" > /sys/bus/netdevsim/new_device
    [root@ciqlts-8-8 pvts]# echo "616263" > /sys/kernel/debug/netdevsim/netdevsim0/trap_flow_action_cookie
    [root@ciqlts-8-8 pvts]# echo 0 > /sys/bus/netdevsim/del_device
    [root@ciqlts-8-8 pvts]# rmmod netdevsim
    [root@ciqlts-8-8 pvts]# echo scan > /sys/kernel/debug/kmemleak
    [root@ciqlts-8-8 pvts]# cat /sys/kernel/debug/kmemleak
    [root@ciqlts-8-8 pvts]#

