### PR TITLE
[fips-9] netdevsim: Fix memory leak of nsim_dev->fa_cookie

### DIFF
--- a/drivers/net/netdevsim/dev.c
+++ b/drivers/net/netdevsim/dev.c
@@ -1675,6 +1675,7 @@ void nsim_drv_remove(struct nsim_bus_dev *nsim_bus_dev)
 				  ARRAY_SIZE(nsim_devlink_params));
 	devl_resources_unregister(devlink);
 	kfree(nsim_dev->vfconfigs);
+	kfree(nsim_dev->fa_cookie);
 	devl_unlock(devlink);
 	devlink_free(devlink);
 	dev_set_drvdata(&nsim_bus_dev->dev, NULL);


### PR DESCRIPTION
jira VULN-65794
cve CVE-2022-49803

```
commit-author Wang Yufen <wangyufen@huawei.com>
commit 064bc7312bd09a48798418663090be0c776183db

kmemleak reports this issue:

unreferenced object 0xffff8881bac872d0 (size 8):
  comm "sh", pid 58603, jiffies 4481524462 (age 68.065s)
  hex dump (first 8 bytes):
    04 00 00 00 de ad be ef                          ........
  backtrace:
    [<00000000c80b8577>] __kmalloc+0x49/0x150
    [<000000005292b8c6>] nsim_dev_trap_fa_cookie_write+0xc1/0x210 [netdevsim]
    [<0000000093d78e77>] full_proxy_write+0xf3/0x180
    [<000000005a662c16>] vfs_write+0x1c5/0xaf0
    [<000000007aabf84a>] ksys_write+0xed/0x1c0
    [<000000005f1d2e47>] do_syscall_64+0x3b/0x90
    [<000000006001c6ec>] entry_SYSCALL_64_after_hwframe+0x63/0xcd

The issue occurs in the following scenarios:

nsim_dev_trap_fa_cookie_write()
  kmalloc() fa_cookie
  nsim_dev->fa_cookie = fa_cookie
..
nsim_drv_remove()

The fa_cookie allocked in nsim_dev_trap_fa_cookie_write() is not freed. To fix, add kfree(nsim_dev->fa_cookie) to nsim_drv_remove().

Fixes: d3cbb907ae57 ("netdevsim: add ACL trap reporting cookie as a metadata")
	Signed-off-by: Wang Yufen <wangyufen@huawei.com>
	Cc: Jiri Pirko <jiri@mellanox.com>
Link: https://lore.kernel.org/r/1668504625-14698-1-git-send-email-wangyufen@huawei.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 064bc7312bd09a48798418663090be0c776183db)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
--
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] sound/virtio/virtio_snd.ko
  BTF [M] virt/lib/irqbypass.ko
  BTF [M] sound/xen/snd_xen_front.ko
[TIMER]{BUILD}: 1443s
Making Modules
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+
[TIMER]{MODULES}: 8s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 58s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1443s
[TIMER]{MODULES}: 8s
[TIMER]{INSTALL}: 58s
[TIMER]{TOTAL} 1527s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the fix

[selftest-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64.log](https://github.com/user-attachments/files/20803518/selftest-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64.log)

[selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+.log](https://github.com/user-attachments/files/20803521/selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395%2B.log)

```
brett@lycia ~/ciq/vuln-65794 % grep ^ok selftest-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64.log | wc -l
242
brett@lycia ~/ciq/vuln-65794 % grep ^ok selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-65794-3f6f10815395+.log | wc -l
244
brett@lycia ~/ciq/vuln-65794 %

```