### PR TITLE
[CBR 7.9] net: sched: Fix use after free in red_enqueue()

### DIFF
--- a/net/sched/sch_red.c
+++ b/net/sched/sch_red.c
@@ -62,6 +62,7 @@ static int red_enqueue(struct sk_buff *skb, struct Qdisc *sch,
 {
 	struct red_sched_data *q = qdisc_priv(sch);
 	struct Qdisc *child = q->qdisc;
+	unsigned int len;
 	int ret;
 
 	q->vars.qavg = red_calc_qavg(&q->parms,
@@ -97,9 +98,10 @@ static int red_enqueue(struct sk_buff *skb, struct Qdisc *sch,
 		break;
 	}
 
+	len = qdisc_pkt_len(skb);
 	ret = qdisc_enqueue(skb, child, to_free);
 	if (likely(ret == NET_XMIT_SUCCESS)) {
-		qdisc_qstats_backlog_inc(sch, skb);
+		sch->qstats.backlog += len;
 		sch->q.qlen++;
 	} else if (net_xmit_drop_count(ret)) {
 		q->stats.pdrop++;


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

```
jira VULN-66495
cve CVE-2022-49921
commit-author Dan Carpenter <dan.carpenter@oracle.com> commit 8bdc2acd420c6f3dd1f1c78750ec989f02a1e2b9

We can't use "skb" again after passing it to qdisc_enqueue().  This is basically identical to commit 2f09707d0c97 ("sch_sfb: Also store skb len before calling child enqueue").

Fixes: d7f4f332f082 ("sch_red: update backlog as well")
	Signed-off-by: Dan Carpenter <dan.carpenter@oracle.com>
	Reviewed-by: Eric Dumazet <edumazet@google.com>
	Signed-off-by: David S. Miller <davem@davemloft.net>
(cherry picked from commit 8bdc2acd420c6f3dd1f1c78750ec989f02a1e2b9)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
Setting Local Version for build
CONFIG_LOCALVERSION="-_ajain__ciqcbr7_9-5b00565"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  SHIPPED scripts/kconfig/zconf.hash.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf --silentoldconfig Kconfig
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  HOSTCC  scripts/basic/bin2c
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_32.h
  WRAP    arch/x86/include/generated/asm/clkdev.h
  WRAP    arch/x86/include/generated/asm/mm-arch-hooks.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  CHK     include/generated/uapi/linux/version.h
  UPD     include/generated/uapi/linux/version.h
  CHK     include/generated/utsrelease.h
  UPD     include/generated/utsrelease.h
  CHK     include/generated/qrwlock.h
  UPD     include/generated/qrwlock.h
  CHK     include/generated/qrwlock_api_smp.h
  UPD     include/generated/qrwlock_api_smp.h
  CHK     include/generated/qrwlock_types.h
  UPD     include/generated/qrwlock_types.h
  CHK     kernel/qrwlock_gen.c
[--snip--]
  INSTALL /lib/firmware/kaweth/trigger_code.bin
  INSTALL /lib/firmware/kaweth/new_code_fix.bin
  INSTALL /lib/firmware/kaweth/trigger_code_fix.bin
  INSTALL /lib/firmware/ti_3410.fw
  INSTALL /lib/firmware/ti_5052.fw
  INSTALL /lib/firmware/mts_cdma.fw
  INSTALL /lib/firmware/mts_gsm.fw
  INSTALL /lib/firmware/mts_edge.fw
  INSTALL /lib/firmware/edgeport/boot.fw
  INSTALL /lib/firmware/edgeport/boot2.fw
  INSTALL /lib/firmware/edgeport/down.fw
  INSTALL /lib/firmware/edgeport/down2.fw
  INSTALL /lib/firmware/edgeport/down3.bin
  INSTALL /lib/firmware/whiteheat_loader.fw
  INSTALL /lib/firmware/whiteheat.fw
  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-_ajain__ciqcbr7_9-5b00565+
[TIMER]{MODULES}: 33s
Making Install
sh ./arch/x86/boot/install.sh 3.10.0-_ajain__ciqcbr7_9-5b00565+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 13s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-_ajain__ciqcbr7_9-ccfd614+.old and Index to 4
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7_9.ciqcbr.4.1.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7_9.ciqcbr.4.1.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-1160.80.1.el7.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.80.1.el7.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-_ajain__ciqcbr7_9-5b00565+
Found initrd image: /boot/initramfs-3.10.0-_ajain__ciqcbr7_9-5b00565+.img
Found linux image: /boot/vmlinuz-3.10.0-_ajain__ciqcbr7_9-ccfd614+
Found initrd image: /boot/initramfs-3.10.0-_ajain__ciqcbr7_9-ccfd614+.img
Found linux image: /boot/vmlinuz-3.10.0-_ajain__ciqcbr7_9-ccfd614+.old
Found initrd image: /boot/initramfs-3.10.0-_ajain__ciqcbr7_9-ccfd614+.img
Found linux image: /boot/vmlinuz-0-rescue-9e065f0961d84ecf8bec2457d927e012
Found initrd image: /boot/initramfs-0-rescue-9e065f0961d84ecf8bec2457d927e012.img
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1635s
[TIMER]{MODULES}: 33s
[TIMER]{INSTALL}: 13s
[TIMER]{TOTAL} 1683s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/20804051/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
2
2
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
1
1
```
[kselftest-after.log](https://github.com/user-attachments/files/20804052/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/20804053/kselftest-before.log)
