### PR TITLE
[CBR 7.9] netfilter: ipset: add missing range check in bitmap_ip_uadt

### DIFF
--- a/net/netfilter/ipset/ip_set_bitmap_ip.c
+++ b/net/netfilter/ipset/ip_set_bitmap_ip.c
@@ -165,11 +165,8 @@ bitmap_ip_uadt(struct ip_set *set, struct nlattr *tb[],
 		ret = ip_set_get_hostipaddr4(tb[IPSET_ATTR_IP_TO], &ip_to);
 		if (ret)
 			return ret;
-		if (ip > ip_to) {
+		if (ip > ip_to)
 			swap(ip, ip_to);
-			if (ip < map->first_ip)
-				return -IPSET_ERR_BITMAP_RANGE;
-		}
 	} else if (tb[IPSET_ATTR_CIDR]) {
 		u8 cidr = nla_get_u8(tb[IPSET_ATTR_CIDR]);
 
@@ -180,7 +177,7 @@ bitmap_ip_uadt(struct ip_set *set, struct nlattr *tb[],
 		ip_to = ip;
 	}
 
-	if (ip_to > map->last_ip)
+	if (ip < map->first_ip || ip_to > map->last_ip)
 		return -IPSET_ERR_BITMAP_RANGE;
 
 	for (; !before(ip_to, ip); ip += map->hosts) {


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

```
jira VULN-46550
cve CVE-2024-53141
commit-author Jeongjun Park <aha310510@gmail.com>
commit 35f56c554eb1b56b77b3cf197a6b00922d49033d

When tb[IPSET_ATTR_IP_TO] is not present but tb[IPSET_ATTR_CIDR] exists, the values of ip and ip_to are slightly swapped. Therefore, the range check for ip should be done later, but this part is missing and it seems that the vulnerability occurs.

So we should add missing range checks and remove unnecessary range checks.

	Cc: <stable@vger.kernel.org>
	Reported-by: syzbot+58c872f7790a4d2ac951@syzkaller.appspotmail.com
Fixes: 72205fc68bd1 ("netfilter: ipset: bitmap:ip set type support")
	Signed-off-by: Jeongjun Park <aha310510@gmail.com>
	Acked-by: Jozsef Kadlecsik <kadlec@blackhole.kfki.hu>
	Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
(cherry picked from commit 35f56c554eb1b56b77b3cf197a6b00922d49033d)
	Signed-off-by: Anmol Jain <ajain@ciq.com>

```
### Kernel build logs
```
/home/anmol/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
Setting Local Version for build
CONFIG_LOCALVERSION="-_ajain_ciqcbr7_9-2565f95"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  SHIPPED scripts/kconfig/zconf.hash.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf --silentoldconfig Kconfig
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  HOSTCC  scripts/basic/bin2c
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_32.h
  WRAP    arch/x86/include/generated/asm/clkdev.h
  WRAP    arch/x86/include/generated/asm/mm-arch-hooks.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  CHK     include/generated/uapi/linux/version.h
  UPD     include/generated/uapi/linux/version.h
  CHK     include/generated/utsrelease.h
  UPD     include/generated/utsrelease.h
[--snip--]
  INSTALL /lib/firmware/edgeport/down.fw
  INSTALL /lib/firmware/edgeport/down2.fw
  INSTALL /lib/firmware/edgeport/down3.bin
  INSTALL /lib/firmware/whiteheat_loader.fw
  INSTALL /lib/firmware/whiteheat.fw
  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-_ajain_ciqcbr7_9-2565f95+
[TIMER]{MODULES}: 33s
Making Install
sh ./arch/x86/boot/install.sh 3.10.0-_ajain_ciqcbr7_9-2565f95+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 13s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-_ajain_ciqcbr7_9-ccfd614+ and Index to 6
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7_9.ciqcbr.4.1.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7_9.ciqcbr.4.1.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-1160.80.1.el7.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.80.1.el7.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-_ajain_ciqcbr7_9-2565f95+
Found initrd image: /boot/initramfs-3.10.0-_ajain_ciqcbr7_9-2565f95+.img
Found linux image: /boot/vmlinuz-3.10.0-_ajain__ciqcbr7_9-5b00565+
Found initrd image: /boot/initramfs-3.10.0-_ajain__ciqcbr7_9-5b00565+.img
Found linux image: /boot/vmlinuz-3.10.0-_ajain__ciqcbr7_9-ccfd614+
Found initrd image: /boot/initramfs-3.10.0-_ajain__ciqcbr7_9-ccfd614+.img
Found linux image: /boot/vmlinuz-3.10.0-_ajain__ciqcbr7_9-ccfd614+.old
Found initrd image: /boot/initramfs-3.10.0-_ajain__ciqcbr7_9-ccfd614+.img
Found linux image: /boot/vmlinuz-3.10.0-_ajain_ciqcbr7_9-ccfd614+
Found initrd image: /boot/initramfs-3.10.0-_ajain_ciqcbr7_9-ccfd614+.img
Found linux image: /boot/vmlinuz-0-rescue-9e065f0961d84ecf8bec2457d927e012
Found initrd image: /boot/initramfs-0-rescue-9e065f0961d84ecf8bec2457d927e012.img
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1629s
[TIMER]{MODULES}: 33s
[TIMER]{INSTALL}: 13s
[TIMER]{TOTAL} 1678s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/20814155/kernel-build.log)
### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
2
2
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
1
1
```
[kselftest-after.log](https://github.com/user-attachments/files/20814156/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/20814157/kselftest-before.log)
