### PR TITLE
[SIG-CLOUD-9] rebase custom changes to 5.14.0-570.22.1.el9 6

### DIFF
--- a/drivers/net/ethernet/microsoft/mana/mana_en.c
+++ b/drivers/net/ethernet/microsoft/mana/mana_en.c
@@ -920,7 +920,7 @@ static void mana_pf_deregister_filter(struct mana_port_context *apc)
 
 static int mana_query_device_cfg(struct mana_context *ac, u32 proto_major_ver,
 				 u32 proto_minor_ver, u32 proto_micro_ver,
-				 u16 *max_num_vports)
+				 u16 *max_num_vports, u8 *bm_hostmode)
 {
 	struct gdma_context *gc = ac->gdma_dev->gdma_context;
 	struct mana_query_device_cfg_resp resp = {};
@@ -931,7 +931,7 @@ static int mana_query_device_cfg(struct mana_context *ac, u32 proto_major_ver,
 	mana_gd_init_req_hdr(&req.hdr, MANA_QUERY_DEV_CONFIG,
 			     sizeof(req), sizeof(resp));
 
-	req.hdr.resp.msg_version = GDMA_MESSAGE_V2;
+	req.hdr.resp.msg_version = GDMA_MESSAGE_V3;
 
 	req.proto_major_ver = proto_major_ver;
 	req.proto_minor_ver = proto_minor_ver;
@@ -955,10 +955,15 @@ static int mana_query_device_cfg(struct mana_context *ac, u32 proto_major_ver,
 
 	*max_num_vports = resp.max_num_vports;
 
-	if (resp.hdr.response.msg_version == GDMA_MESSAGE_V2)
+	if (resp.hdr.response.msg_version >= GDMA_MESSAGE_V2)
 		gc->adapter_mtu = resp.adapter_mtu;
 	else
 		gc->adapter_mtu = ETH_FRAME_LEN;
+
+	if (resp.hdr.response.msg_version >= GDMA_MESSAGE_V3)
+		*bm_hostmode = resp.bm_hostmode;
+	else
+		*bm_hostmode = 0;
 
 	debugfs_create_u16("adapter-MTU", 0400, gc->mana_pci_debugfs, &gc->adapter_mtu);
 
@@ -2439,7 +2444,7 @@ static void mana_destroy_vport(struct mana_port_context *apc)
 	mana_destroy_txq(apc);
 	mana_uncfg_vport(apc);
 
-	if (gd->gdma_context->is_pf)
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode)
 		mana_pf_deregister_hw_vport(apc);
 }
 
@@ -2451,7 +2456,7 @@ static int mana_create_vport(struct mana_port_context *apc,
 
 	apc->default_rxobj = INVALID_MANA_HANDLE;
 
-	if (gd->gdma_context->is_pf) {
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode) {
 		err = mana_pf_register_hw_vport(apc);
 		if (err)
 			return err;
@@ -2675,7 +2680,7 @@ int mana_alloc_queues(struct net_device *ndev)
 	if (err)
 		goto destroy_vport;
 
-	if (gd->gdma_context->is_pf) {
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode) {
 		err = mana_pf_register_filter(apc);
 		if (err)
 			goto destroy_vport;
@@ -2737,7 +2742,7 @@ static int mana_dealloc_queues(struct net_device *ndev)
 
 	mana_chn_setxdp(apc, NULL);
 
-	if (gd->gdma_context->is_pf)
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode)
 		mana_pf_deregister_filter(apc);
 
 	/* No packet can be transmitted now since apc->port_is_up is false.
@@ -2978,6 +2983,7 @@ int mana_probe(struct gdma_dev *gd, bool resuming)
 	struct gdma_context *gc = gd->gdma_context;
 	struct mana_context *ac = gd->driver_data;
 	struct device *dev = gc->dev;
+	u8 bm_hostmode = 0;
 	u16 num_ports = 0;
 	int err;
 	int i;
@@ -3004,9 +3010,11 @@ int mana_probe(struct gdma_dev *gd, bool resuming)
 		goto out;
 
 	err = mana_query_device_cfg(ac, MANA_MAJOR_VERSION, MANA_MINOR_VERSION,
-				    MANA_MICRO_VERSION, &num_ports);
+				    MANA_MICRO_VERSION, &num_ports, &bm_hostmode);
 	if (err)
 		goto out;
+
+	ac->bm_hostmode = bm_hostmode;
 
 	if (!resuming) {
 		ac->num_ports = num_ports;

--- a/include/net/mana/mana.h
+++ b/include/net/mana/mana.h
@@ -405,6 +405,7 @@ struct mana_context {
 	struct gdma_dev *gdma_dev;
 
 	u16 num_ports;
+	u8 bm_hostmode;
 
 	struct mana_eq *eqs;
 	struct dentry *mana_eqs_debugfs;
@@ -554,7 +555,8 @@ struct mana_query_device_cfg_resp {
 	u64 pf_cap_flags4;
 
 	u16 max_num_vports;
-	u16 reserved;
+	u8 bm_hostmode; /* response v3: Bare Metal Host Mode */
+	u8 reserved;
 	u32 max_num_eqs;
 
 	/* response v2: */

--- a/tools/hv/hv_kvp_daemon.c
+++ b/tools/hv/hv_kvp_daemon.c
@@ -77,6 +77,7 @@ enum {
 };
 
 static int in_hand_shake;
+static int debug;
 
 static char *os_name = "";
 static char *os_major = "";
@@ -172,6 +173,20 @@ static void kvp_update_file(int pool)
 	kvp_release_lock(pool);
 }
 
+static void kvp_dump_initial_pools(int pool)
+{
+	int i;
+
+	syslog(LOG_DEBUG, "===Start dumping the contents of pool %d ===\n",
+	       pool);
+
+	for (i = 0; i < kvp_file_info[pool].num_records; i++)
+		syslog(LOG_DEBUG, "pool: %d, %d/%d key=%s val=%s\n",
+		       pool, i + 1, kvp_file_info[pool].num_records,
+		       kvp_file_info[pool].records[i].key,
+		       kvp_file_info[pool].records[i].value);
+}
+
 static void kvp_update_mem_state(int pool)
 {
 	FILE *filep;
@@ -259,6 +274,8 @@ static int kvp_file_init(void)
 			return 1;
 		kvp_file_info[i].num_records = 0;
 		kvp_update_mem_state(i);
+		if (debug)
+			kvp_dump_initial_pools(i);
 	}
 
 	return 0;
@@ -286,6 +303,9 @@ static int kvp_key_delete(int pool, const __u8 *key, int key_size)
 		 * Found a match; just move the remaining
 		 * entries up.
 		 */
+		if (debug)
+			syslog(LOG_DEBUG, "%s: deleting the KVP: pool=%d key=%s val=%s",
+			       __func__, pool, record[i].key, record[i].value);
 		if (i == (num_records - 1)) {
 			kvp_file_info[pool].num_records--;
 			kvp_update_file(pool);
@@ -304,20 +324,36 @@ static int kvp_key_delete(int pool, const __u8 *key, int key_size)
 		kvp_update_file(pool);
 		return 0;
 	}
+
+	if (debug)
+		syslog(LOG_DEBUG, "%s: could not delete KVP: pool=%d key=%s. Record not found",
+		       __func__, pool, key);
+
 	return 1;
 }
 
 static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 				 const __u8 *value, int value_size)
 {
-	int i;
-	int num_records;
 	struct kvp_record *record;
+	int num_records;
 	int num_blocks;
+	int i;
+
+	if (debug)
+		syslog(LOG_DEBUG, "%s: got a KVP: pool=%d key=%s val=%s",
+		       __func__, pool, key, value);
 
 	if ((key_size > HV_KVP_EXCHANGE_MAX_KEY_SIZE) ||
-		(value_size > HV_KVP_EXCHANGE_MAX_VALUE_SIZE))
+		(value_size > HV_KVP_EXCHANGE_MAX_VALUE_SIZE)) {
+		syslog(LOG_ERR, "%s: Too long key or value: key=%s, val=%s",
+		       __func__, key, value);
+
+		if (debug)
+			syslog(LOG_DEBUG, "%s: Too long key or value: pool=%d, key=%s, val=%s",
+			       __func__, pool, key, value);
 		return 1;
+	}
 
 	/*
 	 * First update the in-memory state.
@@ -337,6 +373,9 @@ static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 		 */
 		memcpy(record[i].value, value, value_size);
 		kvp_update_file(pool);
+		if (debug)
+			syslog(LOG_DEBUG, "%s: updated: pool=%d key=%s val=%s",
+			       __func__, pool, key, value);
 		return 0;
 	}
 
@@ -348,8 +387,10 @@ static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 		record = realloc(record, sizeof(struct kvp_record) *
 			 ENTRIES_PER_BLOCK * (num_blocks + 1));
 
-		if (record == NULL)
+		if (!record) {
+			syslog(LOG_ERR, "%s: Memory alloc failure", __func__);
 			return 1;
+		}
 		kvp_file_info[pool].num_blocks++;
 
 	}
@@ -357,6 +398,11 @@ static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 	memcpy(record[i].key, key, key_size);
 	kvp_file_info[pool].records = record;
 	kvp_file_info[pool].num_records++;
+
+	if (debug)
+		syslog(LOG_DEBUG, "%s: added: pool=%d key=%s val=%s",
+		       __func__, pool, key, value);
+
 	kvp_update_file(pool);
 	return 0;
 }
@@ -1355,6 +1401,7 @@ void print_usage(char *argv[])
 	fprintf(stderr, "Usage: %s [options]\n"
 		"Options are:\n"
 		"  -n, --no-daemon        stay in foreground, don't daemonize\n"
+		"  -d, --debug            Enable debug logs(syslog debug by default)\n"
 		"  -h, --help             print this help\n", argv[0]);
 }
 
@@ -1376,10 +1423,11 @@ int main(int argc, char *argv[])
 	static struct option long_options[] = {
 		{"help",	no_argument,	   0,  'h' },
 		{"no-daemon",	no_argument,	   0,  'n' },
+		{"debug",	no_argument,	   0,  'd' },
 		{0,		0,		   0,  0   }
 	};
 
-	while ((opt = getopt_long(argc, argv, "hn", long_options,
+	while ((opt = getopt_long(argc, argv, "hnd", long_options,
 				  &long_index)) != -1) {
 		switch (opt) {
 		case 'n':
@@ -1388,6 +1436,9 @@ int main(int argc, char *argv[])
 		case 'h':
 			print_usage(argv);
 			exit(0);
+		case 'd':
+			debug = 1;
+			break;
 		default:
 			print_usage(argv);
 			exit(EXIT_FAILURE);
@@ -1409,6 +1460,9 @@ int main(int argc, char *argv[])
 	 * unpredictable amount of time to finish.
 	 */
 	kvp_get_domain_name(full_domain_name, sizeof(full_domain_name));
+
+	if (debug)
+		syslog(LOG_INFO, "Logging debug info in syslog(debug)");
 
 	if (kvp_file_init()) {
 		syslog(LOG_ERR, "Failed to initialize the pools");

--- a/tools/testing/selftests/mm/hmm-tests.c
+++ b/tools/testing/selftests/mm/hmm-tests.c
@@ -159,6 +159,10 @@ FIXTURE_TEARDOWN(hmm)
 {
 	int ret = close(self->fd);
 
+	if (ret != 0) {
+		fprintf(stderr, "close returned (%d) fd is (%d)\n", ret, self->fd);
+		exit(1);
+	}
 	ASSERT_EQ(ret, 0);
 	self->fd = -1;
 }


### PR DESCRIPTION
## Update process (This kernel CentOS base for `5.14.0-570`)
* Kernel History Rebuild Process for all `src.rpm`s hosted by RESF
* Create `sig-cloud-9/5.14.0-570.X.1.el8_10` branch
* Check if any maintained code is included in the new `el` release.
* Cherry-pick all code from previous branch into new branch (skipping unneeded code) 
  * Fix conflicts as they arise 
* Build and Test

## Removed Commits
None

## Forward Port Process
```
[jmaple@devbox code]$ cat rolling.release.log
[rolling release update] Rolling Product:  sig-cloud-9
[rolling release update] Checking out branch:  sig-cloud-9/5.14.0-570.19.1.el9_6
[rolling release update] Gathering all the RESF kernel Tags
b'b94108159618 (tag: resf_kernel-5.14.0-570.19.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.19.1.el9_6'
b'e8b954c95fef (tag: resf_kernel-5.14.0-570.18.1.el9_6, origin/fips-9-compliant/5.14.0-570.18.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.18.1.el9_6'
b'838cd1e8d046 (tag: resf_kernel-5.14.0-570.17.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.17.1.el9_6'
b'171ceb527773 (tag: resf_kernel-5.14.0-570.16.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.16.1.el9_6'
b'18c0812a6563 (tag: resf_kernel-5.14.0-570.12.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.12.1.el9_6'
[rolling release update] Old Rolling Branch Tags:  [b'b94108159618', b'e8b954c95fef', b'838cd1e8d046', b'171ceb527773', b'18c0812a6563']
[rolling release update] Checking out branch:  rocky9_6
[rolling release update] Gathering all the RESF kernel Tags
b'667004a38548 (HEAD -> rocky9_6, tag: resf_kernel-5.14.0-570.22.1.el9_6, origin/rocky9_6) Rebuild rocky9_6 with kernel-5.14.0-570.22.1.el9_6'
b'9477e3364951 (tag: resf_kernel-5.14.0-570.21.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.21.1.el9_6'
b'b94108159618 (tag: resf_kernel-5.14.0-570.19.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.19.1.el9_6'
b'e8b954c95fef (tag: resf_kernel-5.14.0-570.18.1.el9_6, origin/fips-9-compliant/5.14.0-570.18.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.18.1.el9_6'
b'838cd1e8d046 (tag: resf_kernel-5.14.0-570.17.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.17.1.el9_6'
b'171ceb527773 (tag: resf_kernel-5.14.0-570.16.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.16.1.el9_6'
b'18c0812a6563 (tag: resf_kernel-5.14.0-570.12.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.12.1.el9_6'
[rolling release update] New Base Branch Tags:  [b'667004a38548', b'9477e3364951', b'b94108159618', b'e8b954c95fef', b'838cd1e8d046', b'171ceb527773', b'18c0812a6563']
[rolling release update] Common tag sha:  b'b94108159618'
"b94108159618043bdd64112095dff10f5a5d7b34 Rebuild rocky9_6 with kernel-5.14.0-570.19.1.el9_6"
[rolling release update] Checking out old rolling branch:  sig-cloud-9/5.14.0-570.19.1.el9_6
[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD
[rolling release update] Getting SHAS b94108159618..HEAD
[rolling release update] Last RESF tag sha:  b'b94108159618'
[rolling release update] Total Commit in old branch:  3
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
{
  "3590a63a6e3c981888012f6eec69d2f7e6f3e6b3": "a9c0b33ef2306327dd2db02c6274107065ff9307",
  "49618a6c50af4f4a0fd2167020619efc3fb848f2": "290e5d3c49f687c1567bde634dc33d57b0674919",
  "8690e71328ef51d80d44d8646d39856cc267a242": ""
}
[rolling release update] Checking out new base branch:  rocky9_6
[rolling release update] Finding the kernel version for the new rolling release
b'667004a38548 (HEAD -> rocky9_6, tag: resf_kernel-5.14.0-570.22.1.el9_6, origin/rocky9_6) Rebuild rocky9_6 with kernel-5.14.0-570.22.1.el9_6'
<re.Match object; span=(0, 70), match=b'667004a38548 (HEAD -> rocky9_6, tag: resf_kernel>
[rolling release update} New Branch to create  sig-cloud-9/5.14.0-570.22.1.el9_6
[rolling release update] Check if branch Exists:  sig-cloud-9/5.14.0-570.22.1.el9_6
Branch sig-cloud-9/5.14.0-570.22.1.el9_6 does not exists creating
[rolling release update] Creating new branch for PR:  jmaple_sig-cloud-9/5.14.0-570.22.1.el9_6
[rolling release update] Creating Map of all new commits from last rolling release fork
[rolling release update] Total Commit in new branch:  26
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
Printing first 5 and last 5 commits
{
  "667004a38548a723e0bb9930f465a40ae73af01f": "",
  "7be330f3951e726cfba87f85f2baa195b1ba051e": "ab4eedb790cae44313759b50fe47da285e2519d5",
  "19695c65e6cadc82e6c3b9270eaf459825ed485d": "b4f82f9ed43aefa79bec2504ae8c29be0c0f5d1d",
  "3ed86f263c6e3f378713ee9bbe245cc3c9634e08": "f708f6970cc9d6bac71da45c129482092e710537",
  "d8581806efcfe74c39823897af3d6e482b951299": "be9581ea8c058d81154251cb0695987098996cad"
}
{
  "85815f0d53c23326b64f5377ad1a6299866c261e": "b33a534610067ade2bdaf2052900aaad99701353",
  "7385be362671c26e28efd95bc78f3b6e97b87266": "b27055a08ad4b415dcf15b63034f9cb236f7fb40",
  "b03c9212fa08202fdcc50f5fe60e96077d413279": "ee01b2f2d7d0010787c2343463965bbc283a497f",
  "53c06ad801c4f31b87d7c34139c3b0d70b0f6b21": "9a0dddfb30f120db3851627935851d262e4e7acb",
  "fc28e9ff96664e621785269bf4317061cd3572f8": "d5e206778e96e8667d3bde695ad372c296dc9353"
}
[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch
[rolling release update] Removing commits from the new branch
[rolling release update] Applying the remaining commits to the new branch
Applying commit  "8690e71328ef51d80d44d8646d39856cc267a242 selftests/mm temporary fix of hmm infinite loop"
Applying commit  "49618a6c50af4f4a0fd2167020619efc3fb848f2 net: mana: Add support for Multi Vports on Bare metal"
Applying commit  "3590a63a6e3c981888012f6eec69d2f7e6f3e6b3 tools: hv: Enable debug logs for hv_kvp_daemon"
```

## Kbuild
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" kbuild.SCN.resf_kernel-5.14.0-570.22.1.el9_6.log
/mnt/code/kernel-src-tree-build
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
--
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  BTF [M] sound/virtio/virtio_snd.ko
  LD [M]  sound/xen/snd_xen_front.ko
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  BTF [M] sound/xen/snd_xen_front.ko
[TIMER]{BUILD}: 2229s
Making Modules
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  STRIP   /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+/kernel/sound/virtio/virtio_snd.ko
  DEPMOD  /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 28s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 2229s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 28s
[TIMER]{TOTAL} 2279s
Rebooting in 10 seconds
```

## KSelfTests
```
[jmaple@devbox code]$ ls ~/workspace/public_kernel-src-tree/auto_history_rebuilder/vms/rocky9/code/kselftest.5.14.0-jmaple_sig-cloud-9_5.14.0-570.19.1.el9_6-8690e71328ef+.log kselftest.5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+.log | while read line; do echo $line; grep '^ok ' $line | wc -l; done
/home/jmaple/workspace/public_kernel-src-tree/auto_history_rebuilder/vms/rocky9/code/kselftest.5.14.0-jmaple_sig-cloud-9_5.14.0-570.19.1.el9_6-8690e71328ef+.log
317
kselftest.5.14.0-jmaple_sig-cloud-9_5.14.0-570.22.1.el9_6-597d631a0005+.log
314
```