### PR TITLE
[fips-8] netdevsim: Fix memory leak of nsim_dev->fa_cookie

### DIFF
--- a/drivers/net/netdevsim/dev.c
+++ b/drivers/net/netdevsim/dev.c
@@ -1647,6 +1647,7 @@ void nsim_drv_remove(struct nsim_bus_dev *nsim_bus_dev)
 				  ARRAY_SIZE(nsim_devlink_params));
 	devl_resources_unregister(devlink);
 	kfree(nsim_dev->vfconfigs);
+	kfree(nsim_dev->fa_cookie);
 	devl_unlock(devlink);
 	devlink_free(devlink);
 	dev_set_drvdata(&nsim_bus_dev->dev, NULL);


### PR DESCRIPTION
jira VULN-65790
cve CVE-2022-49803

```
commit-author Wang Yufen <wangyufen@huawei.com>
commit 064bc7312bd09a48798418663090be0c776183db

kmemleak reports this issue:

unreferenced object 0xffff8881bac872d0 (size 8):
  comm "sh", pid 58603, jiffies 4481524462 (age 68.065s)
  hex dump (first 8 bytes):
    04 00 00 00 de ad be ef                          ........
  backtrace:
    [<00000000c80b8577>] __kmalloc+0x49/0x150
    [<000000005292b8c6>] nsim_dev_trap_fa_cookie_write+0xc1/0x210 [netdevsim]
    [<0000000093d78e77>] full_proxy_write+0xf3/0x180
    [<000000005a662c16>] vfs_write+0x1c5/0xaf0
    [<000000007aabf84a>] ksys_write+0xed/0x1c0
    [<000000005f1d2e47>] do_syscall_64+0x3b/0x90
    [<000000006001c6ec>] entry_SYSCALL_64_after_hwframe+0x63/0xcd

The issue occurs in the following scenarios:

nsim_dev_trap_fa_cookie_write()
  kmalloc() fa_cookie
  nsim_dev->fa_cookie = fa_cookie
..
nsim_drv_remove()

The fa_cookie allocked in nsim_dev_trap_fa_cookie_write() is not freed. To fix, add kfree(nsim_dev->fa_cookie) to nsim_drv_remove().

Fixes: d3cbb907ae57 ("netdevsim: add ACL trap reporting cookie as a metadata")
	Signed-off-by: Wang Yufen <wangyufen@huawei.com>
	Cc: Jiri Pirko <jiri@mellanox.com>
Link: https://lore.kernel.org/r/1668504625-14698-1-git-send-email-wangyufen@huawei.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 064bc7312bd09a48798418663090be0c776183db)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   include/config include/generated arch/x86/include/generated
  CLEAN   .config .config.old
[TIMER]{MRPROPER}: 12s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-8_4.18.0-553.16.1_VULN-65790-53260d98c274"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1038s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-b_f-8_4.18.0-553.16.1_VULN-65790-53260d98c274+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-b_f-8_4.18.0-553.16.1_VULN-65790-53260d98c274+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 105s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-b_f-8_4.18.0-553.16.1_VULN-65790-53260d98c274+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 12s
[TIMER]{BUILD}: 1038s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 105s
[TIMER]{TOTAL} 1184s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the change

[selftest-4.18.0-553.16.1.el8_6.ciqfips.0.8.1.x86_64.log](https://github.com/user-attachments/files/20840430/selftest-4.18.0-553.16.1.el8_6.ciqfips.0.8.1.x86_64.log)

[selftest-4.18.0-b_f-8_4.18.0-553.16.1_VULN-65790-53260d98c274+.log](https://github.com/user-attachments/files/20840432/selftest-4.18.0-b_f-8_4.18.0-553.16.1_VULN-65790-53260d98c274%2B.log)

```
brett@lycia ~/ciq/vuln-65790 % grep ^ok selftest-4.18.0-553.16.1.el8_6.ciqfips.0.8.1.x86_64.log | wc -l
258
brett@lycia ~/ciq/vuln-65790 % grep ^ok selftest-4.18.0-b_f-8_4.18.0-553.16.1_VULN-65790-53260d98c274+.log | wc -l
259
brett@lycia ~/ciq/vuln-65790 %

```