### PR TITLE
[fips-9.2] netfilter: ipset: add the missing IP_SET_HASH_WITH_NET0 macro for ip_…

### DIFF
--- a/net/netfilter/ipset/ip_set_hash_netportnet.c
+++ b/net/netfilter/ipset/ip_set_hash_netportnet.c
@@ -36,6 +36,7 @@ MODULE_ALIAS("ip_set_hash:net,port,net");
 #define IP_SET_HASH_WITH_PROTO
 #define IP_SET_HASH_WITH_NETS
 #define IPSET_NET_COUNT 2
+#define IP_SET_HASH_WITH_NET0
 
 /* IPv4 variant */
 


### PR DESCRIPTION
…set_hash_netportnet.c

jira VULN-8850
cve CVE-2023-42753

```
commit-author Kyle Zeng <zengyhkyle@gmail.com>
commit 050d91c03b28ca479df13dfb02bcd2c60dd6a878

The missing IP_SET_HASH_WITH_NET0 macro in ip_set_hash_netportnet can lead to the use of wrong `CIDR_POS(c)` for calculating array offsets, which can lead to integer underflow. As a result, it leads to slab out-of-bound access.
This patch adds back the IP_SET_HASH_WITH_NET0 macro to ip_set_hash_netportnet to address the issue.

Fixes: 886503f34d63 ("netfilter: ipset: actually allow allowable CIDR 0 in hash:net,port,net")
	Suggested-by: Jozsef Kadlecsik <kadlec@netfilter.org>
	Signed-off-by: Kyle Zeng <zengyhkyle@gmail.com>
	Acked-by: Jozsef Kadlecsik <kadlec@netfilter.org>
	Signed-off-by: Florian Westphal <fw@strlen.de>
(cherry picked from commit 050d91c03b28ca479df13dfb02bcd2c60dd6a878)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
  CLEAN   arch/x86/tools
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old
[TIMER]{MRPROPER}: 10s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
--
  BTF [M] sound/usb/usx2y/snd-usb-usx2y.ko
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] sound/xen/snd_xen_front.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1549s
Making Modules
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+
[TIMER]{MODULES}: 10s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 47s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 10s
[TIMER]{BUILD}: 1549s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 47s
[TIMER]{TOTAL} 1633s
Rebooting in 10 seconds

```

### Testing

kselftests were run before and after applying the fix

```
brett@lycia ~/ciq/vuln-8850 % grep ^ok selftest-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64.log | wc -l
244
brett@lycia ~/ciq/vuln-8850 % grep ^ok selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8850-f4abac5f07e9+.log | wc -l
244
brett@lycia ~/ciq/vuln-8850 %

```