### PR TITLE
[LTS 8.8] net: mdio: fix undefined behavior in bit shift for __mdiobus_register

### DIFF
--- a/drivers/net/phy/mdio_bus.c
+++ b/drivers/net/phy/mdio_bus.c
@@ -623,7 +623,7 @@ int __mdiobus_register(struct mii_bus *bus, struct module *owner)
 	}
 
 	for (i = 0; i < PHY_MAX_ADDR; i++) {
-		if ((bus->phy_mask & (1 << i)) == 0) {
+		if ((bus->phy_mask & BIT(i)) == 0) {
 			struct phy_device *phydev;
 
 			phydev = mdiobus_scan(bus, i);


### PR DESCRIPTION
[LTS 8.8]
CVE-2022-49907
VULN-66412


# Problem

<https://www.cve.org/CVERecord?id=CVE-2022-49907>

    In the Linux kernel, the following vulnerability has been resolved:
    
    net: mdio: fix undefined behavior in bit shift for __mdiobus_register
    
    Shifting signed 32-bit value by 31 bits is undefined, so changing
    significant bit to unsigned. The UBSAN warning calltrace like below:
    
    UBSAN: shift-out-of-bounds in drivers/net/phy/mdio_bus.c:586:27
    left shift of 1 by 31 places cannot be represented in type 'int'
    Call Trace:
     <TASK>
     dump_stack_lvl+0x7d/0xa5
     dump_stack+0x15/0x1b
     ubsan_epilogue+0xe/0x4e
     __ubsan_handle_shift_out_of_bounds+0x1e7/0x20c
     __mdiobus_register+0x49d/0x4e0
     fixed_mdio_bus_init+0xd8/0x12d
     do_one_initcall+0x76/0x430
     kernel_init_freeable+0x3b3/0x422
     kernel_init+0x24/0x1e0
     ret_from_fork+0x1f/0x30
     </TASK>


# Applicability: yes (same as in <https://github.com/ctrliq/kernel-src-tree/pull/359>)

The bug applies to LTS 8.8: the affected MDIO bus driver is central to the control of any ethernet interface device. The patch 40e4eb324c59e11fcb927aa46742d28aba6ecb8a is not backported onto LTS 8.8, yet it is backported onto its mainline sibling stable 4.19 in a3fafc974be37319679f36dc4e7cca7db1e02973.


# Solution (same as in <https://github.com/ctrliq/kernel-src-tree/pull/359>)

The solution in 40e4eb324c59e11fcb927aa46742d28aba6ecb8a involves using the `BIT(i)` macro instead of the raw bit shift `1 << i` to obtain an `int` with *i* -th bit set. The fully expanded `BIT(i)` macro boils down to `1UL << i` construct operating on unsigned type where the left shit is defined for the full range of the type's bits (see `include/vdso/bits.h`, `include/uapi/linux/const.h`, `include/linux/bits.h`).


# kABI check: passed

    DEBUG=1 CVE=CVE-2022-49907 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_8-CVE-2022-49907

    ninja: Entering directory `/data/build/rocky-patching'
    [0/1] Check ABI of kernel [ciqlts8_8-CVE-2022-49907]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.8/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_8/build_files/kernel-src-tree-ciqlts8_8-CVE-2022-49907/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_8-CVE-2022-49907/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20890001/boot-test.log>)


# Kselftests: passed relative


## Coverage

All the network-related tests (except the unstable ones):

`net/forwarding` (except `sch_tbf_ets.sh`, `tc_actions.sh`, `ipip_hier_gre_keys.sh`, `mirror_gre_bridge_1d_vlan.sh`, `sch_tbf_prio.sh`, `sch_ets.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_tbf_root.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `reuseport_addr_any.sh`, `gro.sh`, `xfrm_policy.sh`, `udpgro_fwd.sh`, `txtimestamp.sh`, `reuseaddr_conflict`, `udpgso_bench.sh`, `ip_defrag.sh`), `netfilter` (except `nft_trans_stress.sh`)


## Reference

[kselftests&#x2013;ciqlts8\_8&#x2013;run1.log](<https://github.com/user-attachments/files/20890000/kselftests--ciqlts8_8--run1.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run2.log](<https://github.com/user-attachments/files/20889999/kselftests--ciqlts8_8--run2.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run3.log](<https://github.com/user-attachments/files/20889998/kselftests--ciqlts8_8--run3.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run4.log](<https://github.com/user-attachments/files/20889997/kselftests--ciqlts8_8--run4.log>)
[kselftests&#x2013;ciqlts8\_8&#x2013;run5.log](<https://github.com/user-attachments/files/20889996/kselftests--ciqlts8_8--run5.log>)


## Patch

[kselftests&#x2013;ciqlts8\_8-CVE-2022-49907&#x2013;run1.log](<https://github.com/user-attachments/files/20889995/kselftests--ciqlts8_8-CVE-2022-49907--run1.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2022-49907&#x2013;run2.log](<https://github.com/user-attachments/files/20889994/kselftests--ciqlts8_8-CVE-2022-49907--run2.log>)
[kselftests&#x2013;ciqlts8\_8-CVE-2022-49907&#x2013;run3.log](<https://github.com/user-attachments/files/20889993/kselftests--ciqlts8_8-CVE-2022-49907--run3.log>)


## Comparison

The tests results for patch and reference are the same

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_8--run1.log
    Status1   kselftests--ciqlts8_8--run2.log
    Status2   kselftests--ciqlts8_8--run3.log
    Status3   kselftests--ciqlts8_8--run4.log
    Status4   kselftests--ciqlts8_8--run5.log
    Status5   kselftests--ciqlts8_8-CVE-2022-49907--run1.log
    Status6   kselftests--ciqlts8_8-CVE-2022-49907--run2.log
    Status7   kselftests--ciqlts8_8-CVE-2022-49907--run3.log


# Specific tests: could not replicate (same as in <https://github.com/ctrliq/kernel-src-tree/pull/359>)

An attempt was made to replicate the bug by compiling the kernel with `CONFIG_UBSAN=y`. Unfortunately, the integer overflows resulting from bit shifts were not being captured by UBSAN, not only in the affected driver, but in general, as could have been demonstrated with the modified `test_ubsan` module (enabled with `CONFIG_TEST_UBSAN=y`) where, along the original `test_ubsan_shift_out_of_bounds` function:

    static void test_ubsan_shift_out_of_bounds(void)
    {
    	volatile int val = -1;
    	int val2 = 10;
    
    	val2 <<= val;
    }

an additional `test_ubsan_shift_out_of_bounds1` was defined testing the exact situation as described in the CVE:

    static void test_ubsan_shift_out_of_bounds1(void)
    {
    	volatile int val = 31;
    	int val2 = 1;
    
    	val2 <<= val;
    }

The added `test_ubsan_shift_out_of_bounds1` test was ignored by UBSAN at runtime (as well as original tests for {add, sub, mul, negate} overflows), which only kicked in during the division by zero test `test_ubsan_divrem_overflow` and the kernel rebooted immediately after:

    [root@ciqlts-8-8 pvts]# modprobe test_ubsan
    [   77.060491] ================================================================================
    [   77.064875] UBSAN: Undefined behaviour in /mnt/code/kernel-src-tree-ciqlts8_8-ubsan/lib/test_ubsan.c:51:6
    [   77.069418] division by zero
    [   77.070618] CPU: 1 PID: 1556 Comm: modprobe Kdump: loaded Not tainted 4.18.0-ciqlts8_8-ubsan #2
    [   77.074036] Hardware name: Red Hat KVM/RHEL, BIOS 1.16.3-2.el9_5.1 04/01/2014
    [   77.077214] Call Trace:
    [   77.078095]  dump_stack+0x41/0x60
    [   77.079198]  ubsan_epilogue+0x5/0x25
    [   77.080377]  __ubsan_handle_divrem_overflow.cold.15+0x23/0x49
    [   77.082241]  ? kfree+0x1b4/0x200
    [   77.083260]  test_ubsan_divrem_overflow+0x82/0x90 [test_ubsan]
    [   77.085130]  test_ubsan_init+0x57/0x1000 [test_ubsan]
    [   77.086739]  ? 0xffffffffc0ae9000
    [   77.087590]  do_one_initcall+0x46/0x1d0
    [   77.088491]  ? kmem_cache_alloc_trace+0x4c/0x390
    [   77.089573]  ? load_module+0x156d/0x1b80
    [   77.090480]  do_init_module+0x5a/0x230
    [   77.091363]  load_module+0x157a/0x1b80
    [   77.092224]  ? __do_sys_finit_module+0xb1/0x110
    [   77.093266]  __do_sys_finit_module+0xb1/0x110
    [   77.094270]  do_syscall_64+0x5b/0x1b0
    [   77.095103]  entry_SYSCALL_64_after_hwframe+0x61/0xc6
    [   77.096267] RIP: 0033:0x7f15e4a2f9bd
    [   77.097102] Code: ff c3 66 2e 0f 1f 84 00 00 00 00 00 90 f3 0f 1e fa 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d 9b 54 38 00 f7 d8 64 89 01 48
    [   77.101057] RSP: 002b:00007fff882f12f8 EFLAGS: 00000246 ORIG_RAX: 0000000000000139
    [   77.102368] RAX: ffffffffffffffda RBX: 000056008bcd3b80 RCX: 00007f15e4a2f9bd
    [   77.103493] RDX: 0000000000000000 RSI: 000056008ace88b6 RDI: 0000000000000003
    [   77.104614] RBP: 000056008ace88b6 R08: 0000000000000000 R09: 000056008bcd5780
    [   77.105729] R10: 0000000000000003 R11: 0000000000000246 R12: 0000000000000000
    [   77.106847] R13: 000056008bcd3d20 R14: 0000000000040000 R15: 0000000000000000
    [   77.107987] ================================================================================
    [   77.109330] divide error: 0000 [#1] SMP PTI
    [   77.110015] CPU: 1 PID: 1556 Comm: modprobe Kdump: loaded Not tainted 4.18.0-ciqlts8_8-ubsan #2
    [   77.111374] Hardware name: Red Hat KVM/RHEL, BIOS 1.16.3-2.el9_5.1 04/01/2014
    [   77.112474] RIP: 0010:test_ubsan_divrem_overflow+0x44/0x90 [test_ubsan]
    [   77.113504] Code: 00 00 00 c7 44 24 0c 00 00 00 00 8b 5c 24 0c 8b 44 24 08 3d 00 00 00 80 0f 94 c1 83 fb ff 0f 94 c2 84 d1 75 2a 85 db 74 26 99 <f7> fb 89 44 24 08 48 8b 44 24 10 65 48 33 04 25 28 00 00 00 75 0a
    [   77.116411] RSP: 0018:ffffb7ce441cbc50 EFLAGS: 00010246
    [   77.117241] RAX: 0000000000000010 RBX: 0000000000000000 RCX: 0000000000000000
    [   77.118361] RDX: 0000000000000000 RSI: ffff9d195f89e698 RDI: ffff9d195f89e698
    [   77.119498] RBP: 0000000000000030 R08: 0000000000000000 R09: ffffffff8b01df28
    [   77.120584] R10: 3d3d3d3d3d3d3d3d R11: 3d3d3d3d3d3d3d3d R12: 0000000000000030
    [   77.121668] R13: ffffffffc0ae6040 R14: ffffffffc0ae68d0 R15: 0000000000000000
    [   77.122760] FS:  00007f15e5b1d740(0000) GS:ffff9d195f880000(0000) knlGS:0000000000000000
    [   77.123987] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
    [   77.124867] CR2: 00007f15e4af8310 CR3: 0000000112f1c001 CR4: 0000000000370ee0
    [   77.125957] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
    [   77.127044] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
    [   77.128140] Call Trace:
    [   77.128532]  test_ubsan_init+0x57/0x1000 [test_ubsan]
    [   77.129323]  ? 0xffffffffc0ae9000
    [   77.129838]  do_one_initcall+0x46/0x1d0
    [   77.130430]  ? kmem_cache_alloc_trace+0x4c/0x390
    [   77.131132]  ? load_module+0x156d/0x1b80
    [   77.131738]  do_init_module+0x5a/0x230
    [   77.132309]  load_module+0x157a/0x1b80
    [   77.132894]  ? __do_sys_finit_module+0xb1/0x110
    [   77.133588]  __do_sys_finit_module+0xb1/0x110
    [   77.134251]  do_syscall_64+0x5b/0x1b0
    [   77.134815]  entry_SYSCALL_64_after_hwframe+0x61/0xc6
    [   77.135584] RIP: 0033:0x7f15e4a2f9bd
    [   77.136134] Code: ff c3 66 2e 0f 1f 84 00 00 00 00 00 90 f3 0f 1e fa 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d 9b 54 38 00 f7 d8 64 89 01 48
    [   77.138963] RSP: 002b:00007fff882f12f8 EFLAGS: 00000246 ORIG_RAX: 0000000000000139
    [   77.140109] RAX: ffffffffffffffda RBX: 000056008bcd3b80 RCX: 00007f15e4a2f9bd
    [   77.141175] RDX: 0000000000000000 RSI: 000056008ace88b6 RDI: 0000000000000003
    [   77.142237] RBP: 000056008ace88b6 R08: 0000000000000000 R09: 000056008bcd5780
    [   77.143298] R10: 0000000000000003 R11: 0000000000000246 R12: 0000000000000000
    [   77.144369] R13: 000056008bcd3d20 R14: 0000000000040000 R15: 0000000000000000
    [   77.145428] Modules linked in: test_ubsan(+) intel_rapl_msr intel_rapl_common intel_uncore_frequency_common iTCO_wdt isst_if_common iTCO_vendor_support nfit libnvdimm vfat kvm_intel virtio_gpu fat drm_shmem_helper drm_kms_helper kvm irqbypass syscopyarea sysfillrect rapl sysimgblt fb_sys_fops pcspkr joydev lpc_ich i2c_i801 virtio_balloon drm xfs libcrc32c sr_mod cdrom sg crct10dif_pclmul crc32_pclmul crc32c_intel ghash_clmulni_intel virtio_net ahci net_failover libahci serio_raw virtio_console libata failover virtio_blk virtiofs sunrpc dm_mirror dm_region_hash dm_log dm_mod fuse
    [    0.000000] Linux version 4.18.0-ciqlts8_8-ubsan (pvts@ciqlts-8-8) (gcc version 8.5.0 20210514 (Red Hat 8.5.0-18) (GCC)) #2 SMP Mon Jun 23 05:51:35 UTC 2025
    …

After this unsuccessful replication attempt the specific testing efforts were then abandoned.

