### PR TITLE
[fipslegacy-8.6] net: atlantic: fix aq_vec index out of range error

### DIFF
--- a/drivers/net/ethernet/aquantia/atlantic/aq_nic.c
+++ b/drivers/net/ethernet/aquantia/atlantic/aq_nic.c
@@ -257,12 +257,10 @@ static void aq_nic_service_timer_cb(struct timer_list *t)
 static void aq_nic_polling_timer_cb(struct timer_list *t)
 {
 	struct aq_nic_s *self = from_timer(self, t, polling_timer);
-	struct aq_vec_s *aq_vec = NULL;
 	unsigned int i = 0U;
 
-	for (i = 0U, aq_vec = self->aq_vec[0];
-		self->aq_vecs > i; ++i, aq_vec = self->aq_vec[i])
-		aq_vec_isr(i, (void *)aq_vec);
+	for (i = 0U; self->aq_vecs > i; ++i)
+		aq_vec_isr(i, (void *)self->aq_vec[i]);
 
 	mod_timer(&self->polling_timer, jiffies +
 		  AQ_CFG_POLLING_TIMER_INTERVAL);
@@ -852,7 +850,6 @@ int aq_nic_get_regs_count(struct aq_nic_s *self)
 
 u64 *aq_nic_get_stats(struct aq_nic_s *self, u64 *data)
 {
-	struct aq_vec_s *aq_vec = NULL;
 	struct aq_stats_s *stats;
 	unsigned int count = 0U;
 	unsigned int i = 0U;
@@ -896,11 +893,11 @@ u64 *aq_nic_get_stats(struct aq_nic_s *self, u64 *data)
 	data += i;
 
 	for (tc = 0U; tc < self->aq_nic_cfg.tcs; tc++) {
-		for (i = 0U, aq_vec = self->aq_vec[0];
-		     aq_vec && self->aq_vecs > i;
-		     ++i, aq_vec = self->aq_vec[i]) {
+		for (i = 0U; self->aq_vecs > i; ++i) {
+			if (!self->aq_vec[i])
+				break;
 			data += count;
-			count = aq_vec_get_sw_stats(aq_vec, tc, data);
+			count = aq_vec_get_sw_stats(self->aq_vec[i], tc, data);
 		}
 	}
 
@@ -1215,7 +1212,6 @@ int aq_nic_set_loopback(struct aq_nic_s *self)
 
 int aq_nic_stop(struct aq_nic_s *self)
 {
-	struct aq_vec_s *aq_vec = NULL;
 	unsigned int i = 0U;
 
 	netif_tx_disable(self->ndev);
@@ -1233,9 +1229,8 @@ int aq_nic_stop(struct aq_nic_s *self)
 
 	aq_ptp_irq_free(self);
 
-	for (i = 0U, aq_vec = self->aq_vec[0];
-		self->aq_vecs > i; ++i, aq_vec = self->aq_vec[i])
-		aq_vec_stop(aq_vec);
+	for (i = 0U; self->aq_vecs > i; ++i)
+		aq_vec_stop(self->aq_vec[i]);
 
 	aq_ptp_ring_stop(self);
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-69388
cve CVE-2022-50066
commit-author Chia-Lin Kao (AceLan) <acelan.kao@canonical.com> commit 2ba5e47fb75fbb8fab45f5c1bc8d5c33d8834bd3

The final update statement of the for loop exceeds the array range, the dereference of self->aq_vec[i] is not checked and then leads to the index out of range error.
Also fixed this kind of coding style in other for loop.

[   97.937604] UBSAN: array-index-out-of-bounds in drivers/net/ethernet/aquantia/atlantic/aq_nic.c:1404:48
[   97.937607] index 8 is out of range for type 'aq_vec_s *[8]'
[   97.937608] CPU: 38 PID: 3767 Comm: kworker/u256:18 Not tainted 5.19.0+ #2
[   97.937610] Hardware name: Dell Inc. Precision 7865 Tower/, BIOS 1.0.0 06/12/2022
[   97.937611] Workqueue: events_unbound async_run_entry_fn
[   97.937616] Call Trace:
[   97.937617]  <TASK>
[   97.937619]  dump_stack_lvl+0x49/0x63
[   97.937624]  dump_stack+0x10/0x16
[   97.937626]  ubsan_epilogue+0x9/0x3f
[   97.937627]  __ubsan_handle_out_of_bounds.cold+0x44/0x49
[   97.937629]  ? __scm_send+0x348/0x440
[   97.937632]  ? aq_vec_stop+0x72/0x80 [atlantic]
[   97.937639]  aq_nic_stop+0x1b6/0x1c0 [atlantic]
[   97.937644]  aq_suspend_common+0x88/0x90 [atlantic]
[   97.937648]  aq_pm_suspend_poweroff+0xe/0x20 [atlantic]
[   97.937653]  pci_pm_suspend+0x7e/0x1a0
[   97.937655]  ? pci_pm_suspend_noirq+0x2b0/0x2b0
[   97.937657]  dpm_run_callback+0x54/0x190
[   97.937660]  __device_suspend+0x14c/0x4d0
[   97.937661]  async_suspend+0x23/0x70
[   97.937663]  async_run_entry_fn+0x33/0x120
[   97.937664]  process_one_work+0x21f/0x3f0
[   97.937666]  worker_thread+0x4a/0x3c0
[   97.937668]  ? process_one_work+0x3f0/0x3f0
[   97.937669]  kthread+0xf0/0x120
[   97.937671]  ? kthread_complete_and_exit+0x20/0x20
[   97.937672]  ret_from_fork+0x22/0x30
[   97.937676]  </TASK>

v2. fixed "warning: variable 'aq_vec' set but not used"

v3. simplified a for loop

Fixes: 97bde5c4f909 ("net: ethernet: aquantia: Support for NIC-specific code")
	Signed-off-by: Chia-Lin Kao (AceLan) <acelan.kao@canonical.com>
	Acked-by: Sudarsana Reddy Kalluru <skalluru@marvell.com>
Link: https://lore.kernel.org/r/20220808081845.42005-1-acelan.kao@canonical.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 2ba5e47fb75fbb8fab45f5c1bc8d5c33d8834bd3)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ajain_fips-legacy-8-compliant_4.18.0-425.13.1-e115359e0"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  HOSTCC  scripts/basic/bin2c
  UPD     include/config/kernel.release
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  UPD     include/generated/uapi/linux/version.h
  UPD     include/generated/utsrelease.h
  DESCEND objtool
  HOSTCC  /home/anmol/kernel-src-tree/tools/objtool/fixdep.o
  HOSTLD  /home/anmol/kernel-src-tree/tools/objtool/fixdep-in.o
  LINK    /home/anmol/kernel-src-tree/tools/objtool/fixdep
  CC      /home/anmol/kernel-src-tree/tools/objtool/exec-cmd.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/help.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/pager.o
  CC      /home/anmol/kernel-src-tree/tools/objtool/parse-options.o
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
[--snip--]
  INSTALL sound/usb/misc/snd-ua101.ko
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-_ajain_fips-legacy-8-compliant_4.18.0-425.13.1-e115359e0+
[TIMER]{MODULES}: 21s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-_ajain_fips-legacy-8-compliant_4.18.0-425.13.1-e115359e0+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 33s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-_ajain_fips-legacy-8-compliant_4.18.0-425.13.1-b26c9f0a4+ and Index to 15
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-_ajain_fips-legacy-8-compliant_4.18.0-425.13.1-b26c9f0a4+.conf with index 15 and kernel /boot/vmlinuz-4.18.0-_ajain_fips-legacy-8-compliant_4.18.0-425.13.1-b26c9f0a4+
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-_ajain_fips-legacy-8-compliant_4.18.0-425.13.1-b26c9f0a4+.conf with index 15 and kernel /boot/vmlinuz-4.18.0-_ajain_fips-legacy-8-compliant_4.18.0-425.13.1-b26c9f0a4+
Generating grub configuration file ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 3126s
[TIMER]{MODULES}: 21s
[TIMER]{INSTALL}: 33s
[TIMER]{TOTAL} 3184s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/20903466/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
204
204
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
53
53
```
[kselftest-after.log](https://github.com/user-attachments/files/20903468/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/20903469/kselftest-before.log)
