### PR TITLE
[LTS 7.9] net: mdio: fix undefined behavior in bit shift for __mdiobus_register

### DIFF
--- a/drivers/net/phy/mdio_bus.c
+++ b/drivers/net/phy/mdio_bus.c
@@ -278,7 +278,7 @@ int __mdiobus_register(struct mii_bus *bus, struct module *owner)
 		bus->reset(bus);
 
 	for (i = 0; i < PHY_MAX_ADDR; i++) {
-		if ((bus->phy_mask & (1 << i)) == 0) {
+		if ((bus->phy_mask & BIT(i)) == 0) {
 			struct phy_device *phydev;
 
 			phydev = mdiobus_scan(bus, i);


### PR DESCRIPTION
[CBR 7.9]
CVE-2022-49907
VULN-66410


# Problem

<https://www.cve.org/CVERecord?id=CVE-2022-49907>

    In the Linux kernel, the following vulnerability has been resolved:
    
    net: mdio: fix undefined behavior in bit shift for __mdiobus_register
    
    Shifting signed 32-bit value by 31 bits is undefined, so changing
    significant bit to unsigned. The UBSAN warning calltrace like below:
    
    UBSAN: shift-out-of-bounds in drivers/net/phy/mdio_bus.c:586:27
    left shift of 1 by 31 places cannot be represented in type 'int'
    Call Trace:
     <TASK>
     dump_stack_lvl+0x7d/0xa5
     dump_stack+0x15/0x1b
     ubsan_epilogue+0xe/0x4e
     __ubsan_handle_shift_out_of_bounds+0x1e7/0x20c
     __mdiobus_register+0x49d/0x4e0
     fixed_mdio_bus_init+0xd8/0x12d
     do_one_initcall+0x76/0x430
     kernel_init_freeable+0x3b3/0x422
     kernel_init+0x24/0x1e0
     ret_from_fork+0x1f/0x30
     </TASK>


# Applicability: yes (similar as in <https://github.com/ctrliq/kernel-src-tree/pull/358>)

The bug applies to CBR 7.9: the affected MDIO bus driver is central to the control of any ethernet interface device. The patch 40e4eb324c59e11fcb927aa46742d28aba6ecb8a is not backported onto CBR 7.9. The commit 4fd5f812c23c7deee6425f4a318e85c317cd1d6c marked in 40e4eb324c59e11fcb927aa46742d28aba6ecb8a as introducing the bug is present in `ciqcbr7_9`'s history.


# Solution (same as in <https://github.com/ctrliq/kernel-src-tree/pull/358>)

The solution in 40e4eb324c59e11fcb927aa46742d28aba6ecb8a involves using the `BIT(i)` macro instead of the raw bit shift `1 << i` to obtain an `int` with *i* -th bit set. The fully expanded `BIT(i)` macro boils down to `1UL << i` construct operating on unsigned type where the left shit is defined for the full range of the type's bits (see `include/vdso/bits.h`, `include/uapi/linux/const.h`, `include/linux/bits.h`).


# kABI check: passed

    [pvts@ciqcbr-7-9 kernel-dist-git-el-7.9]$ SOURCES/check-kabi -k SOURCES/Module.kabi_x86_64 -s /mnt/build_files/kernel-src-tree-ciqcbr7_9-CVE-2022-49907/Module.symvers
    [pvts@ciqcbr-7-9 kernel-dist-git-el-7.9]$ echo $? 

    0


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20931676/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqcbr7\_9&#x2013;run1.log](<https://github.com/user-attachments/files/20932152/kselftests--ciqcbr7_9--run1.log>)


## Patch

[kselftests&#x2013;ciqcbr7\_9-CVE-2022-49907&#x2013;run1.log](<https://github.com/user-attachments/files/20932126/kselftests--ciqcbr7_9-CVE-2022-49907--run1.log>)


## Manual comparison

The logs of the CBR 7.9 selftests don't conform to the unified TAP 13 format of the versions ≥ LTS 8.6 and as such they can't be parsed in an automated way. The results must be assessed manually.

The test results for the reference and patched kernel are the same.

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">&#xa0;</th>
<th scope="col" class="org-left">Reference</th>
<th scope="col" class="org-left">Patch</th>
<th scope="col" class="org-left">Comment</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">breakpoints</td>
<td class="org-left">pass</td>
<td class="org-left">pass</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">cpu-hotplug</td>
<td class="org-left">unknown result</td>
<td class="org-left">unknown result</td>
<td class="org-left">Neither errors nor explicit "ok" reported</td>
</tr>


<tr>
<td class="org-left">efivarfs</td>
<td class="org-left">skipped</td>
<td class="org-left">skipped</td>
<td class="org-left">Requires some EFI partition to mount</td>
</tr>


<tr>
<td class="org-left">kcmp</td>
<td class="org-left">skipped</td>
<td class="org-left">skipped</td>
<td class="org-left">Unresolved compilation errors</td>
</tr>


<tr>
<td class="org-left">livepatch:test-livepatch.sh</td>
<td class="org-left">skipped</td>
<td class="org-left">skipped</td>
<td class="org-left">Requires CONFIG&#95;TEST&#95;LIVEPATCH option</td>
</tr>


<tr>
<td class="org-left">livepatch:test-callbacks.sh</td>
<td class="org-left">skipped</td>
<td class="org-left">skipped</td>
<td class="org-left">Requires CONFIG&#95;TEST&#95;LIVEPATCH option</td>
</tr>


<tr>
<td class="org-left">livepatch:test-shadow-vars.sh</td>
<td class="org-left">skipped</td>
<td class="org-left">skipped</td>
<td class="org-left">Requires CONFIG&#95;TEST&#95;LIVEPATCH option</td>
</tr>


<tr>
<td class="org-left">livepatch:test-ftrace.sh</td>
<td class="org-left">skipped</td>
<td class="org-left">skipped</td>
<td class="org-left">Requires CONFIG&#95;TEST&#95;LIVEPATCH option</td>
</tr>


<tr>
<td class="org-left">memory-hotplug</td>
<td class="org-left">unknown result</td>
<td class="org-left">unknown result</td>
<td class="org-left">Neither errors nor explicit "ok" reported</td>
</tr>


<tr>
<td class="org-left">mqueue</td>
<td class="org-left">pass</td>
<td class="org-left">pass</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">net:run&#95;netsocktests</td>
<td class="org-left">pass</td>
<td class="org-left">pass</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">net:run&#95;afpackettests</td>
<td class="org-left">pass</td>
<td class="org-left">pass</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">ptrace</td>
<td class="org-left">pass</td>
<td class="org-left">pass</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">vm:run&#95;vmtests</td>
<td class="org-left">pass</td>
<td class="org-left">pass</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">x86:sigreturn&#95;64</td>
<td class="org-left">fail</td>
<td class="org-left">fail</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">x86:single&#95;step&#95;syscall&#95;64</td>
<td class="org-left">pass</td>
<td class="org-left">pass</td>
<td class="org-left">&#xa0;</td>
</tr>
</tbody>
</table>


# Specific tests: skipped

