### PR TITLE
[LTS 8.6] net: pktgen: fix access outside of user given buffer in pktgen_thread…

### DIFF
--- a/net/core/pktgen.c
+++ b/net/core/pktgen.c
@@ -1777,8 +1777,8 @@ static ssize_t pktgen_thread_write(struct file *file,
 	i = len;
 
 	/* Read variable name */
-
-	len = strn_len(&user_buffer[i], sizeof(name) - 1);
+	max = min(sizeof(name) - 1, count - i);
+	len = strn_len(&user_buffer[i], max);
 	if (len < 0)
 		return len;
 
@@ -1808,7 +1808,8 @@ static ssize_t pktgen_thread_write(struct file *file,
 	if (!strcmp(name, "add_device")) {
 		char f[32];
 		memset(f, 0, 32);
-		len = strn_len(&user_buffer[i], sizeof(f) - 1);
+		max = min(sizeof(f) - 1, count - i);
+		len = strn_len(&user_buffer[i], max);
 		if (len < 0) {
 			ret = len;
 			goto out;


### PR DESCRIPTION
[LTS 8.6]
CVE-2025-38061
VULN-70907


# Problem

<https://lore.kernel.org/linux-cve-announce/2025061835-CVE-2025-38061-caa2@gregkh/T/#u>

    In the Linux kernel, the following vulnerability has been resolved:
    
    net: pktgen: fix access outside of user given buffer in pktgen_thread_write()
    
    Honour the user given buffer size for the strn_len() calls (otherwise
    strn_len() will access memory outside of the user given buffer).
    
    The Linux kernel CVE team has assigned CVE-2025-38061 to this issue.


# Applicability: yes

See <https://github.com/ctrliq/kernel-src-tree/blob/b9fae43398164c4cce83b4e348de2501622820ce/net/core/pktgen.c#L893> and <https://github.com/ctrliq/kernel-src-tree/blob/b9fae43398164c4cce83b4e348de2501622820ce/net/core/pktgen.c#L1811> - the `count` argument is ignored in the `strn_len()` calculation.

The `CONFIG_NET_PKTGEN` option enabling the affected file `net/core/pktgen.c` is `m` for most configuration variants:

    $ grep CONFIG_NET_PKTGEN configs/kernel*.config

    configs/kernel-aarch64-debug.config:CONFIG_NET_PKTGEN=m
    configs/kernel-aarch64.config:CONFIG_NET_PKTGEN=m
    configs/kernel-ppc64le-debug.config:CONFIG_NET_PKTGEN=m
    configs/kernel-ppc64le.config:CONFIG_NET_PKTGEN=m
    configs/kernel-s390x-debug.config:CONFIG_NET_PKTGEN=m
    configs/kernel-s390x-zfcpdump.config:# CONFIG_NET_PKTGEN is not set
    configs/kernel-s390x.config:CONFIG_NET_PKTGEN=m
    configs/kernel-x86_64-debug.config:CONFIG_NET_PKTGEN=m
    configs/kernel-x86_64.config:CONFIG_NET_PKTGEN=m

The module itself is called `pktgen` and is used to generate network packets for testing:

<https://www.kernelconfig.io/CONFIG_NET_PKTGEN?q=CONFIG_NET_PKTGEN&kernelversion=5.15.183&arch=x86>

    This module will inject preconfigured packets, at a configurable
    rate, out of a given interface. It is used for network interface
    stress testing and performance analysis.


# Solution

Mainline fix in 425e64440ad0a2f03bdaf04be0ae53dededbaa77. Applies to `ciqlts8_6` without modifications.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-2025-38061 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_6-CVE-2025-38061

    ninja: Entering directory `/data/build/rocky-patching'
    [0/1] Check ABI of kernel [ciqlts8_6-CVE-2025-38061]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2025-38061/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2025-38061/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20956028/boot-test.log>)


# Kselftests: passed relative


## Coverage

All the network-related tests except the unstable ones.

`net/forwarding` (except `mirror_gre_bridge_1d_vlan.sh`, `sch_ets.sh`, `sch_tbf_prio.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_tbf_root.sh`, `tc_actions.sh`, `sch_tbf_ets.sh`, `ipip_hier_gre_keys.sh`), `net/mptcp` (except `simult_flows.sh`), `net` (except `udpgso_bench.sh`, `reuseaddr_conflict`, `ip_defrag.sh`, `reuseport_addr_any.sh`, `gro.sh`, `xfrm_policy.sh`, `txtimestamp.sh`, `udpgro_fwd.sh`), `netfilter` (except `nft_trans_stress.sh`)


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/20956027/kselftests--ciqlts8_6--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/20956026/kselftests--ciqlts8_6--run2.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2025-38061&#x2013;run1.log](<https://github.com/user-attachments/files/20956025/kselftests--ciqlts8_6-CVE-2025-38061--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2025-38061&#x2013;run2.log](<https://github.com/user-attachments/files/20956024/kselftests--ciqlts8_6-CVE-2025-38061--run2.log>)


## Comparison

The reference and patch kernel results are the same

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6--run2.log
    Status2   kselftests--ciqlts8_6-CVE-2025-38061--run1.log
    Status3   kselftests--ciqlts8_6-CVE-2025-38061--run2.log


# Specific tests: skipped

