### PR TITLE
[LTS 9.2] net: pktgen: fix access outside of user given buffer in pktgen_thread…

### DIFF
--- a/net/core/pktgen.c
+++ b/net/core/pktgen.c
@@ -1766,8 +1766,8 @@ static ssize_t pktgen_thread_write(struct file *file,
 	i = len;
 
 	/* Read variable name */
-
-	len = strn_len(&user_buffer[i], sizeof(name) - 1);
+	max = min(sizeof(name) - 1, count - i);
+	len = strn_len(&user_buffer[i], max);
 	if (len < 0)
 		return len;
 
@@ -1797,7 +1797,8 @@ static ssize_t pktgen_thread_write(struct file *file,
 	if (!strcmp(name, "add_device")) {
 		char f[32];
 		memset(f, 0, 32);
-		len = strn_len(&user_buffer[i], sizeof(f) - 1);
+		max = min(sizeof(f) - 1, count - i);
+		len = strn_len(&user_buffer[i], max);
 		if (len < 0) {
 			ret = len;
 			goto out;


### PR DESCRIPTION
[LTS 9.2]
CVE-2025-38061
VULN-70912


# Problem

<https://lore.kernel.org/linux-cve-announce/2025061835-CVE-2025-38061-caa2@gregkh/T/#u>

    In the Linux kernel, the following vulnerability has been resolved:
    
    net: pktgen: fix access outside of user given buffer in pktgen_thread_write()
    
    Honour the user given buffer size for the strn_len() calls (otherwise
    strn_len() will access memory outside of the user given buffer).
    
    The Linux kernel CVE team has assigned CVE-2025-38061 to this issue.


# Applicability: yes (similar as in <https://github.com/ctrliq/kernel-src-tree/pull/376>)

See <https://github.com/ctrliq/kernel-src-tree/blob/759deb250beef9c96ce49b37a757b4d62180afd2/net/core/pktgen.c#L1770> and <https://github.com/ctrliq/kernel-src-tree/blob/759deb250beef9c96ce49b37a757b4d62180afd2/net/core/pktgen.c#L1800> The `count` argument is ignored in the `strn_len()` calculation.

The `CONFIG_NET_PKTGEN` option enabling the affected file `net/core/pktgen.c` is `m` for most configuration variants:

    $ grep CONFIG_NET_PKTGEN configs/kernel*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-aarch64-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-ppc64le-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-s390x-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-s390x-zfcpdump-rhel.config:# CONFIG_NET_PKTGEN is not set
    configs/kernel-x86_64-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-x86_64-rhel.config:CONFIG_NET_PKTGEN=m

The module itself is called `pktgen` and is used to generate network packets for testing:

<https://www.kernelconfig.io/CONFIG_NET_PKTGEN?q=CONFIG_NET_PKTGEN&kernelversion=5.15.183&arch=x86>

    This module will inject preconfigured packets, at a configurable
    rate, out of a given interface. It is used for network interface
    stress testing and performance analysis.


# Solution (same as in <https://github.com/ctrliq/kernel-src-tree/pull/376>)

Mainline fix in 425e64440ad0a2f03bdaf04be0ae53dededbaa77. Applies to `ciqlts9_2` without modifications.


# kABI check: passed

    DEBUG=1 CVE=CVE-2025-38061 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_2-CVE-2025-38061

    ninja: Entering directory `/data/build/rocky-patching'
    [0/1] Check ABI of kernel [ciqlts9_2-CVE-2025-38061]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2025-38061/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2025-38061/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20956253/boot-test.log>)

    [root@ciqlts-9-2 pvts]# modprobe pktgen
    [   30.093561] pktgen: Packet Generator for packet performance testing. Version: 2.75


# Kselftests: passed relative


## Coverage

All the network-related tests except the unstable ones.

`net/forwarding` (except `sch_tbf_ets.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_ets.sh`, `mirror_gre_bridge_1d_vlan.sh`, `dual_vxlan_bridge.sh`, `ipip_hier_gre_keys.sh`, `sch_tbf_prio.sh`, `vxlan_bridge_1d_ipv6.sh`, `sch_red.sh`, `q_in_vni.sh`, `sch_tbf_root.sh`, `tc_actions.sh`, `tc_police.sh`), `net/mptcp` (except `simult_flows.sh`, `userspace_pm.sh`), `net` (except `reuseaddr_conflict`, `udpgro_fwd.sh`, `udpgso_bench.sh`, `ip_defrag.sh`, `gro.sh`, `xfrm_policy.sh`, `txtimestamp.sh`, `fib_nexthops.sh`, `reuseport_addr_any.sh`), `netfilter` (except `nft_trans_stress.sh`)


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/20956252/kselftests--ciqlts9_2--run1.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/20956251/kselftests--ciqlts9_2--run2.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-2025-38061&#x2013;run1.log](<https://github.com/user-attachments/files/20956250/kselftests--ciqlts9_2-CVE-2025-38061--run1.log>)


## Comparison

The reference and patch kernel results are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2--run2.log
    Status2   kselftests--ciqlts9_2-CVE-2025-38061--run1.log


# Specific tests: skipped

