### PR TITLE
net: pktgen: fix access outside of user given buffer in pktgen_thread…

### DIFF
--- a/net/core/pktgen.c
+++ b/net/core/pktgen.c
@@ -1766,8 +1766,8 @@ static ssize_t pktgen_thread_write(struct file *file,
 	i = len;
 
 	/* Read variable name */
-
-	len = strn_len(&user_buffer[i], sizeof(name) - 1);
+	max = min(sizeof(name) - 1, count - i);
+	len = strn_len(&user_buffer[i], max);
 	if (len < 0)
 		return len;
 
@@ -1797,7 +1797,8 @@ static ssize_t pktgen_thread_write(struct file *file,
 	if (!strcmp(name, "add_device")) {
 		char f[32];
 		memset(f, 0, 32);
-		len = strn_len(&user_buffer[i], sizeof(f) - 1);
+		max = min(sizeof(f) - 1, count - i);
+		len = strn_len(&user_buffer[i], max);
 		if (len < 0) {
 			ret = len;
 			goto out;


### PR DESCRIPTION
[LTS 9.4]
CVE-2025-38061
VULN-70913


# Problem

<https://lore.kernel.org/linux-cve-announce/2025061835-CVE-2025-38061-caa2@gregkh/T/#u>

    In the Linux kernel, the following vulnerability has been resolved:
    
    net: pktgen: fix access outside of user given buffer in pktgen_thread_write()
    
    Honour the user given buffer size for the strn_len() calls (otherwise
    strn_len() will access memory outside of the user given buffer).
    
    The Linux kernel CVE team has assigned CVE-2025-38061 to this issue.


# Applicability: yes (similar as in <https://github.com/ctrliq/kernel-src-tree/pull/376>)

See <https://github.com/ctrliq/kernel-src-tree/blob/8a6224aa3a481c6bd9428d2656476ea7f2110285/net/core/pktgen.c#L1770> and <https://github.com/ctrliq/kernel-src-tree/blob/8a6224aa3a481c6bd9428d2656476ea7f2110285/net/core/pktgen.c#L1800> 
The `count` argument is ignored in the `strn_len()` calculation.

The `CONFIG_NET_PKTGEN` option enabling the affected file `net/core/pktgen.c` is `m` for most configuration variants:

    $ grep CONFIG_NET_PKTGEN configs/kernel*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-aarch64-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-aarch64-rt-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-aarch64-rt-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-ppc64le-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-s390x-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-s390x-zfcpdump-rhel.config:# CONFIG_NET_PKTGEN is not set
    configs/kernel-x86_64-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-x86_64-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-x86_64-rt-debug-rhel.config:CONFIG_NET_PKTGEN=m
    configs/kernel-x86_64-rt-rhel.config:CONFIG_NET_PKTGEN=m

The module itself is called `pktgen` and is used to generate network packets for testing:

<https://www.kernelconfig.io/CONFIG_NET_PKTGEN?q=CONFIG_NET_PKTGEN&kernelversion=5.15.183&arch=x86>

    This module will inject preconfigured packets, at a configurable
    rate, out of a given interface. It is used for network interface
    stress testing and performance analysis.


# Solution (same as in <https://github.com/ctrliq/kernel-src-tree/pull/376>)

Mainline fix in 425e64440ad0a2f03bdaf04be0ae53dededbaa77. Applies to `ciqlts9_4` without modifications.


# kABI check: passed

    DEBUG=1 CVE=CVE-2025-38061 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_4-CVE-2025-38061

    [1/2] Check ABI of kernel [ciqlts9_4-CVE-2025-38061]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-2025-38061/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-2025-38061/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/20970039/boot-test.log>)


# Kselftests: passed relative


## Coverage

All the network-related tests except the unstable ones.

`net/forwarding` (except `tc_actions.sh`, `vxlan_bridge_1d_ipv6.sh`, `ipip_hier_gre_keys.sh`, `router_bridge_1d_lag.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_red.sh`, `dual_vxlan_bridge.sh`, `tc_police.sh`, `sch_tbf_ets.sh`, `sch_tbf_prio.sh`, `q_in_vni.sh`, `mirror_gre_bridge_1d_vlan.sh`, `sch_ets.sh`, `router_bridge_lag.sh`, `sch_tbf_root.sh`, `ip6gre_inner_v6_multipath.sh`), `net/hsr`, `net/mptcp` (except `userspace_pm.sh`, `simult_flows.sh`), `net` (except `srv6_end_flavors_test.sh`, `fib_nexthops.sh`, `xfrm_policy.sh`, `txtimestamp.sh`, `srv6_end_dt46_l3vpn_test.sh`, `reuseaddr_conflict`, `reuseport_addr_any.sh`, `gro.sh`, `ip_defrag.sh`, `srv6_end_dt4_l3vpn_test.sh`, `udpgro_fwd.sh`, `srv6_end_dt6_l3vpn_test.sh`, `udpgso_bench.sh`), `netfilter` (except `nft_trans_stress.sh`)


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/20970038/kselftests--ciqlts9_4--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-2025-38061&#x2013;run1.log](<https://github.com/user-attachments/files/20970036/kselftests--ciqlts9_4-CVE-2025-38061--run1.log>)


## Comparison

The reference and patch kernel results are the same.

    /home/pvts/gtd/projects/conclusive/ciq/rocky-patching/./ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4-CVE-2025-38061--run1.log


# Specific tests: skipped

