### PR TITLE
[LTS 8.6] selftests: reuseaddr_conflict: add missing new line at the end of the output

### DIFF
--- a/tools/testing/selftests/net/reuseaddr_conflict.c
+++ b/tools/testing/selftests/net/reuseaddr_conflict.c
@@ -109,6 +109,6 @@ int main(void)
 	fd1 = open_port(0, 1);
 	if (fd1 >= 0)
 		error(1, 0, "Was allowed to create an ipv4 reuseport on an already bound non-reuseport socket with no ipv6");
-	fprintf(stderr, "Success");
+	fprintf(stderr, "Success\n");
 	return 0;
 }


### PR DESCRIPTION
[LTS 8.6]


# About

This commit fixes bad formatting for the `net:reuseaddr_conflict` test, which prevents automated tools from extracting the test's status.

Before:

    TAP version 13
    1..1
    # selftests: net: reuseaddr_conflict
    # Opening 127.0.0.1:9999
    # Opening INADDR_ANY:9999
    # bind: Address already in use
    # Opening in6addr_any:9999
    # Opening INADDR_ANY:9999
    # bind: Address already in use
    # Opening INADDR_ANY:9999 after closing ipv6 socket
    # bind: Address already in use
    # Successok 5 selftests: net: reuseaddr_conflict

After:

    TAP version 13
    1..1
    # selftests: net: reuseaddr_conflict
    # Opening 127.0.0.1:9999
    # Opening INADDR_ANY:9999
    # bind: Address already in use
    # Opening in6addr_any:9999
    # Opening INADDR_ANY:9999
    # bind: Address already in use
    # Opening INADDR_ANY:9999 after closing ipv6 socket
    # bind: Address already in use
    # Success
    ok 1 selftests: net: reuseaddr_conflict

That it's a proper place for the newline (and not in some script executing the `reuseaddr_conflict` binary, for example) see similar tests from the same collection, eg:

<https://github.com/ctrliq/kernel-src-tree/blob/499f93ab350df5f7b6ba75c9e6002e086ec53038/tools/testing/selftests/net/reuseport_addr_any.c#L270-L278>

<https://github.com/ctrliq/kernel-src-tree/blob/499f93ab350df5f7b6ba75c9e6002e086ec53038/tools/testing/selftests/net/reuseport_bpf.c#L639-L640>


# PS

Turned out there is already a 31974122cfdeaf56abc18d8ab740d580d9833e90 fix in the mainline targeting exactly this issue. Switched to that commit's cherry-pick instead of the manual change.

