### PR TITLE
[LTS 8.8] selftests: reuseaddr_conflict: add missing new line at the end of the…

### DIFF
--- a/tools/testing/selftests/net/reuseaddr_conflict.c
+++ b/tools/testing/selftests/net/reuseaddr_conflict.c
@@ -109,6 +109,6 @@ int main(void)
 	fd1 = open_port(0, 1);
 	if (fd1 >= 0)
 		error(1, 0, "Was allowed to create an ipv4 reuseport on an already bound non-reuseport socket with no ipv6");
-	fprintf(stderr, "Success");
+	fprintf(stderr, "Success\n");
 	return 0;
 }


### PR DESCRIPTION
[LTS 8.8]

Same situation as in <https://github.com/ctrliq/kernel-src-tree/pull/385> (the affected file's `tools/testing/selftests/net/reuseaddr_conflict.c` history is identical).

