### PR TITLE
[LTS 9.2] udmabuf: fix a buf size overflow issue during udmabuf creation

### DIFF
--- a/drivers/dma-buf/udmabuf.c
+++ b/drivers/dma-buf/udmabuf.c
@@ -186,7 +186,7 @@ static long udmabuf_create(struct miscdevice *device,
 	if (!ubuf)
 		return -ENOMEM;
 
-	pglimit = (size_limit_mb * 1024 * 1024) >> PAGE_SHIFT;
+	pglimit = ((u64)size_limit_mb * 1024 * 1024) >> PAGE_SHIFT;
 	for (i = 0; i < head->count; i++) {
 		if (!IS_ALIGNED(list[i].offset, PAGE_SIZE))
 			goto err;


### PR DESCRIPTION
[LTS 9.2]
CVE-2025-37803
VULN-67673


# Problem

<https://nvd.nist.gov/vuln/detail/CVE-2025-37803>

    udmabuf: fix a buf size overflow issue during udmabuf creation
    
    by casting size_limit_mb to u64  when calculate pglimit.


# Background

The problem applies to the `udmabuf` module which provides a mechanism for user-space applications to allocate and manage DMA (Direct Memory Access) buffers. The module has two parameters adjustable from the user space:

    $ ls -lh /sys/module/udmabuf/parameters/

    -rw-r--r--. 1 root root 4.0K Jul  1 19:24 list_limit
    -rw-r--r--. 1 root root 4.0K Jul  1 19:24 size_limit_mb

Their meaning: 

    # modinfo udmabuf

    name:           udmabuf
    filename:       (builtin)
    license:        GPL v2
    file:           drivers/dma-buf/udmabuf
    author:         Gerd Hoffmann <kraxel@redhat.com>
    parm:           list_limit:udmabuf_create_list->count limit. Default is 1024. (int)
    parm:           size_limit_mb:Max size of a dmabuf, in megabytes. Default is 64. (int)

The overflow mentioned in 021ba7f1babd029e714d13a6bf2571b08af96d0f's message occurs during the conversion of `size_limit_mb` into the number of pages upon the allocation of a new DMA buffer.

`drivers/dma-buf/udmabuf.c`:

    pglimit = (size_limit_mb * 1024 * 1024) >> PAGE_SHIFT;


# Applicability: yes

The `udmabuf` module is enabled with `y` in all configuration variants for LTS 9.2:

    $ grep CONFIG_UDMABUF configs/kernel*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-aarch64-64k-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-aarch64-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-aarch64-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-ppc64le-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-s390x-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-s390x-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-x86_64-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-x86_64-rhel.config:CONFIG_UDMABUF=y

The conversion found in <https://github.com/ctrliq/kernel-src-tree/blob/fe9c582022efd196f6e49e821679d509910b159c/drivers/dma-buf/udmabuf.c#L189> doesn't contain the `u64` cast mentioned in the CVE.


# Solution

Mainline fix contained in 021ba7f1babd029e714d13a6bf2571b08af96d0f. Applies to `ciqlts9_2` without any issues.


# kABI check: passed

    DEBUG=1 CVE=CVE-2025-37803 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_2-CVE-2025-37803

    ninja: Entering directory `/data/build/rocky-patching'
    [0/1] Check ABI of kernel [ciqlts9_2-CVE-2025-37803]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2025-37803/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2025-37803/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21006630/boot-test.log>)


# Kselftests


## Module: passed

A selftest exists in LTS 9.2 testing the `udmabuf` module directly: `drivers/dma-buf:udmabuf`. It was run several times on a reference and patched kernel


### Reference

[kselftest-udmabuf&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/21006629/kselftest-udmabuf--ciqlts9_2--run1.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/21006628/kselftest-udmabuf--ciqlts9_2--run2.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2&#x2013;run3.log](<https://github.com/user-attachments/files/21006626/kselftest-udmabuf--ciqlts9_2--run3.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2&#x2013;run4.log](<https://github.com/user-attachments/files/21006625/kselftest-udmabuf--ciqlts9_2--run4.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2&#x2013;run5.log](<https://github.com/user-attachments/files/21006624/kselftest-udmabuf--ciqlts9_2--run5.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2&#x2013;run6.log](<https://github.com/user-attachments/files/21006623/kselftest-udmabuf--ciqlts9_2--run6.log>)


### Patch

[kselftest-udmabuf&#x2013;ciqlts9\_2-CVE-2025-37803&#x2013;run1.log](<https://github.com/user-attachments/files/21006622/kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run1.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2-CVE-2025-37803&#x2013;run2.log](<https://github.com/user-attachments/files/21006621/kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run2.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2-CVE-2025-37803&#x2013;run3.log](<https://github.com/user-attachments/files/21006620/kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run3.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2-CVE-2025-37803&#x2013;run4.log](<https://github.com/user-attachments/files/21006619/kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run4.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2-CVE-2025-37803&#x2013;run5.log](<https://github.com/user-attachments/files/21006618/kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run5.log>)
[kselftest-udmabuf&#x2013;ciqlts9\_2-CVE-2025-37803&#x2013;run6.log](<https://github.com/user-attachments/files/21006617/kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run6.log>)


### Comparison

The test passes consistently in both reference and patched kernel.

    $ ktests.xsh diff  kselftest-udmabuf*.log

    Column    File
    --------  -----------------------------------------------------
    Status0   kselftest-udmabuf--ciqlts9_2--run1.log
    Status1   kselftest-udmabuf--ciqlts9_2--run2.log
    Status2   kselftest-udmabuf--ciqlts9_2--run3.log
    Status3   kselftest-udmabuf--ciqlts9_2--run4.log
    Status4   kselftest-udmabuf--ciqlts9_2--run5.log
    Status5   kselftest-udmabuf--ciqlts9_2--run6.log
    Status6   kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run1.log
    Status7   kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run2.log
    Status8   kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run3.log
    Status9   kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run4.log
    Status10  kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run5.log
    Status11  kselftest-udmabuf--ciqlts9_2-CVE-2025-37803--run6.log
    
    TestCase                 Status0  Status1  Status2  Status3  Status4  Status5  Status6  Status7  Status8  Status9  Status10  Status11  Summary
    drivers/dma-buf:udmabuf  pass     pass     pass     pass     pass     pass     pass     pass     pass     pass     pass      pass      same


## General: passed relative


### Coverage

All available tests except unstable ones.

`bpf` (except `test_progs`, `test_kmod.sh`, `test_sockmap`, `test_progs-no_alu32`, `test_xsk.sh`), `breakpoints` (except `step_after_suspend_test`), `capabilities`, `cgroup` (except `test_freezer`, `test_memcontrol`), `clone3`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding`, `drivers/net/team`, `filesystems/binderfs`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `ir`, `kcmp`, `kexec`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net/forwarding` (except `mirror_gre_vlan_bridge_1q.sh`, `tc_actions.sh`, `q_in_vni.sh`, `sch_tbf_root.sh`, `mirror_gre_bridge_1d_vlan.sh`, `dual_vxlan_bridge.sh`, `sch_tbf_prio.sh`, `vxlan_bridge_1d_ipv6.sh`, `sch_ets.sh`, `gre_inner_v6_multipath.sh`, `tc_police.sh`, `sch_red.sh`, `sch_tbf_ets.sh`, `ipip_hier_gre_keys.sh`), `net/mptcp` (except `userspace_pm.sh`, `simult_flows.sh`, `mptcp_join.sh`), `net` (except `txtimestamp.sh`, `xfrm_policy.sh`, `udpgso_bench.sh`, `udpgro_fwd.sh`, `gro.sh`, `reuseport_addr_any.sh`, `ip_defrag.sh`, `fib_nexthops.sh`, `reuseaddr_conflict`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `openat2`, `pid_namespace`, `pidfd`, `proc` (except `proc-uptime-001`, `proc-pid-vm`), `pstore`, `ptrace`, `rlimits`, `rseq`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `syscall_user_dispatch`, `tc-testing`, `tdx`, `timens`, `timers` (except `raw_skew`), `tmpfs`, `tpm2`, `vDSO`, `vm`, `x86`, `zram`


### Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/21006616/kselftests--ciqlts9_2--run1.log>)


### Patch

[kselftests&#x2013;ciqlts9\_2-CVE-2025-37803&#x2013;run1.log](<https://github.com/user-attachments/files/21006615/kselftests--ciqlts9_2-CVE-2025-37803--run1.log>)


### Comparison

The test results in reference and patch are the same

    $ ktests.xsh diff -d  kselftests--*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2-CVE-2025-37803--run1.log


# Commentary and the specific tests


## Commentary

The bug is not a vulnerability, or at least not in the sense that's implied in the CVE, which is [classified by NIST](https://nvd.nist.gov/vuln/detail/CVE-2025-37803) as "CWE-120 	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')". 

The `pglimit` variable during the calculation of which the overflow may occur is local to the `udmabuf_create` function and is used in exactly two places

1.  Value assignment
    <https://github.com/ctrliq/kernel-src-tree/blob/fe9c582022efd196f6e49e821679d509910b159c/drivers/dma-buf/udmabuf.c#L189>
2.  Value read
    <https://github.com/ctrliq/kernel-src-tree/blob/fe9c582022efd196f6e49e821679d509910b159c/drivers/dma-buf/udmabuf.c#L196-L197>

The variable serves as a limit on the DMA buffer's number of pages, imposed by the system administrator, like

    # echo 128 > /sys/module/udmabuf/parameters/size_limit_mb

For the system with the `PAGE_SIZE` of 4096 (`PAGE_SHIFT` = 12), this translates through

    pglimit = (size_limit_mb * 1024 * 1024) >> PAGE_SHIFT;

to `pglimit = 128 * 1024 * 1024 / 4096 = 32768` pages.

The overflow in the calculation of `pglimit` is indistinguishable from the case of the administrator setting the "overflown" value directly. Assuming the module handles the limiting logic correctly the bug therefore cannot have any influence on the module's memory safety - **there is no buffer overflow occuring**. (If this assumption is wrong then the module has a bigger problem which the 021ba7f1babd029e714d13a6bf2571b08af96d0f commit doesn't fix anyway).

Moreover, the overflow, if occurs, always results in the `pglimit` value being no greater than intended. This can be proved by considering the only two possible scenarios for the overflow of `size_limit_mb * 1024 * 1024` expression:

-   **The most significant bit of `size_limit_mb * 1024 * 1024` is `0`:** The "classic" overflow of a positive integer `x` resulting in a truncated value `x' = x mod 2ᴺ`, further reduced by dividing by `PAGE_SIZE` (for `N` = number of bits in int)
-   **The most significant bit of `size_limit_mb * 1024 * 1024` is `1`:** the "negative" overflow, with the original positive integer `x` becoming `x' - 2ᴺ < 0`, where `x' = x mod 2ᴺ`. Right-shifting such value increases it, but keeps it negative, by the virtue of right shift preserving the most significant bit of the int.


## Bug reproduction

Bug reproduction is especially easy given that the selftest `drivers/dma-buf:udmabuf` (<https://github.com/ctrliq/kernel-src-tree/blob/ciqlts9_2/tools/testing/selftests/drivers/dma-buf/udmabuf.c>) is alsso a nice example of the basic usage of the `udmabuf` module, so there is no need to write any specific testing POCs. The `drivers/dma-buf:udmabuf` test tries to allocate a DMA buffer of the size of 4 pages <https://github.com/ctrliq/kernel-src-tree/blob/fe9c582022efd196f6e49e821679d509910b159c/tools/testing/selftests/drivers/dma-buf/udmabuf.c#L16>

Using `size_limit_mb = 1`:

    [root@ciqlts-9-2 pvts]# echo 1 > /sys/module/udmabuf/parameters/size_limit_mb

which translates on the testing machine to 256 pages, the test works fine, since 4 < 256:

    [root@ciqlts-9-2 pvts]# …/tools/testing/selftests/drivers/dma-buf/udmabuf
    drivers/dma-buf/udmabuf: ok

After setting the MB limit to 0 the test fails:

    [root@ciqlts-9-2 pvts]# echo 0 > /sys/module/udmabuf/parameters/size_limit_mb
    [root@ciqlts-9-2 pvts]# …/tools/testing/selftests/drivers/dma-buf/udmabuf
    drivers/dma-buf/udmabuf: [FAIL,test-4]

at the `ioctl` call where the limit is checked: <https://github.com/ctrliq/kernel-src-tree/blob/fe9c582022efd196f6e49e821679d509910b159c/tools/testing/selftests/drivers/dma-buf/udmabuf.c#L88-L96>

An int overflow resulting in `pglimit = 0` can be achieved with `size_limit_mb * 1024 * 1024 = 2³²`, for the int size of 32, which solved for `size_limit_mb` gives `size_limit_mb = 4096`:

    [root@ciqlts-9-2 pvts]# echo 4096 > /sys/module/udmabuf/parameters/size_limit_mb
    [root@ciqlts-9-2 pvts]# …/tools/testing/selftests/drivers/dma-buf/udmabuf
    drivers/dma-buf/udmabuf: [FAIL,test-4]

Setting it to `4096 + 1` makes the test working again

    [root@ciqlts-9-2 pvts]# echo 4097 > /sys/module/udmabuf/parameters/size_limit_mb
    [root@ciqlts-9-2 pvts]# tools/testing/selftests/drivers/dma-buf/udmabuf
    drivers/dma-buf/udmabuf: ok

This is equivalent to setting `size_limit_mb` to `1` as in the beginning.


## Specific patch test: passed

Repeating the condition for `pglimit` overflow on the patched kernel results in the selftest working fine:

    [root@ciqlts-9-2 pvts]# echo 4096 > /sys/module/udmabuf/parameters/size_limit_mb
    [root@ciqlts-9-2 pvts]# …/tools/testing/selftests/drivers/dma-buf/udmabuf
    drivers/dma-buf/udmabuf: ok

