### PR TITLE
[LTS 9.4] udmabuf: fix a buf size overflow issue during udmabuf creation

### DIFF
--- a/drivers/dma-buf/udmabuf.c
+++ b/drivers/dma-buf/udmabuf.c
@@ -212,7 +212,7 @@ static long udmabuf_create(struct miscdevice *device,
 	if (!ubuf)
 		return -ENOMEM;
 
-	pglimit = (size_limit_mb * 1024 * 1024) >> PAGE_SHIFT;
+	pglimit = ((u64)size_limit_mb * 1024 * 1024) >> PAGE_SHIFT;
 	for (i = 0; i < head->count; i++) {
 		if (!IS_ALIGNED(list[i].offset, PAGE_SIZE))
 			goto err;


### PR DESCRIPTION
[LTS 9.4]
CVE-2025-37803
VULN-67674


# Problem

<https://nvd.nist.gov/vuln/detail/CVE-2025-37803>

    udmabuf: fix a buf size overflow issue during udmabuf creation
    
    by casting size_limit_mb to u64  when calculate pglimit.


# Background

See "Background" section in <https://github.com/ctrliq/kernel-src-tree/pull/389>.


# Applicability: yes

The `udmabuf` module is enabled with `y` in all configuration variants for LTS 9.4:

    $ grep CONFIG_UDMABUF configs/kernel*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-aarch64-64k-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-aarch64-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-aarch64-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-aarch64-rt-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-aarch64-rt-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-ppc64le-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-s390x-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-s390x-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-x86_64-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-x86_64-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-x86_64-rt-debug-rhel.config:CONFIG_UDMABUF=y
    configs/kernel-x86_64-rt-rhel.config:CONFIG_UDMABUF=y

The conversion found in <https://github.com/ctrliq/kernel-src-tree/blob/fe9c582022efd196f6e49e821679d509910b159c/drivers/dma-buf/udmabuf.c#L189> doesn't contain the `u64` cast mentioned in the CVE.


# Solution

Mainline fix contained in 021ba7f1babd029e714d13a6bf2571b08af96d0f. Applies to `ciqlts9_4` without any issues.


# kABI check: passed

    DEBUG=1 CVE=CVE-2025-37803 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_4-CVE-2025-37803

    ninja: Entering directory `/data/build/rocky-patching'
    [0/1] Check ABI of kernel [ciqlts9_4-CVE-2025-37803]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-2025-37803/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-2025-37803/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21008883/boot-test.log>)


# Kselftests: passed


## Coverage

A selftest exists in LTS 9.4 testing the `udmabuf` module directly: `drivers/dma-buf:udmabuf`. It was run several times on a reference and patched kernel.


## Reference

[kselftests-udmabuf&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/21008882/kselftests-udmabuf--ciqlts9_4--run1.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4&#x2013;run2.log](<https://github.com/user-attachments/files/21008881/kselftests-udmabuf--ciqlts9_4--run2.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4&#x2013;run3.log](<https://github.com/user-attachments/files/21008880/kselftests-udmabuf--ciqlts9_4--run3.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4&#x2013;run4.log](<https://github.com/user-attachments/files/21008879/kselftests-udmabuf--ciqlts9_4--run4.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4&#x2013;run5.log](<https://github.com/user-attachments/files/21008878/kselftests-udmabuf--ciqlts9_4--run5.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4&#x2013;run6.log](<https://github.com/user-attachments/files/21008877/kselftests-udmabuf--ciqlts9_4--run6.log>)


## Patch

[kselftests-udmabuf&#x2013;ciqlts9\_4-CVE-2025-37803&#x2013;run1.log](<https://github.com/user-attachments/files/21008876/kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run1.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4-CVE-2025-37803&#x2013;run2.log](<https://github.com/user-attachments/files/21008875/kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run2.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4-CVE-2025-37803&#x2013;run3.log](<https://github.com/user-attachments/files/21008874/kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run3.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4-CVE-2025-37803&#x2013;run4.log](<https://github.com/user-attachments/files/21008873/kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run4.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4-CVE-2025-37803&#x2013;run5.log](<https://github.com/user-attachments/files/21008872/kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run5.log>)
[kselftests-udmabuf&#x2013;ciqlts9\_4-CVE-2025-37803&#x2013;run6.log](<https://github.com/user-attachments/files/21008871/kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run6.log>)


## Comparison

The test results in reference and patch are the same, and all are passing.

    $ ktests.xsh diff  kselftests-udmabuf*.log

    Column    File
    --------  ------------------------------------------------------
    Status0   kselftests-udmabuf--ciqlts9_4--run1.log
    Status1   kselftests-udmabuf--ciqlts9_4--run2.log
    Status2   kselftests-udmabuf--ciqlts9_4--run3.log
    Status3   kselftests-udmabuf--ciqlts9_4--run4.log
    Status4   kselftests-udmabuf--ciqlts9_4--run5.log
    Status5   kselftests-udmabuf--ciqlts9_4--run6.log
    Status6   kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run1.log
    Status7   kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run2.log
    Status8   kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run3.log
    Status9   kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run4.log
    Status10  kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run5.log
    Status11  kselftests-udmabuf--ciqlts9_4-CVE-2025-37803--run6.log
    
    TestCase                 Status0  Status1  Status2  Status3  Status4  Status5  Status6  Status7  Status8  Status9  Status10  Status11  Summary
    drivers/dma-buf:udmabuf  pass     pass     pass     pass     pass     pass     pass     pass     pass     pass     pass      pass      same


# Specific tests: passed

For the explanation of the meaning of the below tests see "Commentary and the specific tests" section of <https://github.com/ctrliq/kernel-src-tree/pull/389>.


## Reference

An overflow occurs for `size_limit_mb = 4096`

    [root@ciqlts-9-4 pvts]# echo 4096 > /sys/module/udmabuf/parameters/size_limit_mb
    [root@ciqlts-9-4 pvts]# /mnt/build_files/kernel-src-tree-kselftests-ciqlts9_4/tools/testing/selftests/drivers/dma-buf/udmabuf
    drivers/dma-buf/udmabuf: [FAIL,test-4]


## Patch

No overflow is observed for the same size limit:

    [root@ciqlts-9-4 pvts]# echo 4096 > /sys/module/udmabuf/parameters/size_limit_mb
    [root@ciqlts-9-4 pvts]# /mnt/build_files/kernel-src-tree-kselftests-ciqlts9_4/tools/testing/selftests/drivers/dma-buf/udmabuf
    drivers/dma-buf/udmabuf: ok

