### PR TITLE
[SIG-CLOUD-8] Rebase custom chages to 4.18.0-553.58.1.el8_10

### DIFF
--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1041,6 +1041,10 @@ static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 
 		c->x86_virt_bits = (eax >> 8) & 0xff;
 		c->x86_phys_bits = eax & 0xff;
+
+		/* Provide a sane default if not enumerated: */
+		if (!c->x86_clflush_size)
+			c->x86_clflush_size = 32;
 	}
 
 	c->x86_cache_bits = c->x86_phys_bits;

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1020,18 +1020,9 @@ void get_cpu_cap(struct cpuinfo_x86 *c)
 static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 {
 	u32 eax, ebx, ecx, edx;
-	bool vp_bits_from_cpuid = true;
 
 	if (!cpu_has(c, X86_FEATURE_CPUID) ||
-	    (c->extended_cpuid_level < 0x80000008))
-		vp_bits_from_cpuid = false;
-
-	if (vp_bits_from_cpuid) {
-		cpuid(0x80000008, &eax, &ebx, &ecx, &edx);
-
-		c->x86_virt_bits = (eax >> 8) & 0xff;
-		c->x86_phys_bits = eax & 0xff;
-	} else {
+	    (c->extended_cpuid_level < 0x80000008)) {
 		if (IS_ENABLED(CONFIG_X86_64)) {
 			c->x86_clflush_size = 64;
 			c->x86_phys_bits = 36;
@@ -1045,7 +1036,13 @@ static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 			    cpu_has(c, X86_FEATURE_PSE36))
 				c->x86_phys_bits = 36;
 		}
+	} else {
+		cpuid(0x80000008, &eax, &ebx, &ecx, &edx);
+
+		c->x86_virt_bits = (eax >> 8) & 0xff;
+		c->x86_phys_bits = eax & 0xff;
 	}
+
 	c->x86_cache_bits = c->x86_phys_bits;
 	c->x86_cache_alignment = c->x86_clflush_size;
 }

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1020,17 +1020,32 @@ void get_cpu_cap(struct cpuinfo_x86 *c)
 static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 {
 	u32 eax, ebx, ecx, edx;
+	bool vp_bits_from_cpuid = true;
 
-	if (c->extended_cpuid_level >= 0x80000008) {
+	if (!cpu_has(c, X86_FEATURE_CPUID) ||
+	    (c->extended_cpuid_level < 0x80000008))
+		vp_bits_from_cpuid = false;
+
+	if (vp_bits_from_cpuid) {
 		cpuid(0x80000008, &eax, &ebx, &ecx, &edx);
 
 		c->x86_virt_bits = (eax >> 8) & 0xff;
 		c->x86_phys_bits = eax & 0xff;
+	} else {
+		if (IS_ENABLED(CONFIG_X86_64)) {
+			c->x86_clflush_size = 64;
+			c->x86_phys_bits = 36;
+			c->x86_virt_bits = 48;
+		} else {
+			c->x86_clflush_size = 32;
+			c->x86_virt_bits = 32;
+			c->x86_phys_bits = 32;
+
+			if (cpu_has(c, X86_FEATURE_PAE) ||
+			    cpu_has(c, X86_FEATURE_PSE36))
+				c->x86_phys_bits = 36;
+		}
 	}
-#ifdef CONFIG_X86_32
-	else if (cpu_has(c, X86_FEATURE_PAE) || cpu_has(c, X86_FEATURE_PSE36))
-		c->x86_phys_bits = 36;
-#endif
 	c->x86_cache_bits = c->x86_phys_bits;
 }
 
@@ -1468,15 +1483,6 @@ static void __init cpu_parse_early_param(void)
  */
 static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 {
-#ifdef CONFIG_X86_64
-	c->x86_clflush_size = 64;
-	c->x86_phys_bits = 36;
-	c->x86_virt_bits = 48;
-#else
-	c->x86_clflush_size = 32;
-	c->x86_phys_bits = 32;
-	c->x86_virt_bits = 32;
-#endif
 	c->x86_cache_alignment = c->x86_clflush_size;
 
 	memset(&c->x86_capability, 0, sizeof(c->x86_capability));
@@ -1488,7 +1494,6 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 		get_cpu_vendor(c);
 		get_cpu_cap(c);
 		get_model_name(c); /* RHEL8: get model name for unsupported check */
-		get_cpu_address_sizes(c);
 		setup_force_cpu_cap(X86_FEATURE_CPUID);
 		cpu_parse_early_param();
 
@@ -1504,6 +1509,8 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 		identify_cpu_without_cpuid(c);
 		setup_clear_cpu_cap(X86_FEATURE_CPUID);
 	}
+
+	get_cpu_address_sizes(c);
 
 	setup_force_cpu_cap(X86_FEATURE_ALWAYS);
 

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1494,6 +1494,7 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 		get_cpu_cap(c);
 		get_model_name(c); /* RHEL8: get model name for unsupported check */
 		setup_force_cpu_cap(X86_FEATURE_CPUID);
+		get_cpu_address_sizes(c);
 		cpu_parse_early_param();
 
 		if (this_cpu->c_early_init)
@@ -1507,9 +1508,8 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 	} else {
 		identify_cpu_without_cpuid(c);
 		setup_clear_cpu_cap(X86_FEATURE_CPUID);
+		get_cpu_address_sizes(c);
 	}
-
-	get_cpu_address_sizes(c);
 
 	setup_force_cpu_cap(X86_FEATURE_ALWAYS);
 

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1047,6 +1047,7 @@ static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 		}
 	}
 	c->x86_cache_bits = c->x86_phys_bits;
+	c->x86_cache_alignment = c->x86_clflush_size;
 }
 
 static void identify_cpu_without_cpuid(struct cpuinfo_x86 *c)
@@ -1483,8 +1484,6 @@ static void __init cpu_parse_early_param(void)
  */
 static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 {
-	c->x86_cache_alignment = c->x86_clflush_size;
-
 	memset(&c->x86_capability, 0, sizeof(c->x86_capability));
 	c->extended_cpuid_level = 0;
 


### PR DESCRIPTION
## Update process (This kernel CentOS base for `4.18.0-553`)
* Kernel History Rebuild Process for all `src.rpm`s hosted by RESF
* Create `sig-cloud-8/4.18.0-553.53.1.el8_10` branch
* Check if any maintained code is included in the new `el` release.
* Cherry-pick all code from previous branch into new branch (skipping unneeded code) 
  * Fix conflicts as they arise 
* Build and Test

## Removed Commits 
None

## Rebase Results
```
[jmaple@devbox code]$ cat RR.553.58.log
[rolling release update] Rolling Product:  sig-cloud-8
[rolling release update] Checking out branch:  sig-cloud-8/4.18.0-553.56.1.el8_10
[rolling release update] Gathering all the RESF kernel Tags
b'1ad2baf0efe1 (tag: resf_kernel-4.18.0-553.56.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.56.1.el8_10'
b'6f9106f46020 (tag: resf_kernel-4.18.0-553.54.1.el8_10, origin/rocky8_10_rebuild) Rebuild rocky8_10 with kernel-4.18.0-553.54.1.el8_10'
b'32f87806bbd4 (tag: resf_kernel-4.18.0-553.53.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.53.1.el8_10'
b'e99974a02d4f (tag: resf_kernel-4.18.0-553.52.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.52.1.el8_10'
b'bda8b8ebc7b7 (tag: resf_kernel-4.18.0-553.51.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.51.1.el8_10'
b'32fa0f457b22 (tag: resf_kernel-4.18.0-553.50.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.50.1.el8_10'
b'01aef32f4a9b (tag: resf_kernel-4.18.0-553.47.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.47.1.el8_10'
b'e622eefa811c (tag: resf_kernel-4.18.0-553.46.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.46.1.el8_10'
b'f025379c5d08 (tag: resf_kernel-4.18.0-553.45.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.45.1.el8_10'
b'16dc63866351 (tag: resf_kernel-4.18.0-553.44.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.44.1.el8_10'
b'5b691f92af91 (tag: resf_kernel-4.18.0-553.42.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.42.1.el8_10'
b'0dbf87712115 (tag: resf_kernel-4.18.0-553.40.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.40.1.el8_10'
b'26d9a06a4a5f (tag: resf_kernel-4.18.0-553.37.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.37.1.el8_10'
b'4673f9b8360d (tag: resf_kernel-4.18.0-553.36.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.36.1.el8_10'
b'7e4fb1a14fcd (tag: resf_kernel-4.18.0-553.34.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.34.1.el8_10'
b'72ceaa9ab31e (tag: resf_kernel-4.18.0-553.33.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.33.1.el8_10'
b'0570eb3e10e4 (tag: resf_kernel-4.18.0-553.32.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.32.1.el8_10'
b'657b4d21132b (tag: resf_kernel-4.18.0-553.30.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.30.1.el8_10'
b'c1970aa3f569 (tag: resf_kernel-4.18.0-553.27.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.27.1.el8_10'
b'8bf75aa29fd0 (tag: resf_kernel-4.18.0-553.22.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.22.1.el8_10'
b'ea7f8a5da93b (tag: resf_kernel-4.18.0-553.16.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.16.1.el8_10'
b'2fd9e62e45de (tag: resf_kernel-4.18.0-553.8.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.8.1.el8_10'
b'a2d1b1a06ff8 (tag: resf_kernel-4.18.0-553.5.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.5.1.el8_10'
b'4533b19a3a3e (tag: resf_kernel-4.18.0-553.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.el8_10'
[rolling release update] Old Rolling Branch Tags:  [b'1ad2baf0efe1', b'6f9106f46020', b'32f87806bbd4', b'e99974a02d4f', b'bda8b8ebc7b7', b'32fa0f457b22', b'01aef32f4a9b', b'e622eefa811c', b'f025379c5d08', b'16dc63866351', b'5b691f92af91', b'0dbf87712115', b'26d9a06a4a5f', b'4673f9b8360d', b'7e4fb1a14fcd', b'72ceaa9ab31e', b'0570eb3e10e4', b'657b4d21132b', b'c1970aa3f569', b'8bf75aa29fd0', b'ea7f8a5da93b', b'2fd9e62e45de', b'a2d1b1a06ff8', b'4533b19a3a3e']
[rolling release update] Checking out branch:  rocky8_10
[rolling release update] Gathering all the RESF kernel Tags
b'2e416d167715 (HEAD -> rocky8_10, tag: resf_kernel-4.18.0-553.58.1.el8_10, origin/rocky8_10) Rebuild rocky8_10 with kernel-4.18.0-553.58.1.el8_10'
b'1ad2baf0efe1 (tag: resf_kernel-4.18.0-553.56.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.56.1.el8_10'
b'6f9106f46020 (tag: resf_kernel-4.18.0-553.54.1.el8_10, origin/rocky8_10_rebuild) Rebuild rocky8_10 with kernel-4.18.0-553.54.1.el8_10'
b'32f87806bbd4 (tag: resf_kernel-4.18.0-553.53.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.53.1.el8_10'
b'e99974a02d4f (tag: resf_kernel-4.18.0-553.52.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.52.1.el8_10'
b'bda8b8ebc7b7 (tag: resf_kernel-4.18.0-553.51.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.51.1.el8_10'
b'32fa0f457b22 (tag: resf_kernel-4.18.0-553.50.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.50.1.el8_10'
b'01aef32f4a9b (tag: resf_kernel-4.18.0-553.47.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.47.1.el8_10'
b'e622eefa811c (tag: resf_kernel-4.18.0-553.46.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.46.1.el8_10'
b'f025379c5d08 (tag: resf_kernel-4.18.0-553.45.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.45.1.el8_10'
b'16dc63866351 (tag: resf_kernel-4.18.0-553.44.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.44.1.el8_10'
b'5b691f92af91 (tag: resf_kernel-4.18.0-553.42.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.42.1.el8_10'
b'0dbf87712115 (tag: resf_kernel-4.18.0-553.40.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.40.1.el8_10'
b'26d9a06a4a5f (tag: resf_kernel-4.18.0-553.37.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.37.1.el8_10'
b'4673f9b8360d (tag: resf_kernel-4.18.0-553.36.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.36.1.el8_10'
b'7e4fb1a14fcd (tag: resf_kernel-4.18.0-553.34.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.34.1.el8_10'
b'72ceaa9ab31e (tag: resf_kernel-4.18.0-553.33.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.33.1.el8_10'
b'0570eb3e10e4 (tag: resf_kernel-4.18.0-553.32.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.32.1.el8_10'
b'657b4d21132b (tag: resf_kernel-4.18.0-553.30.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.30.1.el8_10'
b'c1970aa3f569 (tag: resf_kernel-4.18.0-553.27.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.27.1.el8_10'
b'8bf75aa29fd0 (tag: resf_kernel-4.18.0-553.22.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.22.1.el8_10'
b'ea7f8a5da93b (tag: resf_kernel-4.18.0-553.16.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.16.1.el8_10'
b'2fd9e62e45de (tag: resf_kernel-4.18.0-553.8.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.8.1.el8_10'
b'a2d1b1a06ff8 (tag: resf_kernel-4.18.0-553.5.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.5.1.el8_10'
b'4533b19a3a3e (tag: resf_kernel-4.18.0-553.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.el8_10'
[rolling release update] New Base Branch Tags:  [b'2e416d167715', b'1ad2baf0efe1', b'6f9106f46020', b'32f87806bbd4', b'e99974a02d4f', b'bda8b8ebc7b7', b'32fa0f457b22', b'01aef32f4a9b', b'e622eefa811c', b'f025379c5d08', b'16dc63866351', b'5b691f92af91', b'0dbf87712115', b'26d9a06a4a5f', b'4673f9b8360d', b'7e4fb1a14fcd', b'72ceaa9ab31e', b'0570eb3e10e4', b'657b4d21132b', b'c1970aa3f569', b'8bf75aa29fd0', b'ea7f8a5da93b', b'2fd9e62e45de', b'a2d1b1a06ff8', b'4533b19a3a3e']
[rolling release update] Latest RESF tag sha:  b'1ad2baf0efe1'
"1ad2baf0efe157120b3448abdfcf48736e86508f Rebuild rocky8_10 with kernel-4.18.0-553.56.1.el8_10"
[rolling release update] Checking out old rolling branch:  sig-cloud-8/4.18.0-553.56.1.el8_10
[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD
[rolling release update] Last RESF tag sha:  b'1ad2baf0efe1'
[rolling release update] Total Commit in old branch:  5
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
{
  "f7f119891ca898b58e12aa1202d21b2e8285aa50": "2a38e4ca302280fdcce370ba2bee79bac16c4587",
  "753cc5542703ccb7fcba4e491aecdd015b6a1ab6": "95bfb35269b2e85cff0dd2c957b2d42ebf95ae5f",
  "dbcaa7baf4515a446e2ed719a50a74826ae71439": "9a458198eba98b7207669a166e64d04b04cb651b",
  "44ad6a811ca31e95f14428749053727e4247ddc5": "3e32552652917f10c0aa8ac75cdc8f0b8d257dec",
  "c4f121f8c1589d8d92ba1c6e35ebe7805a977cb0": "fbf6449f84bf5e4ad09f2c09ee70ed7d629b5ff6"
}
[rolling release update] Checking out new base branch:  rocky8_10
[rolling release update] Finding the kernel version for the new rolling release
b'2e416d167715 (HEAD -> rocky8_10, tag: resf_kernel-4.18.0-553.58.1.el8_10, origin/rocky8_10) Rebuild rocky8_10 with kernel-4.18.0-553.58.1.el8_10'
<re.Match object; span=(0, 72), match=b'2e416d167715 (HEAD -> rocky8_10, tag: resf_kerne>
[rolling release update} New Branch to create  sig-cloud-8/4.18.0-553.58.1.el8_10
[rolling release update] Check if branch Exists:  sig-cloud-8/4.18.0-553.58.1.el8_10
Branch sig-cloud-8/4.18.0-553.58.1.el8_10 does not exists creating
[rolling release update] Creating new branch for PR:  jmaple_sig-cloud-8/4.18.0-553.58.1.el8_10
[rolling release update] Creating Map of all new commits from last rolling release fork
[rolling release update] Total Commit in new branch:  53
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
Printing first 5 and last 5 commits
{
  "2e416d1677153d818b7930066693f5b696873dc5": "",
  "77874c7fe949cc2451ff3d6861afc0c7e28c12bb": "628e6d18930bbd21f2d4562228afe27694f66da9",
  "59ff24e84dbb012b0a84503ab4f63f60690d2b43": "3c8ffcd248da34fc41e52a46e51505900115fc2a",
  "c92854d6d2e3d5c3a7612a9aae3a6b50151e7473": "482ad2a4ace2740ca0ff1cbc8f3c7f862f3ab507",
  "6510a3de91eb02c80245f9d3cee74738d6053fc3": "2034d90ae41ae93e30d492ebcf1f06f97a9cfba6"
}
{
  "25900119ca9642f3e3cc1c1f2782ea0f5a32a7b2": "bcb5d6c769039c8358a2359e7c3ea5d97ce93108",
  "d8d6896b7a4f5d1cf87103363f812fcfd19c487d": "0d48566d4b58946c8e1b0baac0347616060a81c9",
  "6bd016b86f50a58099e001af182fa8e5a4f9ff41": "12c30f33cc6769bf411088a2872843c4f9ea32f9",
  "949da0e7e5ea93e8187af71c5371bec30df802a8": "3d6cc9898efdfb062efb74dc18cfc700e082f5d5",
  "2b92079db1888ed6b5fb2d0af08da86f993afcc6": "4a74da044ec9ec8679e6beccc4306b936b62873f"
}
[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch
[rolling release update] Removing commits from the new branch
[rolling release update] Applying the remaining commits to the new branch
Applying commit  "c4f121f8c1589d8d92ba1c6e35ebe7805a977cb0 x86/sev-es: Set x86_virt_bits to the correct value straight away, instead of a two-phase approach"
Applying commit  "44ad6a811ca31e95f14428749053727e4247ddc5 x86/boot: Move x86_cache_alignment initialization to correct spot"
Applying commit  "dbcaa7baf4515a446e2ed719a50a74826ae71439 x86/cpu: Allow reducing x86_phys_bits during early_identify_cpu()"
Applying commit  "753cc5542703ccb7fcba4e491aecdd015b6a1ab6 x86/cpu: Get rid of an unnecessary local variable in get_cpu_address_sizes()"
Applying commit  "f7f119891ca898b58e12aa1202d21b2e8285aa50 x86/cpu: Provide default cache line size if not enumerated"
```

## Build
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" kbuild.SCN8.resf_kernel-4.18.0-553.58.1.el8_10.log
/mnt/code/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_sig-cloud-8_4.18.0-553.58.1.el8_10-7e20e9e9cbf5"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1913s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-jmaple_sig-cloud-8_4.18.0-553.58.1.el8_10-7e20e9e9cbf5+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-jmaple_sig-cloud-8_4.18.0-553.58.1.el8_10-7e20e9e9cbf5+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 20s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-jmaple_sig-cloud-8_4.18.0-553.58.1.el8_10-7e20e9e9cbf5+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1913s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 20s
[TIMER]{TOTAL} 1950s
Rebooting in 10 seconds
```

## KSelfTest
```
[jmaple@devbox code]$ ls kselftest.4.18.0-jmaple_sig-cloud-8_4.18.0-553.56.1.el8_10-f7f119891ca8+.log kselftest.SCN8.4.18.0-jmaple_sig-cloud-8_4.18.0-553.58.1.el8_10-7e20e9e9cbf5+.log | while read line; do echo $line; grep '^ok ' $line | wc -l; done
kselftest.4.18.0-jmaple_sig-cloud-8_4.18.0-553.56.1.el8_10-f7f119891ca8+.log
206
kselftest.SCN8.4.18.0-jmaple_sig-cloud-8_4.18.0-553.58.1.el8_10-7e20e9e9cbf5+.log
206
```