### PR TITLE
[ciqlts9_4] sunrpc: handle SVC_GARBAGE during svc auth processing as auth error

### DIFF
--- a/net/sunrpc/svc.c
+++ b/net/sunrpc/svc.c
@@ -1343,7 +1343,8 @@ svc_process_common(struct svc_rqst *rqstp)
 	case SVC_OK:
 		break;
 	case SVC_GARBAGE:
-		goto err_garbage_args;
+		rqstp->rq_auth_stat = rpc_autherr_badcred;
+		goto err_bad_auth;
 	case SVC_SYSERR:
 		goto err_system_err;
 	case SVC_DENIED:
@@ -1476,13 +1477,6 @@ err_bad_proc:
 
 	serv->sv_stats->rpcbadfmt++;
 	*rqstp->rq_accept_statp = rpc_proc_unavail;
-	goto sendit;
-
-err_garbage_args:
-	svc_printk(rqstp, "failed to decode RPC header\n");
-
-	serv->sv_stats->rpcbadfmt++;
-	*rqstp->rq_accept_statp = rpc_garbage_args;
 	goto sendit;
 
 err_system_err:


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message

```
jira VULN-71607
cve CVE-2025-38089
commit-author Jeff Layton <jlayton@kernel.org>
commit 94d10a4dba0bc482f2b01e39f06d5513d0f75742
upstream-diff A merge conflict was caused because the following
    commit doesn't exit in our tree:
    ab42f4d9a26f ("sunrpc: don't change ->sv_stats if it doesn't exist")

tianshuo han reported a remotely-triggerable crash if the client sends a kernel RPC server a specially crafted packet. If decoding the RPC reply fails in such a way that SVC_GARBAGE is returned without setting the rq_accept_statp pointer, then that pointer can be dereferenced and a value stored there.

If it's the first time the thread has processed an RPC, then that pointer will be set to NULL and the kernel will crash. In other cases, it could create a memory scribble.

The server sunrpc code treats a SVC_GARBAGE return from svc_authenticate or pg_authenticate as if it should send a GARBAGE_ARGS reply. RFC 5531 says that if authentication fails that the RPC should be rejected instead with a status of AUTH_ERR.

Handle a SVC_GARBAGE return as an AUTH_ERROR, with a reason of AUTH_BADCRED instead of returning GARBAGE_ARGS in that case. This sidesteps the whole problem of touching the rpc_accept_statp pointer in this situation and avoids the crash.

	Cc: stable@kernel.org
Fixes: 29cd2927fb91 ("SUNRPC: Fix encoding of accepted but unsuccessful RPC replies")
	Reported-by: tianshuo han <hantianshuo233@gmail.com>
	Reviewed-by: Chuck Lever <chuck.lever@oracle.com>
	Signed-off-by: Jeff Layton <jlayton@kernel.org>
	Signed-off-by: Chuck Lever <chuck.lever@oracle.com>
(cherry picked from commit 94d10a4dba0bc482f2b01e39f06d5513d0f75742)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>
```

### Kernel build logs

```
/mnt/scratch/kernel-src-tree
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/kvm
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/tools
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr/include
  CLEAN   usr
  CLEAN   vmlinux.symvers modules-only.symvers modules.builtin modules.builtin.modinfo
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 9s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-spatel_ciqlts9_4-9e63bed61646"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  
  <--snip-->
  
    STRIP   /lib/modules/5.14.0-spatel_ciqlts9_4-9e63bed61646+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-spatel_ciqlts9_4-9e63bed61646+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-spatel_ciqlts9_4-9e63bed61646+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-spatel_ciqlts9_4-9e63bed61646+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-spatel_ciqlts9_4-9e63bed61646+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-spatel_ciqlts9_4-9e63bed61646+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-spatel_ciqlts9_4-9e63bed61646+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-spatel_ciqlts9_4-9e63bed61646+/kernel/sound/usb/snd-usb-audio.ko
  DEPMOD  /lib/modules/5.14.0-spatel_ciqlts9_4-9e63bed61646+
[TIMER]{MODULES}: 9s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-spatel_ciqlts9_4-9e63bed61646+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 22s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-spatel_ciqlts9_4-9e63bed61646+ and Index to 2
The default is /boot/loader/entries/216206ccc95d48aa9c1f435aaa394c07-5.14.0-spatel_ciqlts9_4-9e63bed61646+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-spatel_ciqlts9_4-9e63bed61646+
The default is /boot/loader/entries/216206ccc95d48aa9c1f435aaa394c07-5.14.0-spatel_ciqlts9_4-9e63bed61646+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-spatel_ciqlts9_4-9e63bed61646+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 9s
[TIMER]{BUILD}: 1414s
[TIMER]{MODULES}: 9s
[TIMER]{INSTALL}: 22s
[TIMER]{TOTAL} 1462s
Rebooting in 10 seconds
```
 
[kernel-build.log](https://github.com/user-attachments/files/21103238/kernel-build.log)

### Kselftests

```
shreeya@spatel-dev-bom:~/ciq$  grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
340
341
shreeya@spatel-dev-bom:~/ciq$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
75
74
```
[kselftest-before.log](https://github.com/user-attachments/files/21103263/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21103267/kselftest-after.log)
  