### PR TITLE
[CBR 7.9] CVE-2023-1281

### DIFF
--- a/include/linux/rcupdate.h
+++ b/include/linux/rcupdate.h
@@ -970,6 +970,24 @@ static inline notrace void rcu_read_unlock_sched_notrace(void)
 	__rcu_assign_pointer((p), (v), __rcu)
 
 /**
+ * rcu_replace_pointer() - replace an RCU pointer, returning its old value
+ * @rcu_ptr: RCU pointer, whose old value is returned
+ * @ptr: regular pointer
+ * @c: the lockdep conditions under which the dereference will take place
+ *
+ * Perform a replacement, where @rcu_ptr is an RCU-annotated
+ * pointer and @c is the lockdep argument that is passed to the
+ * rcu_dereference_protected() call used to read that pointer.  The old
+ * value of @rcu_ptr is returned, and @rcu_ptr is set to @ptr.
+ */
+#define rcu_replace_pointer(rcu_ptr, ptr, c)				\
+({									\
+	typeof(ptr) __tmp = rcu_dereference_protected((rcu_ptr), (c));	\
+	rcu_assign_pointer((rcu_ptr), (ptr));				\
+	__tmp;								\
+})
+
+/**
  * RCU_INIT_POINTER() - initialize an RCU protected pointer
  *
  * Initialize an RCU-protected pointer in special cases where readers

--- a/net/sched/cls_tcindex.c
+++ b/net/sched/cls_tcindex.c
@@ -482,7 +482,7 @@ tcindex_set_parms(struct net *net, struct tcf_proto *tp, unsigned long base,
 		/* lookup the filter, guaranteed to exist */
 		for (cf = rcu_dereference_bh_rtnl(*fp); cf;
 		     fp = &cf->next, cf = rcu_dereference_bh_rtnl(*fp))
-			if (cf->key == handle)
+			if (cf->key == (u16)handle)
 				break;
 
 		f->next = cf->next;

--- a/net/sched/cls_tcindex.c
+++ b/net/sched/cls_tcindex.c
@@ -10,6 +10,7 @@
 #include <linux/skbuff.h>
 #include <linux/errno.h>
 #include <linux/slab.h>
+#include <linux/rcupdate.h>
 #include <net/act_api.h>
 #include <net/netlink.h>
 #include <net/pkt_cls.h>
@@ -313,6 +314,7 @@ tcindex_set_parms(struct net *net, struct tcf_proto *tp, unsigned long base,
 	struct tcindex_filter *f = NULL; /* make gcc behave */
 	int err, balloc = 0;
 	struct tcf_exts e;
+	bool update_h = false;
 
 	err = tcf_exts_init(&e, TCA_TCINDEX_ACT, TCA_TCINDEX_POLICE);
 	if (err < 0)
@@ -427,10 +429,13 @@ tcindex_set_parms(struct net *net, struct tcf_proto *tp, unsigned long base,
 		}
 	}
 
-	if (cp->perfect)
+	if (cp->perfect) {
 		r = cp->perfect + handle;
-	else
-		r = tcindex_lookup(cp, handle) ? : &new_filter_result;
+	} else {
+		/* imperfect area is updated in-place using rcu */
+		update_h = !!tcindex_lookup(cp, handle);
+		r = &new_filter_result;
+	}
 
 	if (r == &new_filter_result) {
 		f = kzalloc(sizeof(*f), GFP_KERNEL);
@@ -464,7 +469,28 @@ tcindex_set_parms(struct net *net, struct tcf_proto *tp, unsigned long base,
 
 	rcu_assign_pointer(tp->root, cp);
 
-	if (r == &new_filter_result) {
+	if (update_h) {
+		struct tcindex_filter __rcu **fp;
+		struct tcindex_filter *cf;
+
+		f->result.res = r->res;
+		tcf_exts_change(&f->result.exts, &r->exts);
+
+		/* imperfect area bucket */
+		fp = cp->h + (handle % cp->hash);
+
+		/* lookup the filter, guaranteed to exist */
+		for (cf = rcu_dereference_bh_rtnl(*fp); cf;
+		     fp = &cf->next, cf = rcu_dereference_bh_rtnl(*fp))
+			if (cf->key == handle)
+				break;
+
+		f->next = cf->next;
+
+		cf = rcu_replace_pointer(*fp, f, 1);
+		tcf_exts_get_net(&cf->result.exts);
+		tcf_queue_work(&cf->rwork, tcindex_destroy_fexts_work);
+	} else if (r == &new_filter_result) {
 		struct tcindex_filter *nfp;
 		struct tcindex_filter __rcu **fp;
 


### PR DESCRIPTION
[CBR 7.9]
CVE-2023-1281
VULN-7633


# Problem

<https://nvd.nist.gov/vuln/detail/CVE-2023-1281>
> Use After Free vulnerability in Linux kernel traffic control index filter (tcindex) allows Privilege Escalation. The imperfect hash area can be updated while packets are traversing, which will cause a use-after-free when 'tcf\_exts\_exec()' is called with the destroyed tcf\_ext. A local attacker user can use this vulnerability to elevate its privileges to root. This issue affects Linux Kernel: from 4.14 before git commit ee059170b1f7e94e55fa6cadee544e176a6e59c2.


# Applicability: yes

The `CONFIG_NET_CLS_TCINDEX` option including the affected file `net/sched/cls_tcindex.c` in the build is enabled in `configs/kernel-3.10.0-x86_64.config` <https://github.com/ctrliq/kernel-src-tree/blob/ba92bd2dff3dad032e1968b7d950965ad3350ca5/configs/kernel-3.10.0-x86_64.config#L1360>

The `tcindex_set_parms` function clearly doesn't contain the rcu-related code from the fix ee059170b1f7e94e55fa6cadee544e176a6e59c2:

<https://github.com/ctrliq/kernel-src-tree/blob/ba92bd2dff3dad032e1968b7d950965ad3350ca5/net/sched/cls_tcindex.c#L430-L433>

<https://github.com/ctrliq/kernel-src-tree/blob/ba92bd2dff3dad032e1968b7d950965ad3350ca5/net/sched/cls_tcindex.c#L467-L481>


# Solution

The mainline fix ee059170b1f7e94e55fa6cadee544e176a6e59c2 makes use of `rcu_replace_pointer` macro from the Read-Copy-Update synchronization system, file `include/linux/rcupdate.h`, which is missing from CBR 7.9. It was introduced in a63fc6b75cca984c71f095282e0227a390ba88f3 and backported as part of this patch.

The ee059170b1f7e94e55fa6cadee544e176a6e59c2 fix was also imperfect and a fix-of-the fix appeared in 42018a322bd453e38b3ffee294982243e50a484f. It was also included as part of this patch.

The solution therefore consists of backported 3 mainline commits:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Hash</th>
<th scope="col" class="org-left">Description</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">a63fc6b75cca984c71f095282e0227a390ba88f3</td>
<td class="org-left">RCU system prerequisite</td>
</tr>


<tr>
<td class="org-left">ee059170b1f7e94e55fa6cadee544e176a6e59c2</td>
<td class="org-left">The fix proper</td>
</tr>


<tr>
<td class="org-left">42018a322bd453e38b3ffee294982243e50a484f</td>
<td class="org-left">The follow-up of the fix</td>
</tr>
</tbody>
</table>

No differences relative to the mainline changes are present in the backports.


# kABI check: passed

    python /mnt/code/kernel-dist-git-el-7.9/SOURCES/check-kabi -k /mnt/code/kernel-dist-git-el-7.9/SOURCES/Module.kabi_x86_64 -s /mnt/build_files/kernel-src-tree-ciqcbr7_9-CVE-2023-1281/Module.symvers
    echo $? 

    0


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21130097/boot-test.log>)


# Kselftests


## Reference

[kselftests&#x2013;ciqcbr7\_9&#x2013;run1.log](<https://github.com/user-attachments/files/21130093/kselftests--ciqcbr7_9--run1.log>)
[kselftests&#x2013;ciqcbr7\_9&#x2013;run2.log](<https://github.com/user-attachments/files/21130091/kselftests--ciqcbr7_9--run2.log>)
[kselftests&#x2013;ciqcbr7\_9&#x2013;run3.log](<https://github.com/user-attachments/files/21130089/kselftests--ciqcbr7_9--run3.log>)


## Patch

[kselftests&#x2013;ciqcbr7\_9-CVE-2023-1281&#x2013;run1.log](<https://github.com/user-attachments/files/21130087/kselftests--ciqcbr7_9-CVE-2023-1281--run1.log>)
[kselftests&#x2013;ciqcbr7\_9-CVE-2023-1281&#x2013;run2.log](<https://github.com/user-attachments/files/21130084/kselftests--ciqcbr7_9-CVE-2023-1281--run2.log>)
[kselftests&#x2013;ciqcbr7\_9-CVE-2023-1281&#x2013;run3.log](<https://github.com/user-attachments/files/21130077/kselftests--ciqcbr7_9-CVE-2023-1281--run3.log>)


# Specific tests: passed

Given lack of nearly any selftests for networking in CBR 7.9 some tests relating specifically to the `tcindex` module were carried out. They do not precisely capture the bug, therefore there is no "before and after" comparison with a clearly visible improvemnt; rather a sanity check of the module was done on the patched kernel to prove the proper working of its basic functionality.

The test consists of setting up a dsmark qdisc using some tcindex filters, then generating some traffic with `iperf3` and thus confirming that the kernel didn't crash and the network remained functional. The setup is taken from <https://lartc.org/lartc.html>. (An attempt was made to modify the setup in a controlled manner such that the proper working of `tcindex` filter could be shown but it failed due to nearly no documentation of `tcindex` available (the tcindex(8) manpage is a joke) and similar lack of examples on the internet of this obscure feature.)

1.  Reference bandwidth between the hypervisor and the virtual host measurement. The IPs are `192.168.122.1` for the hypervisor and `192.168.122.224` for the virtual host.
    
    1.  Virtual machine:
        
            [root@ciqcbr-7-9 pvts]# iperf3 -s
        
            -----------------------------------------------------------
            Server listening on 5201
            -----------------------------------------------------------
            Accepted connection from 192.168.122.1, port 43228
            [  5] local 192.168.122.224 port 5201 connected to 192.168.122.1 port 43244
            [ ID] Interval           Transfer     Bandwidth
            [  5]   0.00-1.00   sec  4.14 GBytes  35.6 Gbits/sec                  
            [  5]   1.00-2.00   sec  4.39 GBytes  37.7 Gbits/sec                  
            [  5]   2.00-3.00   sec  4.32 GBytes  37.1 Gbits/sec                  
            [  5]   3.00-4.00   sec  4.37 GBytes  37.6 Gbits/sec                  
            [  5]   4.00-5.00   sec  4.38 GBytes  37.6 Gbits/sec                  
            [  5]   5.00-6.00   sec  4.39 GBytes  37.7 Gbits/sec                  
            [  5]   6.00-7.00   sec  4.40 GBytes  37.8 Gbits/sec                  
            [  5]   7.00-8.00   sec  4.41 GBytes  37.9 Gbits/sec                  
            [  5]   8.00-9.00   sec  4.45 GBytes  38.2 Gbits/sec                  
            [  5]   9.00-10.00  sec  4.45 GBytes  38.2 Gbits/sec                  
            [  5]  10.00-10.03  sec   140 MBytes  37.1 Gbits/sec                  
            - - - - - - - - - - - - - - - - - - - - - - - - -
            [ ID] Interval           Transfer     Bandwidth
            [  5]   0.00-10.03  sec  0.00 Bytes  0.00 bits/sec                  sender
            [  5]   0.00-10.03  sec  43.8 GBytes  37.5 Gbits/sec                  receiver
            -----------------------------------------------------------
            Server listening on 5201
            -----------------------------------------------------------
    2.  Hypervisor
        
            $ iperf3 -c 192.168.122.224
        
            [  5] local 192.168.122.1 port 43244 connected to 192.168.122.224 port 5201
            [ ID] Interval           Transfer     Bitrate         Retr  Cwnd
            [  5]   0.00-1.00   sec  4.29 GBytes  36.8 Gbits/sec    0   2.71 MBytes       
            [  5]   1.00-2.00   sec  4.39 GBytes  37.7 Gbits/sec    0   2.71 MBytes       
            [  5]   2.00-3.00   sec  4.32 GBytes  37.1 Gbits/sec    0   2.71 MBytes       
            [  5]   3.00-4.00   sec  4.37 GBytes  37.6 Gbits/sec    0   2.71 MBytes       
            [  5]   4.00-5.00   sec  4.38 GBytes  37.6 Gbits/sec    0   2.71 MBytes       
            [  5]   5.00-6.00   sec  4.39 GBytes  37.7 Gbits/sec    0   2.71 MBytes       
            [  5]   6.00-7.00   sec  4.39 GBytes  37.7 Gbits/sec    0   3.09 MBytes       
            [  5]   7.00-8.00   sec  4.41 GBytes  37.9 Gbits/sec    0   3.09 MBytes       
            [  5]   8.00-9.00   sec  4.45 GBytes  38.2 Gbits/sec    0   3.09 MBytes       
            [  5]   9.00-10.00  sec  4.45 GBytes  38.2 Gbits/sec    0   3.09 MBytes       
            - - - - - - - - - - - - - - - - - - - - - - - - -
            [ ID] Interval           Transfer     Bitrate         Retr
            [  5]   0.00-10.00  sec  43.8 GBytes  37.7 Gbits/sec    0             sender
            [  5]   0.00-10.00  sec  43.8 GBytes  37.7 Gbits/sec                  receiver
            
            iperf Done.
    
    The bandwidth is huge, which is to be expected given that there is no actual physical link involved.
2.  `tc` setup
    
        [root@ciqcbr-7-9 pvts]# tc qdisc add dev eth0 handle 1:0 root dsmark indices 64 set_tc_index
        [root@ciqcbr-7-9 pvts]# tc filter add dev eth0 parent 1:0 protocol ip prio 1 tcindex mask 0xfc shift 2
        [root@ciqcbr-7-9 pvts]# tc qdisc add dev eth0 parent 1:0 handle 2:0 cbq bandwidth 10Mbit cell 8 avpkt 1000 mpu 64
        [root@ciqcbr-7-9 pvts]# tc class add dev eth0 parent 2:0 classid 2:1 cbq bandwidth 10Mbit rate 1500Kbit avpkt 1000 prio 1 bounded isolated allot 1514 weight 1 maxburst 10
        [root@ciqcbr-7-9 pvts]# tc qdisc add dev eth0 parent 2:1 pfifo limit 5
        [root@ciqcbr-7-9 pvts]# tc filter add dev eth0 parent 2:0 protocol ip prio 1 handle 0x2e tcindex classid 2:1 pass_on
3.  Display the classes statistics for control
    
        [root@ciqcbr-7-9 pvts]# tc -s class show dev eth0 
        class cbq 2: root rate 10Mbit (bounded,isolated) prio no-transmit
         Sent 256 bytes 2 pkt (dropped 0, overlimits 0 requeues 0) 
         backlog 0b 0p requeues 0 
          borrowed 0 overactions 0 avgidle 12500 undertime 0
        class cbq 2:1 parent 2: leaf 8001: rate 1500Kbit (bounded,isolated) prio 1
         Sent 0 bytes 0 pkt (dropped 0, overlimits 0 requeues 0) 
         backlog 0b 0p requeues 0 
          borrowed 0 overactions 0 avgidle 846984 undertime 0
4.  Run `iperf3` again
    
        $ iperf3 -c  192.168.122.224
        Connecting to host 192.168.122.224, port 5201
        [  5] local 192.168.122.1 port 56614 connected to 192.168.122.224 port 5201
        [ ID] Interval           Transfer     Bitrate         Retr  Cwnd
        [  5]   0.00-1.00   sec  4.41 GBytes  37.9 Gbits/sec    0   1.44 MBytes       
        [  5]   1.00-2.00   sec  4.54 GBytes  39.0 Gbits/sec    0   3.08 MBytes       
        [  5]   2.00-3.00   sec  4.40 GBytes  37.8 Gbits/sec    0   3.08 MBytes       
        [  5]   3.00-4.00   sec  4.33 GBytes  37.2 Gbits/sec    0   3.08 MBytes       
        [  5]   4.00-5.00   sec  4.36 GBytes  37.5 Gbits/sec    0   3.08 MBytes       
        [  5]   5.00-6.00   sec  4.36 GBytes  37.5 Gbits/sec    0   3.08 MBytes       
        [  5]   6.00-7.00   sec  4.36 GBytes  37.5 Gbits/sec    0   3.08 MBytes       
        [  5]   7.00-8.00   sec  4.36 GBytes  37.5 Gbits/sec    0   3.08 MBytes       
        [  5]   8.00-9.00   sec  4.35 GBytes  37.3 Gbits/sec    0   3.08 MBytes       
        [  5]   9.00-10.00  sec  4.36 GBytes  37.5 Gbits/sec    0   3.08 MBytes       
        - - - - - - - - - - - - - - - - - - - - - - - - -
        [ ID] Interval           Transfer     Bitrate         Retr
        [  5]   0.00-10.00  sec  43.8 GBytes  37.7 Gbits/sec    0             sender
        [  5]   0.00-10.00  sec  43.8 GBytes  37.6 Gbits/sec                  receiver
        
        iperf Done.
    
    The network is functional.
5.  Display the classes statistics on the VM again
    
        [root@ciqcbr-7-9 pvts]# tc -s class show dev eth0 
        class cbq 2: root rate 10Mbit (bounded,isolated) prio no-transmit
         Sent 12317427 bytes 186622 pkt (dropped 0, overlimits 0 requeues 0) 
         backlog 0b 0p requeues 0 
          borrowed 0 overactions 0 avgidle 12500 undertime 0
        class cbq 2:1 parent 2: leaf 8001: rate 1500Kbit (bounded,isolated) prio 1
         Sent 0 bytes 0 pkt (dropped 0, overlimits 0 requeues 0) 
         backlog 0b 0p requeues 0 
          borrowed 0 overactions 0 avgidle 846984 undertime 0
    
    All traffic was handled by the cbq class `2:`.

