### PR TITLE
sunrpc: handle SVC_GARBAGE during svc auth processing as auth error

### DIFF
--- a/net/sunrpc/svc.c
+++ b/net/sunrpc/svc.c
@@ -1287,7 +1287,8 @@ svc_process_common(struct svc_rqst *rqstp, struct kvec *argv, struct kvec *resv)
 	case SVC_OK:
 		break;
 	case SVC_GARBAGE:
-		goto err_garbage;
+		rqstp->rq_auth_stat = rpc_autherr_badcred;
+		goto err_bad_auth;
 	case SVC_SYSERR:
 		rpc_stat = rpc_system_err;
 		goto err_bad;
@@ -1416,10 +1417,6 @@ err_bad_proc:
 	svc_putnl(resv, RPC_PROC_UNAVAIL);
 	goto sendit;
 
-err_garbage:
-	svc_printk(rqstp, "failed to decode args\n");
-
-	rpc_stat = rpc_garbage_args;
 err_bad:
 	serv->sv_stats->rpcbadfmt++;
 	svc_putnl(resv, ntohl(rpc_stat));


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-71606
cve CVE-2025-38089
commit-author Jeff Layton <jlayton@kernel.org>
commit 94d10a4dba0bc482f2b01e39f06d5513d0f75742
upstream-diff The following commits cause merge conflicts since they are
    not present in the ciqlts9_2 branch:
    6d037b15e439 ("SUNRPC: Remove the rpc_stat variable in svc_process_common()")
    ab42f4d9a26f ("sunrpc: don't change ->sv_stats if it doesn't exist")
    649a692e0f2b ("SUNRPC: Convert RPC Reply header encoding to use xdr_stream")

tianshuo han reported a remotely-triggerable crash if the client sends a kernel RPC server a specially crafted packet. If decoding the RPC reply fails in such a way that SVC_GARBAGE is returned without setting the rq_accept_statp pointer, then that pointer can be dereferenced and a value stored there.

If it's the first time the thread has processed an RPC, then that pointer will be set to NULL and the kernel will crash. In other cases, it could create a memory scribble.

The server sunrpc code treats a SVC_GARBAGE return from svc_authenticate or pg_authenticate as if it should send a GARBAGE_ARGS reply. RFC 5531 says that if authentication fails that the RPC should be rejected instead with a status of AUTH_ERR.

Handle a SVC_GARBAGE return as an AUTH_ERROR, with a reason of AUTH_BADCRED instead of returning GARBAGE_ARGS in that case. This sidesteps the whole problem of touching the rpc_accept_statp pointer in this situation and avoids the crash.

	Cc: stable@kernel.org
Fixes: 29cd2927fb91 ("SUNRPC: Fix encoding of accepted but unsuccessful RPC replies")
	Reported-by: tianshuo han <hantianshuo233@gmail.com>
	Reviewed-by: Chuck Lever <chuck.lever@oracle.com>
	Signed-off-by: Jeff Layton <jlayton@kernel.org>
	Signed-off-by: Chuck Lever <chuck.lever@oracle.com>
(cherry picked from commit 94d10a4dba0bc482f2b01e39f06d5513d0f75742)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>
```

### Kernel build logs
```
/mnt/scratch/kernel-src-tree
Skipping mrproper (not requested)
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_spatel__ciqlts9_2-9a0c8434ef40"
Making olddefconfig
#
# configuration written to .config
#
Starting Build
  SYNC    include/config/auto.conf.cmd
  UPD     include/config/kernel.release
  DESCEND objtool
  DESCEND bpf/resolve_btfids
  UPD     include/generated/utsrelease.h
  CALL    scripts/atomic/check-atomics.sh
warning: generated include/linux/atomic/atomic-instrumented.h has been modified.
  CALL    scripts/checksyscalls.sh
  CHK     include/generated/compile.h
  CC      init/version.o
  CC      arch/x86/crypto/aesni-intel_glue.o
  AR      init/built-in.a
  CC      kernel/sys.o
  CC      crypto/fips.o
  CC      security/integrity/ima/ima_init.o
  AR      arch/x86/crypto/built-in.a
  CC      crypto/algapi.o
  AR      arch/x86/built-in.a
  AR      security/integrity/ima/built-in.a
  AR      security/integrity/built-in.a
  AR      security/built-in.a
  CC      net/ethtool/ioctl.o
  CC      crypto/dh.o
  CC      crypto/rsa.o
  CC      crypto/rsa_helper.o
  CC      kernel/module.o
  CC      crypto/testmgr.o
  CC      drivers/base/firmware_loader/fallback_table.o
  CC      drivers/base/firmware_loader/main.o
  CC      drivers/base/firmware_loader/fallback.o
  CC [M]  fs/cifs/smbencrypt.o
  AR      net/ethtool/built-in.a
  CC      drivers/base/firmware_loader/sysfs.o
  CC      drivers/base/firmware_loader/sysfs_upload.o
  CC [M]  fs/cifs/cifsencrypt.o
  CC      crypto/hmac.o
  CC      drivers/base/firmware_loader/builtin/main.o
  AR      drivers/base/firmware_loader/builtin/built-in.a
  CC      crypto/xts.o
  CC [M]  drivers/nvme/target/admin-cmd.o
  AR      drivers/base/firmware_loader/built-in.a
  AR      drivers/base/built-in.a
  
  <--snip-->
  
    SIGN    /lib/modules/5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  STRIP   /lib/modules/5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  SIGN    /lib/modules/5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  DEPMOD  /lib/modules/5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+
[TIMER]{MODULES}: 8s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 23s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+ and Index to 0
The default is /boot/loader/entries/2d84c760132f4bab9836f9dd9e3ac547-5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+
The default is /boot/loader/entries/2d84c760132f4bab9836f9dd9e3ac547-5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-_spatel__ciqlts9_2-9a0c8434ef40+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 214s
[TIMER]{MODULES}: 8s
[TIMER]{INSTALL}: 23s
[TIMER]{TOTAL} 250s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21142779/kernel-build.log)

### Kselftests
```
shreeya@spatel-dev-bom:~/ciq$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
297
297
shreeya@spatel-dev-bom:~/ciq$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
69
69
```

[kselftest-before.log](https://github.com/user-attachments/files/21142815/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21142818/kselftest-after.log)

