### PR TITLE
[SIG-CLOUD-9] rebase custom changes to 5.14.0-570.25.1.el9

### DIFF
--- a/drivers/net/ethernet/microsoft/mana/mana_en.c
+++ b/drivers/net/ethernet/microsoft/mana/mana_en.c
@@ -920,7 +920,7 @@ static void mana_pf_deregister_filter(struct mana_port_context *apc)
 
 static int mana_query_device_cfg(struct mana_context *ac, u32 proto_major_ver,
 				 u32 proto_minor_ver, u32 proto_micro_ver,
-				 u16 *max_num_vports)
+				 u16 *max_num_vports, u8 *bm_hostmode)
 {
 	struct gdma_context *gc = ac->gdma_dev->gdma_context;
 	struct mana_query_device_cfg_resp resp = {};
@@ -931,7 +931,7 @@ static int mana_query_device_cfg(struct mana_context *ac, u32 proto_major_ver,
 	mana_gd_init_req_hdr(&req.hdr, MANA_QUERY_DEV_CONFIG,
 			     sizeof(req), sizeof(resp));
 
-	req.hdr.resp.msg_version = GDMA_MESSAGE_V2;
+	req.hdr.resp.msg_version = GDMA_MESSAGE_V3;
 
 	req.proto_major_ver = proto_major_ver;
 	req.proto_minor_ver = proto_minor_ver;
@@ -955,10 +955,15 @@ static int mana_query_device_cfg(struct mana_context *ac, u32 proto_major_ver,
 
 	*max_num_vports = resp.max_num_vports;
 
-	if (resp.hdr.response.msg_version == GDMA_MESSAGE_V2)
+	if (resp.hdr.response.msg_version >= GDMA_MESSAGE_V2)
 		gc->adapter_mtu = resp.adapter_mtu;
 	else
 		gc->adapter_mtu = ETH_FRAME_LEN;
+
+	if (resp.hdr.response.msg_version >= GDMA_MESSAGE_V3)
+		*bm_hostmode = resp.bm_hostmode;
+	else
+		*bm_hostmode = 0;
 
 	debugfs_create_u16("adapter-MTU", 0400, gc->mana_pci_debugfs, &gc->adapter_mtu);
 
@@ -2439,7 +2444,7 @@ static void mana_destroy_vport(struct mana_port_context *apc)
 	mana_destroy_txq(apc);
 	mana_uncfg_vport(apc);
 
-	if (gd->gdma_context->is_pf)
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode)
 		mana_pf_deregister_hw_vport(apc);
 }
 
@@ -2451,7 +2456,7 @@ static int mana_create_vport(struct mana_port_context *apc,
 
 	apc->default_rxobj = INVALID_MANA_HANDLE;
 
-	if (gd->gdma_context->is_pf) {
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode) {
 		err = mana_pf_register_hw_vport(apc);
 		if (err)
 			return err;
@@ -2675,7 +2680,7 @@ int mana_alloc_queues(struct net_device *ndev)
 	if (err)
 		goto destroy_vport;
 
-	if (gd->gdma_context->is_pf) {
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode) {
 		err = mana_pf_register_filter(apc);
 		if (err)
 			goto destroy_vport;
@@ -2737,7 +2742,7 @@ static int mana_dealloc_queues(struct net_device *ndev)
 
 	mana_chn_setxdp(apc, NULL);
 
-	if (gd->gdma_context->is_pf)
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode)
 		mana_pf_deregister_filter(apc);
 
 	/* No packet can be transmitted now since apc->port_is_up is false.
@@ -2978,6 +2983,7 @@ int mana_probe(struct gdma_dev *gd, bool resuming)
 	struct gdma_context *gc = gd->gdma_context;
 	struct mana_context *ac = gd->driver_data;
 	struct device *dev = gc->dev;
+	u8 bm_hostmode = 0;
 	u16 num_ports = 0;
 	int err;
 	int i;
@@ -3004,9 +3010,11 @@ int mana_probe(struct gdma_dev *gd, bool resuming)
 		goto out;
 
 	err = mana_query_device_cfg(ac, MANA_MAJOR_VERSION, MANA_MINOR_VERSION,
-				    MANA_MICRO_VERSION, &num_ports);
+				    MANA_MICRO_VERSION, &num_ports, &bm_hostmode);
 	if (err)
 		goto out;
+
+	ac->bm_hostmode = bm_hostmode;
 
 	if (!resuming) {
 		ac->num_ports = num_ports;

--- a/include/net/mana/mana.h
+++ b/include/net/mana/mana.h
@@ -405,6 +405,7 @@ struct mana_context {
 	struct gdma_dev *gdma_dev;
 
 	u16 num_ports;
+	u8 bm_hostmode;
 
 	struct mana_eq *eqs;
 	struct dentry *mana_eqs_debugfs;
@@ -554,7 +555,8 @@ struct mana_query_device_cfg_resp {
 	u64 pf_cap_flags4;
 
 	u16 max_num_vports;
-	u16 reserved;
+	u8 bm_hostmode; /* response v3: Bare Metal Host Mode */
+	u8 reserved;
 	u32 max_num_eqs;
 
 	/* response v2: */

--- a/tools/hv/hv_kvp_daemon.c
+++ b/tools/hv/hv_kvp_daemon.c
@@ -77,6 +77,7 @@ enum {
 };
 
 static int in_hand_shake;
+static int debug;
 
 static char *os_name = "";
 static char *os_major = "";
@@ -172,6 +173,20 @@ static void kvp_update_file(int pool)
 	kvp_release_lock(pool);
 }
 
+static void kvp_dump_initial_pools(int pool)
+{
+	int i;
+
+	syslog(LOG_DEBUG, "===Start dumping the contents of pool %d ===\n",
+	       pool);
+
+	for (i = 0; i < kvp_file_info[pool].num_records; i++)
+		syslog(LOG_DEBUG, "pool: %d, %d/%d key=%s val=%s\n",
+		       pool, i + 1, kvp_file_info[pool].num_records,
+		       kvp_file_info[pool].records[i].key,
+		       kvp_file_info[pool].records[i].value);
+}
+
 static void kvp_update_mem_state(int pool)
 {
 	FILE *filep;
@@ -259,6 +274,8 @@ static int kvp_file_init(void)
 			return 1;
 		kvp_file_info[i].num_records = 0;
 		kvp_update_mem_state(i);
+		if (debug)
+			kvp_dump_initial_pools(i);
 	}
 
 	return 0;
@@ -286,6 +303,9 @@ static int kvp_key_delete(int pool, const __u8 *key, int key_size)
 		 * Found a match; just move the remaining
 		 * entries up.
 		 */
+		if (debug)
+			syslog(LOG_DEBUG, "%s: deleting the KVP: pool=%d key=%s val=%s",
+			       __func__, pool, record[i].key, record[i].value);
 		if (i == (num_records - 1)) {
 			kvp_file_info[pool].num_records--;
 			kvp_update_file(pool);
@@ -304,20 +324,36 @@ static int kvp_key_delete(int pool, const __u8 *key, int key_size)
 		kvp_update_file(pool);
 		return 0;
 	}
+
+	if (debug)
+		syslog(LOG_DEBUG, "%s: could not delete KVP: pool=%d key=%s. Record not found",
+		       __func__, pool, key);
+
 	return 1;
 }
 
 static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 				 const __u8 *value, int value_size)
 {
-	int i;
-	int num_records;
 	struct kvp_record *record;
+	int num_records;
 	int num_blocks;
+	int i;
+
+	if (debug)
+		syslog(LOG_DEBUG, "%s: got a KVP: pool=%d key=%s val=%s",
+		       __func__, pool, key, value);
 
 	if ((key_size > HV_KVP_EXCHANGE_MAX_KEY_SIZE) ||
-		(value_size > HV_KVP_EXCHANGE_MAX_VALUE_SIZE))
+		(value_size > HV_KVP_EXCHANGE_MAX_VALUE_SIZE)) {
+		syslog(LOG_ERR, "%s: Too long key or value: key=%s, val=%s",
+		       __func__, key, value);
+
+		if (debug)
+			syslog(LOG_DEBUG, "%s: Too long key or value: pool=%d, key=%s, val=%s",
+			       __func__, pool, key, value);
 		return 1;
+	}
 
 	/*
 	 * First update the in-memory state.
@@ -337,6 +373,9 @@ static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 		 */
 		memcpy(record[i].value, value, value_size);
 		kvp_update_file(pool);
+		if (debug)
+			syslog(LOG_DEBUG, "%s: updated: pool=%d key=%s val=%s",
+			       __func__, pool, key, value);
 		return 0;
 	}
 
@@ -348,8 +387,10 @@ static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 		record = realloc(record, sizeof(struct kvp_record) *
 			 ENTRIES_PER_BLOCK * (num_blocks + 1));
 
-		if (record == NULL)
+		if (!record) {
+			syslog(LOG_ERR, "%s: Memory alloc failure", __func__);
 			return 1;
+		}
 		kvp_file_info[pool].num_blocks++;
 
 	}
@@ -357,6 +398,11 @@ static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 	memcpy(record[i].key, key, key_size);
 	kvp_file_info[pool].records = record;
 	kvp_file_info[pool].num_records++;
+
+	if (debug)
+		syslog(LOG_DEBUG, "%s: added: pool=%d key=%s val=%s",
+		       __func__, pool, key, value);
+
 	kvp_update_file(pool);
 	return 0;
 }
@@ -1355,6 +1401,7 @@ void print_usage(char *argv[])
 	fprintf(stderr, "Usage: %s [options]\n"
 		"Options are:\n"
 		"  -n, --no-daemon        stay in foreground, don't daemonize\n"
+		"  -d, --debug            Enable debug logs(syslog debug by default)\n"
 		"  -h, --help             print this help\n", argv[0]);
 }
 
@@ -1376,10 +1423,11 @@ int main(int argc, char *argv[])
 	static struct option long_options[] = {
 		{"help",	no_argument,	   0,  'h' },
 		{"no-daemon",	no_argument,	   0,  'n' },
+		{"debug",	no_argument,	   0,  'd' },
 		{0,		0,		   0,  0   }
 	};
 
-	while ((opt = getopt_long(argc, argv, "hn", long_options,
+	while ((opt = getopt_long(argc, argv, "hnd", long_options,
 				  &long_index)) != -1) {
 		switch (opt) {
 		case 'n':
@@ -1388,6 +1436,9 @@ int main(int argc, char *argv[])
 		case 'h':
 			print_usage(argv);
 			exit(0);
+		case 'd':
+			debug = 1;
+			break;
 		default:
 			print_usage(argv);
 			exit(EXIT_FAILURE);
@@ -1409,6 +1460,9 @@ int main(int argc, char *argv[])
 	 * unpredictable amount of time to finish.
 	 */
 	kvp_get_domain_name(full_domain_name, sizeof(full_domain_name));
+
+	if (debug)
+		syslog(LOG_INFO, "Logging debug info in syslog(debug)");
 
 	if (kvp_file_init()) {
 		syslog(LOG_ERR, "Failed to initialize the pools");

--- a/tools/testing/selftests/mm/hmm-tests.c
+++ b/tools/testing/selftests/mm/hmm-tests.c
@@ -159,6 +159,10 @@ FIXTURE_TEARDOWN(hmm)
 {
 	int ret = close(self->fd);
 
+	if (ret != 0) {
+		fprintf(stderr, "close returned (%d) fd is (%d)\n", ret, self->fd);
+		exit(1);
+	}
 	ASSERT_EQ(ret, 0);
 	self->fd = -1;
 }


### PR DESCRIPTION
## Update process (This kernel CentOS base for `5.14.0-570`)
* Kernel History Rebuild Process for all `src.rpm`s hosted by RESF
* Create `sig-cloud-9/5.14.0-570.X.1.el8_10` branch
* Check if any maintained code is included in the new `el` release.
* Cherry-pick all code from previous branch into new branch (skipping unneeded code) 
  * Fix conflicts as they arise 
* Build and Test

## Removed Commits
Already in Base Branch
```
96794508804e8d69a557061700908bb1781d7ab7 github actions: Update Actions to deal with devel
```

## Forward Port Process
```
[jmaple@devbox kernel-src-tree-tools]$ python3 rolling-release-update.py --repo ../kernel-src-tree/ --new-base-branch rocky9_6 --old-rolling-branch $(git -C ../kernel-src-tree branch --sort=-creatordate --all --list "*sig-cloud-9*" | sed 's/remotes\/origin\///g' | head -n1)
[rolling release update] Rolling Product:  sig-cloud-9
[rolling release update] Checking out branch:  sig-cloud-9/5.14.0-570.23.1.el9_6
[rolling release update] Gathering all the RESF kernel Tags
b'08b6475feb07 (tag: resf_kernel-5.14.0-570.23.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.23.1.el9_6'
b'667004a38548 (tag: resf_kernel-5.14.0-570.22.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.22.1.el9_6'
b'9477e3364951 (tag: resf_kernel-5.14.0-570.21.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.21.1.el9_6'
b'b94108159618 (tag: resf_kernel-5.14.0-570.19.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.19.1.el9_6'
b'e8b954c95fef (tag: resf_kernel-5.14.0-570.18.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.18.1.el9_6'
b'838cd1e8d046 (tag: resf_kernel-5.14.0-570.17.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.17.1.el9_6'
b'171ceb527773 (tag: resf_kernel-5.14.0-570.16.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.16.1.el9_6'
b'18c0812a6563 (tag: resf_kernel-5.14.0-570.12.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.12.1.el9_6'
[rolling release update] Old Rolling Branch Tags:  [b'08b6475feb07', b'667004a38548', b'9477e3364951', b'b94108159618', b'e8b954c95fef', b'838cd1e8d046', b'171ceb527773', b'18c0812a6563']
[rolling release update] Checking out branch:  rocky9_6
[rolling release update] Gathering all the RESF kernel Tags
b'cad0cbcb03be (HEAD -> rocky9_6, tag: resf_kernel-5.14.0-570.25.1.el9_6, origin/rocky9_6) Rebuild rocky9_6 with kernel-5.14.0-570.25.1.el9_6'
b'4743a27158ca (tag: resf_kernel-5.14.0-570.24.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.24.1.el9_6'
b'08b6475feb07 (tag: resf_kernel-5.14.0-570.23.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.23.1.el9_6'
b'667004a38548 (tag: resf_kernel-5.14.0-570.22.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.22.1.el9_6'
b'9477e3364951 (tag: resf_kernel-5.14.0-570.21.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.21.1.el9_6'
b'b94108159618 (tag: resf_kernel-5.14.0-570.19.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.19.1.el9_6'
b'e8b954c95fef (tag: resf_kernel-5.14.0-570.18.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.18.1.el9_6'
b'838cd1e8d046 (tag: resf_kernel-5.14.0-570.17.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.17.1.el9_6'
b'171ceb527773 (tag: resf_kernel-5.14.0-570.16.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.16.1.el9_6'
b'18c0812a6563 (tag: resf_kernel-5.14.0-570.12.1.el9_6) Rebuild rocky9_6 with kernel-5.14.0-570.12.1.el9_6'
[rolling release update] New Base Branch Tags:  [b'cad0cbcb03be', b'4743a27158ca', b'08b6475feb07', b'667004a38548', b'9477e3364951', b'b94108159618', b'e8b954c95fef', b'838cd1e8d046', b'171ceb527773', b'18c0812a6563']
[rolling release update] Common tag sha:  b'08b6475feb07'
"08b6475feb0710ce784c7dda662b85e110bea9d9 Rebuild rocky9_6 with kernel-5.14.0-570.23.1.el9_6"
[rolling release update] Checking out old rolling branch:  sig-cloud-9/5.14.0-570.23.1.el9_6
[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD
[rolling release update] Getting SHAS 08b6475feb07..HEAD
[rolling release update] Last RESF tag sha:  b'08b6475feb07'
[rolling release update] Total Commit in old branch:  4
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
{
  "ac92a001c7aaa70488b9ce8e65eedc3b0e16b004": "a9c0b33ef2306327dd2db02c6274107065ff9307",
  "ef936605a7ddb3c16bcad777c687180cf33062f2": "290e5d3c49f687c1567bde634dc33d57b0674919",
  "5470cad4b6a33e0205287c3bcdac955c7e8776d3": "",
  "96794508804e8d69a557061700908bb1781d7ab7": ""
}
[rolling release update] Checking out new base branch:  rocky9_6
[rolling release update] Finding the kernel version for the new rolling release
b'cad0cbcb03be (HEAD -> rocky9_6, tag: resf_kernel-5.14.0-570.25.1.el9_6, origin/rocky9_6) Rebuild rocky9_6 with kernel-5.14.0-570.25.1.el9_6'
<re.Match object; span=(0, 70), match=b'cad0cbcb03be (HEAD -> rocky9_6, tag: resf_kernel>
[rolling release update} New Branch to create  sig-cloud-9/5.14.0-570.25.1.el9_6
[rolling release update] Check if branch Exists:  sig-cloud-9/5.14.0-570.25.1.el9_6
Branch sig-cloud-9/5.14.0-570.25.1.el9_6 does not exists creating
[rolling release update] Creating new branch for PR:  jmaple_sig-cloud-9/5.14.0-570.25.1.el9_6
[rolling release update] Creating Map of all new commits from last rolling release fork
[rolling release update] Total Commit in new branch:  20
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
Printing first 5 and last 5 commits
{
  "cad0cbcb03be58a6773b9f611dcc85138af73030": "",
  "8766d311440a3d83beeba0fbc44375c52afc3c31": "c8af247de385ce49afabc3bf1cf4fd455c94bfe8",
  "7add85a2d6e4ee06a4a3d61a032f733c5311ee4e": "4c2227656d9003f4d77afc76f34dd81b95e4c2c4",
  "8fb1e012e90e870c106fb6ffec532b5b441f0c2e": "4d4832ed13ff505fe0371544b4773e79be2bb964",
  "8a1a728b59fcbb50efda2d7ce968927481bd254b": "087c1faa594fa07a66933d750c0b2610aa1a2946"
}
{
  "db880e107329adb57df019fd8645cc88404eec16": "fcf857ee1958e9247298251f7615d0c76f1e9b38",
  "833cb8c3b04f7a9388bf8ca65c16d107d7521b54": "eb3fabde15bccdf34f1c9b35a83aa4c0dacbb4ca",
  "1c248300e40d1d0c624eb171ed294908a5450ee1": "62e2a47ceab8f3f7d2e3f0e03fdd1c5e0059fd8b",
  "fcc060fe1b3ede393f8318c956e8e8224aaf7118": "b4bac279319d3082eb42f074799c7b18ba528c71",
  "96794508804e8d69a557061700908bb1781d7ab7": ""
}
[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch
- CIQ Commit 96794508804e8d69a557061700908bb1781d7ab7 already present in new base branch: 96794508804e8d69a557061700908bb1781d7ab7 github actions: Update Actions to deal with devel
[rolling release update] Removing commits from the new branch
96794508804e8d69a557061700908bb1781d7ab7 github actions: Update Actions to deal with devel
[rolling release update] Applying the remaining commits to the new branch
Applying commit  "5470cad4b6a33e0205287c3bcdac955c7e8776d3 selftests/mm temporary fix of hmm infinite loop"
Applying commit  "ef936605a7ddb3c16bcad777c687180cf33062f2 net: mana: Add support for Multi Vports on Bare metal"
Applying commit  "ac92a001c7aaa70488b9ce8e65eedc3b0e16b004 tools: hv: Enable debug logs for hv_kvp_daemon"
```

## Builder
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" kbuild.jmaple_sig-cloud-9_5.14.0-570.25.1.el9_6.log
/mnt/code/kernel-src-tree-build
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
--
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  BTF [M] sound/usb/usx2y/snd-usb-us122l.ko
  BTF [M] sound/virtio/virtio_snd.ko
  BTF [M] sound/xen/snd_xen_front.ko
  BTF [M] sound/usb/usx2y/snd-usb-usx2y.ko
[TIMER]{BUILD}: 1857s
Making Modules
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  SIGN    /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+
[TIMER]{MODULES}: 12s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 24s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 1857s
[TIMER]{MODULES}: 12s
[TIMER]{INSTALL}: 24s
[TIMER]{TOTAL} 1899s
Rebooting in 10 seconds
```

## KSelfTest
```
[jmaple@devbox code]$ ls kselftest.5.14.0-jmaple_sig-cloud-9_5.14.0-570.23.1.el9_6-ac92a001c7aa+.log kselftest.5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+.log | while read line ; do echo $line; grep '^ok ' $line | wc -l ; done
kselftest.5.14.0-jmaple_sig-cloud-9_5.14.0-570.23.1.el9_6-ac92a001c7aa+.log
317
kselftest.5.14.0-jmaple_sig-cloud-9_5.14.0-570.25.1.e-05c2d4780a1c+.log
317
```