### PR TITLE
[fips-9-compliant] sunrpc: handle SVC_GARBAGE during svc auth processing as auth error

### DIFF
--- a/net/sunrpc/svc.c
+++ b/net/sunrpc/svc.c
@@ -1287,7 +1287,8 @@ svc_process_common(struct svc_rqst *rqstp, struct kvec *argv, struct kvec *resv)
 	case SVC_OK:
 		break;
 	case SVC_GARBAGE:
-		goto err_garbage;
+		rqstp->rq_auth_stat = rpc_autherr_badcred;
+		goto err_bad_auth;
 	case SVC_SYSERR:
 		rpc_stat = rpc_system_err;
 		goto err_bad;
@@ -1416,10 +1417,6 @@ err_bad_proc:
 	svc_putnl(resv, RPC_PROC_UNAVAIL);
 	goto sendit;
 
-err_garbage:
-	svc_printk(rqstp, "failed to decode args\n");
-
-	rpc_stat = rpc_garbage_args;
 err_bad:
 	serv->sv_stats->rpcbadfmt++;
 	svc_putnl(resv, ntohl(rpc_stat));


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-71608
cve CVE-2025-38089
commit-author Jeff Layton <jlayton@kernel.org>
commit 94d10a4dba0bc482f2b01e39f06d5513d0f75742
upstream-diff The following commits cause merge conflicts since they are
    not present in the fips-9-compliant/5.14.0-284.30.1 :-
    6d037b15e439 ("SUNRPC: Remove the rpc_stat variable in svc_process_common()")
    ab42f4d9a26f ("sunrpc: don't change ->sv_stats if it doesn't exist")
    649a692e0f2b ("SUNRPC: Convert RPC Reply header encoding to use xdr_stream")

tianshuo han reported a remotely-triggerable crash if the client sends a kernel RPC server a specially crafted packet. If decoding the RPC reply fails in such a way that SVC_GARBAGE is returned without setting the rq_accept_statp pointer, then that pointer can be dereferenced and a value stored there.

If it's the first time the thread has processed an RPC, then that pointer will be set to NULL and the kernel will crash. In other cases, it could create a memory scribble.

The server sunrpc code treats a SVC_GARBAGE return from svc_authenticate or pg_authenticate as if it should send a GARBAGE_ARGS reply. RFC 5531 says that if authentication fails that the RPC should be rejected instead with a status of AUTH_ERR.

Handle a SVC_GARBAGE return as an AUTH_ERROR, with a reason of AUTH_BADCRED instead of returning GARBAGE_ARGS in that case. This sidesteps the whole problem of touching the rpc_accept_statp pointer in this situation and avoids the crash.

	Cc: stable@kernel.org
Fixes: 29cd2927fb91 ("SUNRPC: Fix encoding of accepted but unsuccessful RPC replies")
	Reported-by: tianshuo han <hantianshuo233@gmail.com>
	Reviewed-by: Chuck Lever <chuck.lever@oracle.com>
	Signed-off-by: Jeff Layton <jlayton@kernel.org>
	Signed-off-by: Chuck Lever <chuck.lever@oracle.com>
(cherry picked from commit 94d10a4dba0bc482f2b01e39f06d5513d0f75742)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>
```

### Kernel build logs
```
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba"
Making olddefconfig
#
# configuration written to .config
#
Starting Build
  SYNC    include/config/auto.conf.cmd
  DESCEND objtool
  DESCEND bpf/resolve_btfids
  CALL    scripts/atomic/check-atomics.sh
warning: generated include/linux/atomic/atomic-instrumented.h has been modified.
  CALL    scripts/checksyscalls.sh
  CHK     include/generated/compile.h
  CC      net/8021q/vlan_core.o
  CC [M]  net/8021q/vlan.o
  CC [M]  net/8021q/vlan_dev.o
  CC [M]  net/8021q/vlan_netlink.o
  CC      net/ipv4/inet_fragment.o
  CC      net/ipv6/raw.o
  CC      net/ipv6/icmp.o
  CC [M]  net/8021q/vlan_gvrp.o
  CC      net/ipv4/ping.o
  CC [M]  net/netfilter/nf_nat_ftp.o
  CC      net/ipv4/ip_tunnel_core.o
  CHK     kernel/kheaders_data.tar.xz
  CC [M]  net/8021q/vlan_mvrp.o
  GEN     kernel/kheaders_data.tar.xz
  CC      net/ipv6/mcast.o
  CC [M]  net/netfilter/nf_nat_irc.o
  CC [M]  fs/nfs/nfs4getroot.o
  CC [M]  net/netfilter/nf_nat_sip.o
  CC      net/ipv6/reassembly.o
  CC [M]  net/8021q/vlanproc.o
  CC      net/ipv4/gre_offload.o
  <--snip-->
    STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  DEPMOD  /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+
[TIMER]{MODULES}: 10s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 26s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+ and Index to 0
The default is /boot/loader/entries/809410938d1447fc931cf787fb714082-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+
The default is /boot/loader/entries/809410938d1447fc931cf787fb714082-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-91b81b1101ba+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 536s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 26s
[TIMER]{TOTAL} 577s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21227294/kernel-build.log)

### Kselftests
```
shreeya@spatel-dev-bom:~/ciq$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
329
329
shreeya@spatel-dev-bom:~/ciq$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
79
79
```

[kselftest-after.log](https://github.com/user-attachments/files/21227320/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21227324/kselftest-before.log)
