### PR TITLE
Set standard drbg in FIPS to use HMAC SHA256 - revert previous change. Approved by lab.

### DIFF
--- a/crypto/drbg.c
+++ b/crypto/drbg.c
@@ -178,16 +178,16 @@ static const struct drbg_core drbg_cores[] = {
 		.backend_cra_name = "hmac(sha384)",
 	}, {
 		.flags = DRBG_HMAC | DRBG_STRENGTH256,
-		.statelen = 32, /* block length of cipher */
-		.blocklen_bytes = 32,
-		.cra_name = "hmac_sha256",
-		.backend_cra_name = "hmac(sha256)",
-	}, {
-		.flags = DRBG_HMAC | DRBG_STRENGTH256,
 		.statelen = 64, /* block length of cipher */
 		.blocklen_bytes = 64,
 		.cra_name = "hmac_sha512",
 		.backend_cra_name = "hmac(sha512)",
+	}, {
+		.flags = DRBG_HMAC | DRBG_STRENGTH256,
+		.statelen = 32, /* block length of cipher */
+		.blocklen_bytes = 32,
+		.cra_name = "hmac_sha256",
+		.backend_cra_name = "hmac(sha256)",
 	},
 #endif /* CONFIG_CRYPTO_DRBG_HMAC */
 };


### PR DESCRIPTION
	The default DRBG is the one that has the highest priority. The priority
	is defined based on the order of the list drbg_cores[] where the highest
	priority is given to the last entry by drbg_fill_array.

	With this patch the default DRBG is switched from HMAC SHA256 to HMAC
	SHA512 to support compliance with SP800-90B and SP800-90C (current
	draft).

	The user of the crypto API is completely unaffected by the change.

	Signed-off-by: Stephan Mueller <smueller@chronox.de>
	Acked-by: simo Sorce <simo@redhat.com>
	Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>

This changes the default DRBG back to HMAC SHA256 as more processors have hardware acceleration for this algorithm.

Approved by the lab.