### PR TITLE
[LTS 8.6] ext4: fix double-free of blocks due to wrong extents moved_len

### DIFF
--- a/fs/ext4/move_extent.c
+++ b/fs/ext4/move_extent.c
@@ -615,6 +615,7 @@ ext4_move_extents(struct file *o_filp, struct file *d_filp, __u64 orig_blk,
 		goto out;
 	o_end = o_start + len;
 
+	*moved_len = 0;
 	while (o_start < o_end) {
 		struct ext4_extent *ex;
 		ext4_lblk_t cur_blk, next_blk;
@@ -670,7 +671,7 @@ ext4_move_extents(struct file *o_filp, struct file *d_filp, __u64 orig_blk,
 		 */
 		ext4_double_up_write_data_sem(orig_inode, donor_inode);
 		/* Swap original branches with new branches */
-		move_extent_per_page(o_filp, donor_inode,
+		*moved_len += move_extent_per_page(o_filp, donor_inode,
 				     orig_page_index, donor_page_index,
 				     offset_in_page, cur_len,
 				     unwritten, &ret);
@@ -680,9 +681,6 @@ ext4_move_extents(struct file *o_filp, struct file *d_filp, __u64 orig_blk,
 		o_start += cur_len;
 		d_start += cur_len;
 	}
-	*moved_len = o_start - orig_blk;
-	if (*moved_len > len)
-		*moved_len = len;
 
 out:
 	if (*moved_len) {


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-4776
cve CVE-2024-26704
commit-author Baokun Li <libaokun1@huawei.com>
commit 55583e899a5357308274601364741a83e78d6ac4

In ext4_move_extents(), moved_len is only updated when all moves are successfully executed, and only discards orig_inode and donor_inode preallocations when moved_len is not zero. When the loop fails to exit after successfully moving some extents, moved_len is not updated and remains at 0, so it does not discard the preallocations.

If the moved extents overlap with the preallocated extents, the overlapped extents are freed twice in ext4_mb_release_inode_pa() and ext4_process_freed_data() (as described in commit 94d7c16cbbbd ("ext4: Fix double-free of blocks with EXT4_IOC_MOVE_EXT")), and bb_free is incremented twice. Hence when trim is executed, a zero-division bug is triggered in mb_update_avg_fragment_size() because bb_free is not zero and bb_fragments is zero.

Therefore, update move_len after each extent move to avoid the issue.

	Reported-by: Wei Chen <harperchen1110@gmail.com>
	Reported-by: xingwei lee <xrivendell7@gmail.com>
Closes: https://lore.kernel.org/r/CAO4mrferzqBUnCag8R3m2zf897ts9UEuhjFQGPtODT92rYyR2Q@mail.gmail.com Fixes: fcf6b1b729bc ("ext4: refactor ext4_move_extents code base") CC:  <stable@vger.kernel.org> # 3.18
	Signed-off-by: Baokun Li <libaokun1@huawei.com>
	Reviewed-by: Jan Kara <jack@suse.cz>
Link: https://lore.kernel.org/r/20240104142040.2835097-2-libaokun1@huawei.com
	Signed-off-by: Theodore Ts'o <tytso@mit.edu>
(cherry picked from commit 55583e899a5357308274601364741a83e78d6ac4)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ajain_ciqlts8_6-a2bddbb69"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  HOSTCC  scripts/basic/bin2c
  UPD     include/config/kernel.release
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  UPD     include/generated/uapi/linux/version.h
  UPD     include/generated/utsrelease.h
  DESCEND objtool
  HOSTCC  /home/anmol/kernel-src-tree/tools/objtool/fixdep.o
[--snip--]
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-_ajain_ciqlts8_6-a2bddbb69+
[TIMER]{MODULES}: 21s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-_ajain_ciqlts8_6-a2bddbb69+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 32s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-_ajain_ciqlts8_6-a2bddbb69+ and Index to 25
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-_ajain_ciqlts8_6-a2bddbb69+.conf with index 25 and kernel /boot/vmlinuz-4.18.0-_ajain_ciqlts8_6-a2bddbb69+
The default is /boot/loader/entries/d1213ab044df421ca370e008adff1cf2-4.18.0-_ajain_ciqlts8_6-a2bddbb69+.conf with index 25 and kernel /boot/vmlinuz-4.18.0-_ajain_ciqlts8_6-a2bddbb69+
Generating grub configuration file ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 3125s
[TIMER]{MODULES}: 21s
[TIMER]{INSTALL}: 32s
[TIMER]{TOTAL} 3182s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21287724/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
196
196
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
51
51
```
[kselftest-after.log](https://github.com/user-attachments/files/21287739/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21287751/kselftest-before.log)
