### PR TITLE
[FIPS 9.2] dmaengine: idxd: Fix possible Use-After-Free in irq_process_work_list

### DIFF
--- a/drivers/dma/idxd/irq.c
+++ b/drivers/dma/idxd/irq.c
@@ -460,11 +460,13 @@ static void irq_process_work_list(struct idxd_irq_entry *irq_entry)
 
 	spin_unlock(&irq_entry->list_lock);
 
-	list_for_each_entry(desc, &flist, list) {
+	list_for_each_entry_safe(desc, n, &flist, list) {
 		/*
 		 * Check against the original status as ABORT is software defined
 		 * and 0xff, which DSA_COMP_STATUS_MASK can mask out.
 		 */
+		list_del(&desc->list);
+
 		if (unlikely(desc->completion->status == IDXD_COMP_DESC_ABORT)) {
 			idxd_dma_complete_txd(desc, IDXD_COMPLETE_ABORT, true);
 			continue;


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-47991
cve CVE-2024-40956
commit-author Li RongQing <lirongqing@baidu.com>
commit e3215deca4520773cd2b155bed164c12365149a7

Use list_for_each_entry_safe() to allow iterating through the list and deleting the entry in the iteration process. The descriptor is freed via idxd_desc_complete() and there's a slight chance may cause issue for the list iterator when the descriptor is reused by another thread without it being deleted from the list.

Fixes: 16e19e11228b ("dmaengine: idxd: Fix list corruption in description completion")
	Signed-off-by: Li RongQing <lirongqing@baidu.com>
	Reviewed-by: Dave Jiang <dave.jiang@intel.com>
	Reviewed-by: Fenghua Yu <fenghua.yu@intel.com>
Link: https://lore.kernel.org/r/20240603012444.11902-1-lirongqing@baidu.com
	Signed-off-by: Vinod Koul <vkoul@kernel.org>
(cherry picked from commit e3215deca4520773cd2b155bed164c12365149a7)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/x86/include/generated/uapi/asm/param.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
[--snip--]
  INSTALL /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+
[TIMER]{MODULES}: 16s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-1decebd73+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 38s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-f644d6a99+ and Index to 1
The default is /boot/loader/entries/65b5ae363fe94129b0075258ce5a010a-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-f644d6a99+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-f644d6a99+
The default is /boot/loader/entries/65b5ae363fe94129b0075258ce5a010a-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-f644d6a99+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-f644d6a99+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 3032s
[TIMER]{MODULES}: 16s
[TIMER]{INSTALL}: 38s
[TIMER]{TOTAL} 3090s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21303501/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
318
318
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
65
65
```
[kselftest-after.log](https://github.com/user-attachments/files/21303503/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21303506/kselftest-before.log)
