### PR TITLE
[LTS 9.4] net: sched: use RCU read-side critical section in taprio_dump()

### DIFF
--- a/net/sched/sch_taprio.c
+++ b/net/sched/sch_taprio.c
@@ -2382,9 +2382,6 @@ static int taprio_dump(struct Qdisc *sch, struct sk_buff *skb)
 	struct tc_mqprio_qopt opt = { 0 };
 	struct nlattr *nest, *sched_nest;
 
-	oper = rtnl_dereference(q->oper_sched);
-	admin = rtnl_dereference(q->admin_sched);
-
 	mqprio_qopt_reconstruct(dev, &opt);
 
 	nest = nla_nest_start_noflag(skb, TCA_OPTIONS);
@@ -2405,18 +2402,23 @@ static int taprio_dump(struct Qdisc *sch, struct sk_buff *skb)
 	    nla_put_u32(skb, TCA_TAPRIO_ATTR_TXTIME_DELAY, q->txtime_delay))
 		goto options_error;
 
+	rcu_read_lock();
+
+	oper = rtnl_dereference(q->oper_sched);
+	admin = rtnl_dereference(q->admin_sched);
+
 	if (oper && taprio_dump_tc_entries(skb, q, oper))
-		goto options_error;
+		goto options_error_rcu;
 
 	if (oper && dump_schedule(skb, oper))
-		goto options_error;
+		goto options_error_rcu;
 
 	if (!admin)
 		goto done;
 
 	sched_nest = nla_nest_start_noflag(skb, TCA_TAPRIO_ATTR_ADMIN_SCHED);
 	if (!sched_nest)
-		goto options_error;
+		goto options_error_rcu;
 
 	if (dump_schedule(skb, admin))
 		goto admin_error;
@@ -2424,10 +2426,14 @@ static int taprio_dump(struct Qdisc *sch, struct sk_buff *skb)
 	nla_nest_end(skb, sched_nest);
 
 done:
+	rcu_read_unlock();
 	return nla_nest_end(skb, nest);
 
 admin_error:
 	nla_nest_cancel(skb, sched_nest);
+
+options_error_rcu:
+	rcu_read_unlock();
 
 options_error:
 	nla_nest_cancel(skb, nest);


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-8620
cve CVE-2024-50126
commit-author Dmitry Antipov <dmantipov@yandex.ru> commit b22db8b8befe90b61c98626ca1a2fbb0505e9fe3

Fix possible use-after-free in 'taprio_dump()' by adding RCU read-side critical section there. Never seen on x86 but found on a KASAN-enabled arm64 system when investigating https://syzkaller.appspot.com/bug?extid=b65e0af58423fc8a73aa:

[T15862] BUG: KASAN: slab-use-after-free in taprio_dump+0xa0c/0xbb0 [T15862] Read of size 4 at addr ffff0000d4bb88f8 by task repro/15862 [T15862]
[T15862] CPU: 0 UID: 0 PID: 15862 Comm: repro Not tainted 6.11.0-rc1-00293-gdefaf1a2113a-dirty #2 [T15862] Hardware name: QEMU QEMU Virtual Machine, BIOS edk2-20240524-5.fc40 05/24/2024 [T15862] Call trace:
[T15862]  dump_backtrace+0x20c/0x220
[T15862]  show_stack+0x2c/0x40
[T15862]  dump_stack_lvl+0xf8/0x174
[T15862]  print_report+0x170/0x4d8
[T15862]  kasan_report+0xb8/0x1d4
[T15862]  __asan_report_load4_noabort+0x20/0x2c
[T15862]  taprio_dump+0xa0c/0xbb0
[T15862]  tc_fill_qdisc+0x540/0x1020
[T15862]  qdisc_notify.isra.0+0x330/0x3a0
[T15862]  tc_modify_qdisc+0x7b8/0x1838
[T15862]  rtnetlink_rcv_msg+0x3c8/0xc20
[T15862]  netlink_rcv_skb+0x1f8/0x3d4
[T15862]  rtnetlink_rcv+0x28/0x40
[T15862]  netlink_unicast+0x51c/0x790
[T15862]  netlink_sendmsg+0x79c/0xc20
[T15862]  __sock_sendmsg+0xe0/0x1a0
[T15862]  ____sys_sendmsg+0x6c0/0x840
[T15862]  ___sys_sendmsg+0x1ac/0x1f0
[T15862]  __sys_sendmsg+0x110/0x1d0
[T15862]  __arm64_sys_sendmsg+0x74/0xb0
[T15862]  invoke_syscall+0x88/0x2e0
[T15862]  el0_svc_common.constprop.0+0xe4/0x2a0
[T15862]  do_el0_svc+0x44/0x60
[T15862]  el0_svc+0x50/0x184
[T15862]  el0t_64_sync_handler+0x120/0x12c
[T15862]  el0t_64_sync+0x190/0x194
[T15862]
[T15862] Allocated by task 15857:
[T15862]  kasan_save_stack+0x3c/0x70
[T15862]  kasan_save_track+0x20/0x3c
[T15862]  kasan_save_alloc_info+0x40/0x60
[T15862]  __kasan_kmalloc+0xd4/0xe0
[T15862]  __kmalloc_cache_noprof+0x194/0x334
[T15862]  taprio_change+0x45c/0x2fe0
[T15862]  tc_modify_qdisc+0x6a8/0x1838
[T15862]  rtnetlink_rcv_msg+0x3c8/0xc20
[T15862]  netlink_rcv_skb+0x1f8/0x3d4
[T15862]  rtnetlink_rcv+0x28/0x40
[T15862]  netlink_unicast+0x51c/0x790
[T15862]  netlink_sendmsg+0x79c/0xc20
[T15862]  __sock_sendmsg+0xe0/0x1a0
[T15862]  ____sys_sendmsg+0x6c0/0x840
[T15862]  ___sys_sendmsg+0x1ac/0x1f0
[T15862]  __sys_sendmsg+0x110/0x1d0
[T15862]  __arm64_sys_sendmsg+0x74/0xb0
[T15862]  invoke_syscall+0x88/0x2e0
[T15862]  el0_svc_common.constprop.0+0xe4/0x2a0
[T15862]  do_el0_svc+0x44/0x60
[T15862]  el0_svc+0x50/0x184
[T15862]  el0t_64_sync_handler+0x120/0x12c
[T15862]  el0t_64_sync+0x190/0x194
[T15862]
[T15862] Freed by task 6192:
[T15862]  kasan_save_stack+0x3c/0x70
[T15862]  kasan_save_track+0x20/0x3c
[T15862]  kasan_save_free_info+0x4c/0x80
[T15862]  poison_slab_object+0x110/0x160
[T15862]  __kasan_slab_free+0x3c/0x74
[T15862]  kfree+0x134/0x3c0
[T15862]  taprio_free_sched_cb+0x18c/0x220
[T15862]  rcu_core+0x920/0x1b7c
[T15862]  rcu_core_si+0x10/0x1c
[T15862]  handle_softirqs+0x2e8/0xd64
[T15862]  __do_softirq+0x14/0x20

Fixes: 18cdd2f0998a ("net/sched: taprio: taprio_dump and taprio_change are protected by rtnl_mutex")
	Acked-by: Vinicius Costa Gomes <vinicius.gomes@intel.com>
	Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
Link: https://patch.msgid.link/20241018051339.418890-2-dmantipov@yandex.ru
	Signed-off-by: Paolo Abeni <pabeni@redhat.com>

(cherry picked from commit b22db8b8befe90b61c98626ca1a2fbb0505e9fe3)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>
```

### Kernel build logs
```
/mnt/scratch/kernel-src-tree
Skipping mrproper (not requested)
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291"
Making olddefconfig
#
# configuration written to .config
#
Starting Build
  SYNC    include/config/auto.conf.cmd
  UPD     include/config/kernel.release
  DESCEND objtool
  DESCEND bpf/resolve_btfids
  UPD     include/generated/utsrelease.h
  CALL    scripts/atomic/check-atomics.sh
warning: generated include/linux/atomic/atomic-instrumented.h has been modified.
  CALL    scripts/checksyscalls.sh
  CHK     include/generated/compile.h
  CC      init/version.o
  CC      arch/x86/crypto/aesni-intel_glue.o
  AR      init/built-in.a
  CC      kernel/sys.o
  CC      security/integrity/ima/ima_init.o
  CC      crypto/fips.o
  AR      arch/x86/crypto/built-in.a
  AR      security/integrity/ima/built-in.a
  AR      security/integrity/built-in.a
  AR      security/built-in.a
  AR      arch/x86/built-in.a
  CC      crypto/algapi.o
  CC [M]  net/sched/sch_taprio.o
  CC [M]  lib/crypto/des.o
  <--snip-->
    STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+
[TIMER]{MODULES}: 10s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 23s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+ and Index to 1
The default is /boot/loader/entries/809410938d1447fc931cf787fb714082-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+
The default is /boot/loader/entries/809410938d1447fc931cf787fb714082-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-_spatel__fips-9-compliant_5.14.0-284.30.1-e5f58b654291+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 212s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 23s
[TIMER]{TOTAL} 249s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21318202/kernel-build.log)

### Kselftests
```
shreeya@spatel-dev-bom:~/ciq/ciqlts9_4$ grep '^ok ' kselftest-before_9_4.log | wc -l && grep '^ok ' kselftest-after_9_4.log | wc -l
335
335
shreeya@spatel-dev-bom:~/ciq/ciqlts9_4$ grep '^not ok ' kselftest-before_9_4.log | wc -l && grep '^not ok ' kselftest-after_9_4.log | wc -l
72
72
```
[kselftest-before_9_4.log](https://github.com/user-attachments/files/21318209/kselftest-before_9_4.log)
[kselftest-after_9_4.log](https://github.com/user-attachments/files/21318212/kselftest-after_9_4.log)
