### PR TITLE
[LTS 9.2] smb: client: fix OOBs when building SMB2_IOCTL request

### DIFF
--- a/fs/cifs/smb2pdu.c
+++ b/fs/cifs/smb2pdu.c
@@ -3057,6 +3057,15 @@ SMB2_ioctl_init(struct cifs_tcon *tcon, struct TCP_Server_Info *server,
 		return rc;
 
 	if (indatalen) {
+		unsigned int len;
+
+		if (WARN_ON_ONCE(smb3_encryption_required(tcon) &&
+				 (check_add_overflow(total_len - 1,
+						     ALIGN(indatalen, 8), &len) ||
+				  len > MAX_CIFS_SMALL_BUFFER_SIZE))) {
+			cifs_small_buf_release(req);
+			return -EIO;
+		}
 		/*
 		 * indatalen is usually small at a couple of bytes max, so
 		 * just allocate through generic pool


### PR DESCRIPTION
[LTS 9.2]
CVE-2024-50151
VULN-8636


# Problem

<https://access.redhat.com/security/cve/CVE-2024-50151>
> A flaw was found in the cifs module in the Linux kernel. When building SMB2\_IOCTL requests using encryption, either enforced by the server or using the 'seal' mount option, an out-of-bounds write can be triggered when the user passes an input buffer greater than 328 bytes, resulting in memory corruption and a kernel crash.


# Background

CIFS (Common Internet File System) is basically a different name for Microsoft's SMB (Server Message Block) protocol, allowing for sharing files and printers on the network. Functionality-wise CIFS is the same as more Linux-native NFS system. From the practical perspective, using the CIFS module boils down to mounting appropriately addressed remote "share" at a local directory (hence the "'seal' mount option" mentioned in the CVE description).


# Applicability: yes

The original mainline fix is contained in 1ab60323c5201bef25f2a3dc0ccc404d9aca77f1. The affected file is `fs/smb/client/smb2pdu.c`. For the LTS 9.2 version this corresponds to the `fs/cifs/smb2pdu.c` file, which was moved to `fs/smb/client/` in 38c8a9a52082579090e34c033d439ed2cd1a462d. The file is compiled into the kernel with the `CONFIG_CIFS` option: <https://github.com/ctrliq/kernel-src-tree/blob/e656ea9c4275c587683495697e009e31fcdfe47e/fs/cifs/Makefile#L6-L14>.

The option is enabled in `ciqlts9_2`:

    $ grep 'CONFIG_CIFS\b' configs/*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_CIFS=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-aarch64-rhel.config:CONFIG_CIFS=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-ppc64le-rhel.config:CONFIG_CIFS=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-s390x-rhel.config:CONFIG_CIFS=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_CIFS=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-x86_64-rhel.config:CONFIG_CIFS=m

The e77fe73c7e38c36145825d84cfe385d400aba4fd commit identified in 1ab60323c5201bef25f2a3dc0ccc404d9aca77f1 as introducing the bug is present in `ciqlts9_2`'s history of the module (specifically the files `fs/cifs/{smb2inode.c,smb2ops.c,smb2proto.h}`). The fixing 1ab60323c5201bef25f2a3dc0ccc404d9aca77f1 commit was not backported to `ciqlts9_2`.


# Solution

An official stable release backport e07d05b7f5ad9a503d9cab0afde2ab867bb65470 to 5.15 was used to cherry-pick onto `ciqlts9_2`. It applies cleanly, unlike the mainline fix, as 5.15 uses the same CIFS module's files layout as `ciqlts9_2`.


# kABI check: passed

    DEBUG=1 CVE=CVE-2024-50151 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_2-CVE-2024-50151

    [0/1] Check ABI of kernel [ciqlts9_2-CVE-2024-50151]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2024-50151/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2024-50151/x86_64/kabi_checked


# Boot test: passed

See [Specific tests](#org5ce0fe0) for the implied boot test passing.


# Kselftests: passed relative

No selftests were found for the CIFS module. The general selftsts were run nevertheless, mainly as part of the effort to debug the kernels 9.2 and 9.4 instability issue.


## Coverage

`bpf` (except `test_kmod.sh`, `test_xsk.sh`, `test_progs`, `test_progs-no_alu32`, `test_sockmap`), `breakpoints` (except `step_after_suspend_test`), `capabilities`, `cgroup` (except `test_freezer`, `test_memcontrol`), `clone3`, `core`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding`, `drivers/net/team`, `filesystems/binderfs`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `ir`, `kcmp`, `kexec`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net/forwarding` (except `sch_tbf_prio.sh`, `mirror_gre_vlan_bridge_1q.sh`, `dual_vxlan_bridge.sh`, `ipip_hier_gre_keys.sh`, `vxlan_bridge_1d_ipv6.sh`, `sch_tbf_root.sh`, `sch_tbf_ets.sh`, `sch_red.sh`, `tc_actions.sh`, `mirror_gre_bridge_1d_vlan.sh`, `tc_police.sh`, `q_in_vni.sh`, `sch_ets.sh`, `gre_inner_v6_multipath.sh`), `net/mptcp` (except `mptcp_join.sh`, `simult_flows.sh`, `userspace_pm.sh`), `net` (except `xfrm_policy.sh`, `reuseport_addr_any.sh`, `udpgro_fwd.sh`, `gro.sh`, `txtimestamp.sh`, `fib_nexthops.sh`, `ip_defrag.sh`, `udpgso_bench.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `openat2`, `pid_namespace`, `pidfd`, `proc` (except `proc-pid-vm`, `proc-uptime-001`), `pstore`, `ptrace`, `rlimits`, `rseq`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `syscall_user_dispatch`, `tc-testing`, `tdx`, `timens`, `timers` (except `raw_skew`), `tmpfs`, `tpm2`, `vDSO`, `vm`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/21372816/kselftests--ciqlts9_2--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-2024-50151&#x2013;run2.log](<https://github.com/user-attachments/files/21372814/kselftests--ciqlts9_2-CVE-2024-50151--run2.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-2024-50151&#x2013;run1.log](<https://github.com/user-attachments/files/21372815/kselftests--ciqlts9_2-CVE-2024-50151--run1.log>)


## Comparison

The reference and patch results are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2-CVE-2024-50151--run1.log
    Status2   kselftests--ciqlts9_2-CVE-2024-50151--run2.log


<a id="org5ce0fe0"></a>

# Specific tests: passed

The 1ab60323c5201bef25f2a3dc0ccc404d9aca77f1 commit mentions a way to replicate the bug

    mount.cifs //srv/share /mnt -o ...,seal
    ln -s $(perl -e "print('a')for 1..1024") /mnt/link

An attempt was made to replicate the bug on `ciqlts9_2` with KASAN enabled, but it failed - no KASAN errors were obtained and the symlink creation worked fine. Perhaps it had to do with the SMB share being hosted on the very same machine where it was mounted, but setting up a "proper" samba share were dropped after a couple of unsuccesfull attempts at getting rid of `NT_STATUS_CONNECTION_REFUSED` error. The same test was repeated on the patched kernel with the same result. At the very least it shows that the CIFS module remains functional.

The steps setting up encrypted samba share were as follows:

    sudo dnf --color=never install cifs-utils samba -y
    mkdir -p /sambashare
    chmod 2770 /sambashare/
    semanage fcontext -at samba_share_t '/sambashare(/.*)?'
    restorecon -vvFR /sambashare
    groupadd sales
    chgrp sales /sambashare/
    useradd -s /sbin/nologin -G sales calvin
    smbpasswd -a calvin
    echo -e '
    [global]
    \tworkgroup = SAMBA
    \tsecurity = user
    
    \tpassdb backend = tdbsam
    
    \tprinting = cups
    \tprintcap name = cups
    \tload printers = yes
    \tcups options = raw
    
    [smbshare]
    \tpath = /sambashare
    \twrite list = @sales
    ' > /etc/samba/smb.conf
    SYSTEMD_COLORS=0 systemctl --no-pager restart smb
    SYSTEMD_COLORS=0 systemctl --no-pager restart nmb
    echo "username=calvin
    password=redhat
    " > smb-multiuser.txt
    mkdir sales
    sudo mount.cifs //localhost/smbshare /home/pvts/sales -o credentials=/home/pvts/smb-multiuser.txt,multiuser,sec=ntlmssp,mfsymlinks,seal
    ln -s $(perl -e "print('a')for 1..1024") /home/pvts/sales/link

[reference-replication.log](<https://github.com/user-attachments/files/21372810/reference-replication.log>)
[patch-replication.log](<https://github.com/user-attachments/files/21372812/patch-replication.log>)

