### PR TITLE
i2c: Fix a potential use after free

### DIFF
--- a/drivers/i2c/i2c-core-base.c
+++ b/drivers/i2c/i2c-core-base.c
@@ -2467,8 +2467,9 @@ void i2c_put_adapter(struct i2c_adapter *adap)
 	if (!adap)
 		return;
 
-	put_device(&adap->dev);
 	module_put(adap->owner);
+	/* Should be last, otherwise we risk use-after-free with 'adap' */
+	put_device(&adap->dev);
 }
 EXPORT_SYMBOL(i2c_put_adapter);
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-33
cve CVE-2019-25162
commit-author Xu Wang <vulab@iscas.ac.cn>
commit e4c72c06c367758a14f227c847f9d623f1994ecf

Free the adap structure only after we are done using it. This patch just moves the put_device() down a bit to avoid the use after free.

Fixes: 611e12ea0f12 ("i2c: core: manage i2c bus device refcount in i2c_[get|put]_adapter")
	Signed-off-by: Xu Wang <vulab@iscas.ac.cn>
[wsa: added comment to the code, added Fixes tag]
	Signed-off-by: Wolfram Sang <wsa@kernel.org>
(cherry picked from commit e4c72c06c367758a14f227c847f9d623f1994ecf)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
/home/pratham/kernel/ppatel_ciqlts9_2
fatal: not a git repository: /home/pratham/my-git-repos/ciq/kernel/bare-kernel-src-tree.git/worktrees/ppatel_ciqlts9_2
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr/include
  CLEAN   usr
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/tools
  CLEAN   vmlinux.symvers modules-only.symvers modules.builtin modules.builtin.modinfo
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 9s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
fatal: not a git repository: /home/pratham/my-git-repos/ciq/kernel/bare-kernel-src-tree.git/worktrees/ppatel_ciqlts9_2
CONFIG_LOCALVERSION="--"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/x86/include/generated/uapi/asm/param.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/resource.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  WRAP    arch/x86/include/generated/uapi/asm/sockios.h
  WRAP    arch/x86/include/generated/uapi/asm/termios.h
  WRAP    arch/x86/include/generated/uapi/asm/termbits.h
  WRAP    arch/x86/include/generated/uapi/asm/types.h
  HOSTCC  arch/x86/tools/relocs_32.o
 [---snip---]
   SIGN    /lib/modules/5.14.0--/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0--/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0--/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  DEPMOD  /lib/modules/5.14.0--
[TIMER]{MODULES}: 5s
Making Install
sh ./arch/x86/boot/install.sh \
        5.14.0-- arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 16s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-0-rescue-bd61ab4cecf7433c8e934f90898699c5 and Index to 4
The default is /boot/loader/entries/bd61ab4cecf7433c8e934f90898699c5-0-rescue.conf with index 4 and kernel /boot/vmlinuz-0-rescue-bd61ab4cecf7433c8e934f90898699c5
The default is /boot/loader/entries/bd61ab4cecf7433c8e934f90898699c5-0-rescue.conf with index 4 and kernel /boot/vmlinuz-0-rescue-bd61ab4cecf7433c8e934f90898699c5
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 9s
[TIMER]{BUILD}: 1212s
[TIMER]{MODULES}: 5s
[TIMER]{INSTALL}: 16s
[TIMER]{TOTAL} 1250s
Rebooting in 10 seconds
```
[build.log](https://github.com/user-attachments/files/21393991/build.log)


### Kselftests
**The tests for `lkdtm` were skipped because the kselftest would get stuck after displaying `# ./stack-entropy.sh: line 13: /sys/kernel/debug/provoke-crash/DIRECT: Permission denied`.**
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
326
327

$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
84
83
```
[kselftest-before.log](https://github.com/user-attachments/files/21394002/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21394004/kselftest-after.log)