### PR TITLE
[LTS 9.4] smb: client: fix OOBs when building SMB2_IOCTL request

### DIFF
--- a/fs/smb/client/smb2pdu.c
+++ b/fs/smb/client/smb2pdu.c
@@ -3059,6 +3059,15 @@ SMB2_ioctl_init(struct cifs_tcon *tcon, struct TCP_Server_Info *server,
 		return rc;
 
 	if (indatalen) {
+		unsigned int len;
+
+		if (WARN_ON_ONCE(smb3_encryption_required(tcon) &&
+				 (check_add_overflow(total_len - 1,
+						     ALIGN(indatalen, 8), &len) ||
+				  len > MAX_CIFS_SMALL_BUFFER_SIZE))) {
+			cifs_small_buf_release(req);
+			return -EIO;
+		}
 		/*
 		 * indatalen is usually small at a couple of bytes max, so
 		 * just allocate through generic pool


### PR DESCRIPTION
[LTS 9.4]
CVE-2024-50151
VULN-8637


# Problem

<https://access.redhat.com/security/cve/CVE-2024-50151>
> A flaw was found in the cifs module in the Linux kernel. When building SMB2\_IOCTL requests using encryption, either enforced by the server or using the 'seal' mount option, an out-of-bounds write can be triggered when the user passes an input buffer greater than 328 bytes, resulting in memory corruption and a kernel crash.


# Background

See "Background" section in <https://github.com/ctrliq/kernel-src-tree/pull/431>.


# Applicability: yes

(Situation differs slightly from <https://github.com/ctrliq/kernel-src-tree/pull/431> - the CIFS module files are already moved to `fs/smb/client/` dir in `ciqlts9_4`)

The original mainline fix is contained in 1ab60323c5201bef25f2a3dc0ccc404d9aca77f1. The affected file is `fs/smb/client/smb2pdu.c`. It's compiled into the kernel with the `CONFIG_CIFS` option: <https://github.com/ctrliq/kernel-src-tree/blob/28a0306e2178be5bcac1f95cb1302e392e42e509/fs/smb/client/Makefile#L6-L15>

The option is enabled in `ciqlts9_4`:

    $ grep 'CONFIG_CIFS\b' configs/*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_CIFS=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-aarch64-rhel.config:CONFIG_CIFS=m
    configs/kernel-aarch64-rt-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-aarch64-rt-rhel.config:CONFIG_CIFS=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-ppc64le-rhel.config:CONFIG_CIFS=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-s390x-rhel.config:CONFIG_CIFS=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_CIFS=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-x86_64-rhel.config:CONFIG_CIFS=m
    configs/kernel-x86_64-rt-debug-rhel.config:CONFIG_CIFS=m
    configs/kernel-x86_64-rt-rhel.config:CONFIG_CIFS=m

The e77fe73c7e38c36145825d84cfe385d400aba4fd commit identified in 1ab60323c5201bef25f2a3dc0ccc404d9aca77f1 as introducing the bug is present in `ciqlts9_4`'s history of the module (specifically the files `fs/cifs/{smb2inode.c,smb2ops.c,smb2proto.h}`). The fixing 1ab60323c5201bef25f2a3dc0ccc404d9aca77f1 commit was not backported to `ciqlts9_4`.


# Solution

Mainline fix 1ab60323c5201bef25f2a3dc0ccc404d9aca77f1 was cherry-picked without any modifications.


# kABI check: passed

    DEBUG=1 CVE=CVE-2024-50151 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_4-CVE-2024-50151

    ninja: Entering directory `/data/build/rocky-patching'
    [0/1] Check ABI of kernel [ciqlts9_4-CVE-2024-50151]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-2024-50151/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-2024-50151/x86_64/kabi_checked


# Boot test: passed

See [specific tests](#org2741fd5) for the implied boot test passing.


# Kselftests: passed relative

No selftests were found for the CIFS module. The general selftsts were run nevertheless, mainly as part of the effort to debug the selftests instability issue.


## Coverage

Additinal tests `bpf:test_maps` and `drivers/net/bonding:bond_macvlan.sh` where omitted (compared to the usual scope) as it turned out they mismanage memory and destabilize kernel, often causing the selftests routine to crash at random places with NULL ptr dereference or similar memory-related errors.

`bpf` (except `test_kmod.sh`, `get_cgroup_id_user`, `test_xdp_redirect_multi.sh`, `test_xdp_features.sh`, `test_xdp_vlan_mode_native.sh`, `test_progs`, `test_xdp_veth.sh`, `test_xdp_meta.sh`, `test_maps`, `test_bpftool_metadata.sh`, `test_bpftool_build.sh`, `test_lwt_ip_encap.sh`, `test_lirc_mode2.sh`, `test_xdp_redirect.sh`, `test_tunnel.sh`, `test_xsk.sh`, `test_lwt_seg6local.sh`, `test_xdp_vlan_mode_generic.sh`, `test_skb_cgroup_id.sh`, `test_xdping.sh`, `test_bpftool.sh`, `test_tc_tunnel.sh`, `test_offload.py`, `test_dev_cgroup`, `test_flow_dissector.sh`, `test_progs-no_alu32`, `test_tcp_check_syncookie.sh`, `test_sock_addr.sh`, `test_progs-cpuv4`, `test_tc_edt.sh`, `test_sockmap`, `test_doc_build.sh`), `breakpoints` (except `step_after_suspend_test`), `capabilities`, `clone3`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding` (except `bond_macvlan.sh`), `drivers/net/team`, `exec`, `filesystems/binderfs`, `filesystems/epoll`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `iommu`, `ipc`, `ir`, `kcmp`, `kexec`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net/forwarding` (except `tc_police.sh`, `router_bridge_1d_lag.sh`, `sch_ets.sh`, `sch_tbf_prio.sh`, `router_bridge_lag.sh`, `sch_red.sh`, `sch_tbf_root.sh`, `q_in_vni.sh`, `dual_vxlan_bridge.sh`, `vxlan_bridge_1d_ipv6.sh`, `sch_tbf_ets.sh`, `mirror_gre_vlan_bridge_1q.sh`, `tc_actions.sh`, `ip6gre_inner_v6_multipath.sh`, `gre_inner_v6_multipath.sh`, `ipip_hier_gre_keys.sh`, `mirror_gre_bridge_1d_vlan.sh`), `net/hsr`, `net/mptcp` (except `simult_flows.sh`, `userspace_pm.sh`, `mptcp_join.sh`), `net` (except `udpgro_fwd.sh`, `xfrm_policy.sh`, `srv6_end_dt4_l3vpn_test.sh`, `fib_nexthops.sh`, `reuseaddr_conflict`, `reuseport_addr_any.sh`, `srv6_end_dt6_l3vpn_test.sh`, `srv6_end_flavors_test.sh`, `srv6_end_dt46_l3vpn_test.sh`, `txtimestamp.sh`, `gro.sh`, `ip_defrag.sh`, `udpgso_bench.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `pid_namespace`, `pidfd`, `proc` (except `proc-pid-vm`, `proc-uptime-001`), `pstore`, `ptrace`, `rlimits`, `rseq`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `syscall_user_dispatch`, `tc-testing`, `tdx`, `timens`, `timers`, `tmpfs`, `tpm2`, `tty`, `vDSO`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/21394777/kselftests--ciqlts9_4--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-2024-50151&#x2013;run1.log](<https://github.com/user-attachments/files/21394776/kselftests--ciqlts9_4-CVE-2024-50151--run1.log>)


## Comparison

The reference and patch results are the same.

    ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4-CVE-2024-50151--run1.log


<a id="org2741fd5"></a>

# Specific tests: passed

(The LTS 9.4 direct CIFS testing follows the same pattern as LTS 9.2 described in <https://github.com/ctrliq/kernel-src-tree/pull/431>)

The 1ab60323c5201bef25f2a3dc0ccc404d9aca77f1 commit mentions a way to replicate the bug

    mount.cifs //srv/share /mnt -o ...,seal
    ln -s $(perl -e "print('a')for 1..1024") /mnt/link

An attempt was made to replicate the bug on `ciqlts9_4` with KASAN enabled, but it failed - no KASAN errors were obtained and the symlink creation worked fine. Perhaps it had to do with the SMB share being hosted on the very same machine where it was mounted, but setting up a "proper" samba share were dropped after a couple of unsuccesfull attempts at getting rid of `NT_STATUS_CONNECTION_REFUSED` error. The same test was repeated on the patched kernel with the same result. At the very least it shows that the CIFS module remains functional.

The steps setting up encrypted samba share were as follows:

    # dnf --color=never install cifs-utils samba -y
    # mkdir -p /sambashare
    # chmod 2770 /sambashare/
    # semanage fcontext -at samba_share_t '/sambashare(/.*)?'
    # restorecon -vvFR /sambashare
    # groupadd sales
    # chgrp sales /sambashare/
    # useradd -s /sbin/nologin -G sales calvin
    # smbpasswd -a calvin
    # echo -e '
    [global]
    \tworkgroup = SAMBA
    \tsecurity = user
    
    \tpassdb backend = tdbsam
    
    \tprinting = cups
    \tprintcap name = cups
    \tload printers = yes
    \tcups options = raw
    
    [smbshare]
    \tpath = /sambashare
    \twrite list = @sales
    ' > /etc/samba/smb.conf
    # SYSTEMD_COLORS=0 systemctl --no-pager restart smb
    # SYSTEMD_COLORS=0 systemctl --no-pager restart nmb
    # echo "username=calvin
    password=redhat
    " > smb-multiuser.txt
    # mkdir sales
    # mount.cifs //localhost/smbshare /home/pvts/sales -o credentials=/home/pvts/smb-multiuser.txt,multiuser,sec=ntlmssp,mfsymlinks,seal
    # ln -s $(perl -e "print('a')for 1..1024") /home/pvts/sales/link

[reference-replication.log](<https://github.com/user-attachments/files/21394774/reference-replication.log>)
[patch-replication.log](<https://github.com/user-attachments/files/21394775/patch-replication.log>)

