### PR TITLE
[LTS-8.6] i2c: Fix a potential use after free

### DIFF
--- a/drivers/i2c/i2c-core-base.c
+++ b/drivers/i2c/i2c-core-base.c
@@ -2328,8 +2328,9 @@ void i2c_put_adapter(struct i2c_adapter *adap)
 	if (!adap)
 		return;
 
-	put_device(&adap->dev);
 	module_put(adap->owner);
+	/* Should be last, otherwise we risk use-after-free with 'adap' */
+	put_device(&adap->dev);
 }
 EXPORT_SYMBOL(i2c_put_adapter);
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-28
cve CVE-2019-25162
commit-author Xu Wang <vulab@iscas.ac.cn>
commit e4c72c06c367758a14f227c847f9d623f1994ecf

Free the adap structure only after we are done using it. This patch just moves the put_device() down a bit to avoid the use after free.

Fixes: 611e12ea0f12 ("i2c: core: manage i2c bus device refcount in i2c_[get|put]_adapter")
	Signed-off-by: Xu Wang <vulab@iscas.ac.cn>
[wsa: added comment to the code, added Fixes tag]
	Signed-off-by: Wolfram Sang <wsa@kernel.org>
(cherry picked from commit e4c72c06c367758a14f227c847f9d623f1994ecf)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
/home/pratham/kernel/kernel-src-tree
  CLEAN   .
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/tools
  CLEAN    resolve_btfids
  CLEAN   .tmp_versions
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config usr/include include/generated arch/x86/include/generated
  CLEAN   .config .config.old .version Module.symvers
[TIMER]{MRPROPER}: 10s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ppatel__ciqlts8_6-fa79650bcdf8"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  HYPERCALLS arch/x86/include/generated/asm/xen-hypercalls.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  HOSTCC  scripts/basic/bin2c
[---snip---]
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-_ppatel__ciqlts8_6-fa79650bcdf8+
[TIMER]{MODULES}: 8s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-_ppatel__ciqlts8_6-fa79650bcdf8+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 12s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_6-a5f217e5b6e3+ and Index to 1
The default is /boot/loader/entries/0e8da30330394274b2930b4ab85d0b36-4.18.0-_ppatel__ciqlts8_6-a5f217e5b6e3+.conf with index 1 and kernel /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_6-a5f217e5b6e3+
The default is /boot/loader/entries/0e8da30330394274b2930b4ab85d0b36-4.18.0-_ppatel__ciqlts8_6-a5f217e5b6e3+.conf with index 1 and kernel /boot/vmlinuz-4.18.0-_ppatel__ciqlts8_6-a5f217e5b6e3+
Generating grub configuration file ...
Adding boot menu entry for EFI firmware configuration
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 10s
[TIMER]{BUILD}: 1366s
[TIMER]{MODULES}: 8s
[TIMER]{INSTALL}: 12s
[TIMER]{TOTAL} 1400s
Rebooting in 10 seconds
```
[build.log](https://github.com/user-attachments/files/21409914/build.log)

### Kselftests
```
$ grep '^ok ' ../logs/kselftest-before.log | wc -l && grep '^ok ' ../logs/kselftest-after.log | wc -l
212
212

$ grep '^not ok ' ../logs/kselftest-before.log | wc -l && grep '^not ok ' ../logs/kselftest-after.log | wc -l
55
55
```
[kselftest-before.log](https://github.com/user-attachments/files/21409918/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21409919/kselftest-after.log)
