### PR TITLE
[fips-9.2] i2c: Fix a potential use after free

### DIFF
--- a/drivers/i2c/i2c-core-base.c
+++ b/drivers/i2c/i2c-core-base.c
@@ -2467,8 +2467,9 @@ void i2c_put_adapter(struct i2c_adapter *adap)
 	if (!adap)
 		return;
 
-	put_device(&adap->dev);
 	module_put(adap->owner);
+	/* Should be last, otherwise we risk use-after-free with 'adap' */
+	put_device(&adap->dev);
 }
 EXPORT_SYMBOL(i2c_put_adapter);
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-59662
cve CVE-2019-25162
commit-author Xu Wang <vulab@iscas.ac.cn>
commit e4c72c06c367758a14f227c847f9d623f1994ecf

Free the adap structure only after we are done using it. This patch just moves the put_device() down a bit to avoid the use after free.

Fixes: 611e12ea0f12 ("i2c: core: manage i2c bus device refcount in i2c_[get|put]_adapter")
	Signed-off-by: Xu Wang <vulab@iscas.ac.cn>
[wsa: added comment to the code, added Fixes tag]
	Signed-off-by: Wolfram Sang <wsa@kernel.org>
(cherry picked from commit e4c72c06c367758a14f227c847f9d623f1994ecf)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
/home/pratham/kernel/kernel-src-tree
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr/include
  CLEAN   usr
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/tools
  CLEAN   vmlinux.symvers modules-only.symvers modules.builtin modules.builtin.modinfo
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 8s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
[---snip---]
  STRIP   /lib/modules/5.14.0-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0+/kernel/sound/usb/snd-usb-audio.ko
  DEPMOD  /lib/modules/5.14.0-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0+
[TIMER]{MODULES}: 5s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-fips-9-compliant_5.14.0-284.30.1-675c051dc7f0+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 13s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-fips-9-compliant_5.14.0-284.30.1-e976acfa8522+ and Index to 1
The default is /boot/loader/entries/04daffe20e6a4913b56ca2d10c763ffa-5.14.0-fips-9-compliant_5.14.0-284.30.1-e976acfa8522+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-fips-9-compliant_5.14.0-284.30.1-e976acfa8522+
The default is /boot/loader/entries/04daffe20e6a4913b56ca2d10c763ffa-5.14.0-fips-9-compliant_5.14.0-284.30.1-e976acfa8522+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-fips-9-compliant_5.14.0-284.30.1-e976acfa8522+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 8s
[TIMER]{BUILD}: 1222s
[TIMER]{MODULES}: 5s
[TIMER]{INSTALL}: 13s
[TIMER]{TOTAL} 1255s
Rebooting in 10 seconds
```
[build.log](https://github.com/user-attachments/files/21435763/build.log)

### Kselftests
**The tests for `lkdtm` were skipped because the kselftest would get stuck after displaying `# ./stack-entropy.sh: line 13: /sys/kernel/debug/provoke-crash/DIRECT: Permission denied`.**
```
$ grep '^ok ' ../logs/kselftest-before.log | wc -l && grep '^ok ' ../logs/kselftest-after.log | wc -l
313
313

$ grep '^not ok ' ../logs/kselftest-before.log | wc -l && grep '^not ok ' ../logs/kselftest-after.log | wc -l
78
78
```
[kselftest-before.log](https://github.com/user-attachments/files/21435764/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21435765/kselftest-after.log)
