### PR TITLE
[LTS 8.6] netfilter: nf_tables: Reject tables of unsupported family

### DIFF
--- a/net/netfilter/nf_tables_api.c
+++ b/net/netfilter/nf_tables_api.c
@@ -1003,6 +1003,30 @@ static int nft_objname_hash_cmp(struct rhashtable_compare_arg *arg,
 	return strcmp(obj->key.name, k->name);
 }
 
+static bool nft_supported_family(u8 family)
+{
+	return false
+#ifdef CONFIG_NF_TABLES_INET
+		|| family == NFPROTO_INET
+#endif
+#ifdef CONFIG_NF_TABLES_IPV4
+		|| family == NFPROTO_IPV4
+#endif
+#ifdef CONFIG_NF_TABLES_ARP
+		|| family == NFPROTO_ARP
+#endif
+#ifdef CONFIG_NF_TABLES_NETDEV
+		|| family == NFPROTO_NETDEV
+#endif
+#if IS_ENABLED(CONFIG_NF_TABLES_BRIDGE)
+		|| family == NFPROTO_BRIDGE
+#endif
+#ifdef CONFIG_NF_TABLES_IPV6
+		|| family == NFPROTO_IPV6
+#endif
+		;
+}
+
 static int nf_tables_newtable(struct net *net, struct sock *nlsk,
 			      struct sk_buff *skb, const struct nlmsghdr *nlh,
 			      const struct nlattr * const nla[],
@@ -1016,6 +1040,9 @@ static int nf_tables_newtable(struct net *net, struct sock *nlsk,
 	u32 flags = 0;
 	struct nft_ctx ctx;
 	int err;
+
+	if (!nft_supported_family(family))
+		return -EOPNOTSUPP;
 
 	lockdep_assert_held(&net->nft_commit_mutex);
 	attr = nla[NFTA_TABLE_NAME];


### PR DESCRIPTION
[LTS 8.6]
CVE-2023-6040
VULN-8162


# Problem

<https://www.openwall.com/lists/oss-security/2024/01/12/1>

> An out-of-bounds access vulnerability involving netfilter was reported
> and fixed as:
> 
> <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f1082dd31fe461d482d69da2a8eccfeb7bf07ac2>
> 
> While creating a new netfilter table, lack of a safeguard against
> invalid nf\_tables family (pf) values within \`nf\_tables\_newtable\`
> function enables an attacker to achieve out-of-bounds access.
> 
> This out-of-bounds access can occur in two locations:
> 
> 1) \`xt\_find\_target\` function in \`x\_tables.c\` can dereference the \`xt\`
> array without a boundary check. This allows an attacker to fake an
> \`xt\_af\` data and achieve further ends.
> 
> 2) \`nf\_logger\_find\_get\` function in \`nf\_log.c\` uses \`pf\` as an index on
> \`loggers\` global which consists of \`struct nf\_logger\` members. An
> attacker can find a suitable global data to fake as \`struct nf\_logger\`
> and use the invalid \`pf\` to dereference adjacent global data.
> 
> Disabling unprivileged user namespaces mitigates the issue.
> 
> This issue was reported to Ubuntu Security directly by Lin Ma from Ant
> Security Light-Year Lab and has been assigned CVE-2023-6040.
> 
> It affects upstream stable 5.4.y, 5.10.y, 5.15.y. Those require the fix
> to be applied. Any upstream kernel newer than 5.18-rc1 should be safe.


# Applicability: yes

`nf_tables` are enabled in LTS 8.6:

    $ grep 'CONFIG_NF_TABLES\b' configs/*.config

    configs/kernel-aarch64-debug.config:CONFIG_NF_TABLES=m
    configs/kernel-aarch64.config:CONFIG_NF_TABLES=m
    configs/kernel-ppc64le-debug.config:CONFIG_NF_TABLES=m
    configs/kernel-ppc64le.config:CONFIG_NF_TABLES=m
    configs/kernel-s390x-debug.config:CONFIG_NF_TABLES=m
    configs/kernel-s390x-zfcpdump.config:CONFIG_NF_TABLES=m
    configs/kernel-s390x.config:CONFIG_NF_TABLES=m
    configs/kernel-x86_64-debug.config:CONFIG_NF_TABLES=m
    configs/kernel-x86_64.config:CONFIG_NF_TABLES=m

The fixing commit f1082dd31fe461d482d69da2a8eccfeb7bf07ac2 is not present in the affected file's `net/netfilter/nf_tables_api.c` history for `ciqlts8_6`, nor was it backported.

The bug can't be blamed on a single commit - there is no "fixes" commit indicated in f1082dd31fe461d482d69da2a8eccfeb7bf07ac2 to check whether it exists in `ciqlts8_6` history or not. However, without replicating Ant Security Lab's analysis it can be reasonably assumed that the bug is present in LTS 8.6 based on the following arguments:

1.  The fix was backported onto Linux 4.19 stable in 087d38ae0fd5a9a41b949e97601b4b0d09336f19, suggesting that the close `ciqlts8_6` kernel 4.18 is vulnerable.
2.  The `xt_find_target` function exists in `net/netfilter/x_tables.c` and it does dereference the `xt` array a couple of times without boundary checking:
    <https://github.com/ctrliq/kernel-src-tree/blob/a5f217e5b6e39677c2466d0aa781f849dfe2fed2/net/netfilter/x_tables.c#L238>
    <https://github.com/ctrliq/kernel-src-tree/blob/a5f217e5b6e39677c2466d0aa781f849dfe2fed2/net/netfilter/x_tables.c#L239>
    <https://github.com/ctrliq/kernel-src-tree/blob/a5f217e5b6e39677c2466d0aa781f849dfe2fed2/net/netfilter/x_tables.c#L243>
    <https://github.com/ctrliq/kernel-src-tree/blob/a5f217e5b6e39677c2466d0aa781f849dfe2fed2/net/netfilter/x_tables.c#L250>
3.  The `nf_logger_find_get` function exists in `net/netfilter/nf_log.c` and the global `loggers` variable is dereferenced with `pf`
    <https://github.com/ctrliq/kernel-src-tree/blob/a5f217e5b6e39677c2466d0aa781f849dfe2fed2/net/netfilter/nf_log.c#L173>


# Solution

Naively cherry-picking the f1082dd31fe461d482d69da2a8eccfeb7bf07ac2 commit leads to many conflicts but they aren't indicative of any semantic mismatches between the patch and `net/netfilter/nf_tables_api.c` file under `ciqlts8_6` revision. The changes were applied manually as they appear in the diff.


# kABI check: passed

    DEBUG=1 CVE=CVE-2023-6040 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_6-CVE-2023-6040

    [0/1] Check ABI of kernel [ciqlts8_6-CVE-2023-6040]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2023-6040/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2023-6040/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21438325/boot-test.log>)


# Kselftests: passed relative


## Coverage

The patch is contained within the `netfilter` subsystem which has its dedicated test suite - all the `netfilter:*` tests were picked for testing.


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/21438324/kselftests--ciqlts8_6--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/21438323/kselftests--ciqlts8_6--run2.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run3.log](<https://github.com/user-attachments/files/21438322/kselftests--ciqlts8_6--run3.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run4.log](<https://github.com/user-attachments/files/21438321/kselftests--ciqlts8_6--run4.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2023-6040&#x2013;run1.log](<https://github.com/user-attachments/files/21438320/kselftests--ciqlts8_6-CVE-2023-6040--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2023-6040&#x2013;run2.log](<https://github.com/user-attachments/files/21438319/kselftests--ciqlts8_6-CVE-2023-6040--run2.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2023-6040&#x2013;run3.log](<https://github.com/user-attachments/files/21438318/kselftests--ciqlts8_6-CVE-2023-6040--run3.log>)


## Comparison

The reference and patch tests results are the same

    ktests.xsh diff kselftests*.log

    Column    File
    --------  ---------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6--run2.log
    Status2   kselftests--ciqlts8_6--run3.log
    Status3   kselftests--ciqlts8_6--run4.log
    Status4   kselftests--ciqlts8_6-CVE-2023-6040--run1.log
    Status5   kselftests--ciqlts8_6-CVE-2023-6040--run2.log
    Status6   kselftests--ciqlts8_6-CVE-2023-6040--run3.log
    
    TestCase                              Status0  Status1  Status2  Status3  Status4  Status5  Status6  Summary
    netfilter:conntrack_icmp_related.sh   pass     pass     pass     pass     pass     pass     pass     same
    netfilter:conntrack_tcp_unreplied.sh  fail     fail     fail     fail     fail     fail     fail     same
    netfilter:ipvs.sh                     skip     skip     skip     skip     skip     skip     skip     same
    netfilter:nft_flowtable.sh            fail     fail     fail     fail     fail     fail     fail     same
    netfilter:nft_meta.sh                 pass     pass     pass     pass     pass     pass     pass     same
    netfilter:nft_nat.sh                  pass     pass     pass     pass     pass     pass     pass     same
    netfilter:nft_queue.sh                pass     pass     pass     pass     pass     pass     pass     same
    netfilter:nft_trans_stress.sh         pass     pass     pass     pass     pass     pass     pass     same


# Specific tests: skipped

