### PR TITLE
[LTS 9.2] netfilter: nf_tables: Reject tables of unsupported family

### DIFF
--- a/net/netfilter/nf_tables_api.c
+++ b/net/netfilter/nf_tables_api.c
@@ -1164,6 +1164,30 @@ static int nft_objname_hash_cmp(struct rhashtable_compare_arg *arg,
 	return strcmp(obj->key.name, k->name);
 }
 
+static bool nft_supported_family(u8 family)
+{
+	return false
+#ifdef CONFIG_NF_TABLES_INET
+		|| family == NFPROTO_INET
+#endif
+#ifdef CONFIG_NF_TABLES_IPV4
+		|| family == NFPROTO_IPV4
+#endif
+#ifdef CONFIG_NF_TABLES_ARP
+		|| family == NFPROTO_ARP
+#endif
+#ifdef CONFIG_NF_TABLES_NETDEV
+		|| family == NFPROTO_NETDEV
+#endif
+#if IS_ENABLED(CONFIG_NF_TABLES_BRIDGE)
+		|| family == NFPROTO_BRIDGE
+#endif
+#ifdef CONFIG_NF_TABLES_IPV6
+		|| family == NFPROTO_IPV6
+#endif
+		;
+}
+
 static int nf_tables_newtable(struct sk_buff *skb, const struct nfnl_info *info,
 			      const struct nlattr * const nla[])
 {
@@ -1177,6 +1201,9 @@ static int nf_tables_newtable(struct sk_buff *skb, const struct nfnl_info *info,
 	struct nft_ctx ctx;
 	u32 flags = 0;
 	int err;
+
+	if (!nft_supported_family(family))
+		return -EOPNOTSUPP;
 
 	lockdep_assert_held(&nft_net->commit_mutex);
 	attr = nla[NFTA_TABLE_NAME];


### PR DESCRIPTION
[LTS 9.2]
CVE-2023-6040
VULN-8164


# Problem

<https://www.openwall.com/lists/oss-security/2024/01/12/1>

> An out-of-bounds access vulnerability involving netfilter was reported
> and fixed as:
> 
> <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f1082dd31fe461d482d69da2a8eccfeb7bf07ac2>
> 
> While creating a new netfilter table, lack of a safeguard against
> invalid nf\_tables family (pf) values within \`nf\_tables\_newtable\`
> function enables an attacker to achieve out-of-bounds access.
> 
> This out-of-bounds access can occur in two locations:
> 
> 1) \`xt\_find\_target\` function in \`x\_tables.c\` can dereference the \`xt\`
> array without a boundary check. This allows an attacker to fake an
> \`xt\_af\` data and achieve further ends.
> 
> 2) \`nf\_logger\_find\_get\` function in \`nf\_log.c\` uses \`pf\` as an index on
> \`loggers\` global which consists of \`struct nf\_logger\` members. An
> attacker can find a suitable global data to fake as \`struct nf\_logger\`
> and use the invalid \`pf\` to dereference adjacent global data.
> 
> Disabling unprivileged user namespaces mitigates the issue.
> 
> This issue was reported to Ubuntu Security directly by Lin Ma from Ant
> Security Light-Year Lab and has been assigned CVE-2023-6040.
> 
> It affects upstream stable 5.4.y, 5.10.y, 5.15.y. Those require the fix
> to be applied. Any upstream kernel newer than 5.18-rc1 should be safe.


# Applicability: yes

The `nf_tables` module is enabled in LTS 9.2:

    $ grep 'CONFIG_NF_TABLES\b' configs/*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-aarch64-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-ppc64le-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-s390x-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_NF_TABLES=m
    configs/kernel-x86_64-rhel.config:CONFIG_NF_TABLES=m

The fixing commit f1082dd31fe461d482d69da2a8eccfeb7bf07ac2 is not present in the affected file's `net/netfilter/nf_tables_api.c` history for `ciqlts9_2`, nor was it backported.

The bug can't be blamed on a single commit - there is no "fixes" commit indicated in f1082dd31fe461d482d69da2a8eccfeb7bf07ac2 to check whether it exists in `ciqlts9_2` history or not. However, without replicating Ant Security Lab's analysis it can be reasonably assumed that the bug is present in LTS 9.2 based on the following arguments:

1.  The fix was backported onto Linux 5.15 stable in ab3a3aadb373b47a1f401c7626608b1b214cec9e, suggesting that the close `ciqlts9_2` kernel 5.14 is vulnerable.
2.  The fix was backported to LTS 9.4 in fbab0b7a83957026e3fc25107ce38179b6d7e806 by RH and the `ciqlts9_4` history of the files mentioned in CVE where the OOB can occur - `net/netfilter/x_tables.c` and `net/netfilter/nf_log.c` - are exactly the same in `ciqlts9_2`:
    [x\_tables&#x2013;history-comparison&#x2013;mainline&#x2013;ciqlts9\_4&#x2013;ciqlts9\_2.txt](<https://github.com/user-attachments/files/21439187/x_tables--history-comparison--mainline--ciqlts9_4--ciqlts9_2.txt>)
    [nf\_log&#x2013;history-comparison&#x2013;mainline&#x2013;ciqlts9\_4&#x2013;ciqlts9\_2.txt](<https://github.com/user-attachments/files/21439190/nf_log--history-comparison--mainline--ciqlts9_4--ciqlts9_2.txt>)


# Solution

The mainline fix f1082dd31fe461d482d69da2a8eccfeb7bf07ac2 applies to `ciqlts9_2` cleanly without any changes.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-2023-6040 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_2-CVE-2023-6040 

    [0/1] Check ABI of kernel [ciqlts9_2-CVE-2023-6040]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2023-6040/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2023-6040/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21438461/boot-test.log>)


# Kselftests: passed relative


## Coverage

The patch is contained within the `netfilter` subsystem which has its dedicated test suite - all the `netfilter:*` tests were picked for testing.


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/21438460/kselftests--ciqlts9_2--run1.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/21438459/kselftests--ciqlts9_2--run2.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run3.log](<https://github.com/user-attachments/files/21438458/kselftests--ciqlts9_2--run3.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run4.log](<https://github.com/user-attachments/files/21438457/kselftests--ciqlts9_2--run4.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-2023-6040&#x2013;run1.log](<https://github.com/user-attachments/files/21438456/kselftests--ciqlts9_2-CVE-2023-6040--run1.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-2023-6040&#x2013;run2.log](<https://github.com/user-attachments/files/21438455/kselftests--ciqlts9_2-CVE-2023-6040--run2.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-2023-6040&#x2013;run3.log](<https://github.com/user-attachments/files/21438453/kselftests--ciqlts9_2-CVE-2023-6040--run3.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-2023-6040&#x2013;run4.log](<https://github.com/user-attachments/files/21438452/kselftests--ciqlts9_2-CVE-2023-6040--run4.log>)


## Comparison

The reference and patch tests results are the same

    $ ktests.xsh diff kselftests*.log

    Column    File
    --------  ---------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2--run2.log
    Status2   kselftests--ciqlts9_2--run3.log
    Status3   kselftests--ciqlts9_2--run4.log
    Status4   kselftests--ciqlts9_2-CVE-2023-6040--run1.log
    Status5   kselftests--ciqlts9_2-CVE-2023-6040--run2.log
    Status6   kselftests--ciqlts9_2-CVE-2023-6040--run3.log
    Status7   kselftests--ciqlts9_2-CVE-2023-6040--run4.log
    
    TestCase                              Status0  Status1  Status2  Status3  Status4  Status5  Status6  Status7  Summary
    netfilter:bridge_brouter.sh           skip     skip     skip     skip     skip     skip     skip     skip     same
    netfilter:conntrack_icmp_related.sh   pass     pass     pass     pass     pass     pass     pass     pass     same
    netfilter:conntrack_tcp_unreplied.sh  fail     fail     fail     fail     fail     fail     fail     fail     same
    netfilter:conntrack_vrf.sh            fail     fail     fail     fail     fail     fail     fail     fail     same
    netfilter:ipip-conntrack-mtu.sh       skip     skip     skip     skip     skip     skip     skip     skip     same
    netfilter:ipvs.sh                     skip     skip     skip     skip     skip     skip     skip     skip     same
    netfilter:nf_nat_edemux.sh            skip     skip     skip     skip     skip     skip     skip     skip     same
    netfilter:nft_concat_range.sh         fail     fail     fail     fail     fail     fail     fail     fail     same
    netfilter:nft_conntrack_helper.sh     skip     skip     skip     skip     skip     skip     skip     skip     same
    netfilter:nft_fib.sh                  pass     pass     pass     pass     pass     pass     pass     pass     same
    netfilter:nft_flowtable.sh            fail     fail     fail     fail     fail     fail     fail     fail     same
    netfilter:nft_meta.sh                 pass     pass     pass     pass     pass     pass     pass     pass     same
    netfilter:nft_nat.sh                  fail     fail     fail     fail     fail     fail     fail     fail     same
    netfilter:nft_queue.sh                pass     pass     pass     pass     pass     pass     pass     pass     same
    netfilter:nft_trans_stress.sh         pass     pass     pass     pass     pass     pass     pass     pass     same
    netfilter:rpath.sh                    pass     pass     pass     pass     pass     pass     pass     pass     same


# Specific tests: skipped

