### PR TITLE
[lts-9.2] i2c: Fix a potential use after free

### DIFF
--- a/drivers/i2c/i2c-core-base.c
+++ b/drivers/i2c/i2c-core-base.c
@@ -2479,8 +2479,9 @@ void i2c_put_adapter(struct i2c_adapter *adap)
 	if (!adap)
 		return;
 
-	put_device(&adap->dev);
 	module_put(adap->owner);
+	/* Should be last, otherwise we risk use-after-free with 'adap' */
+	put_device(&adap->dev);
 }
 EXPORT_SYMBOL(i2c_put_adapter);
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-59661
cve CVE-2019-25162
commit-author Xu Wang <vulab@iscas.ac.cn>
commit e4c72c06c367758a14f227c847f9d623f1994ecf

Free the adap structure only after we are done using it. This patch just moves the put_device() down a bit to avoid the use after free.

Fixes: 611e12ea0f12 ("i2c: core: manage i2c bus device refcount in i2c_[get|put]_adapter")
	Signed-off-by: Xu Wang <vulab@iscas.ac.cn>
[wsa: added comment to the code, added Fixes tag]
	Signed-off-by: Wolfram Sang <wsa@kernel.org>
(cherry picked from commit e4c72c06c367758a14f227c847f9d623f1994ecf)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
/home/pratham/kernel/kernel-src-tree
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/kvm
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/tools
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr/include
  CLEAN   usr
  CLEAN   vmlinux.symvers modules-only.symvers modules.builtin modules.builtin.modinfo
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 9s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-_ppatel__ciqlts9_4-20af740a2419"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
[---snip---]
  SIGN    /lib/modules/5.14.0-_ppatel__ciqlts9_4-20af740a2419+/kernel/sound/usb/snd-usb-audio.ko
  DEPMOD  /lib/modules/5.14.0-_ppatel__ciqlts9_4-20af740a2419+
[TIMER]{MODULES}: 6s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-_ppatel__ciqlts9_4-20af740a2419+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 15s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_ppatel__ciqlts9_4-20af740a2419+ and Index to 3
The default is /boot/loader/entries/c7e4b93193fb4a20bdffe656511b00d0-5.14.0-_ppatel__ciqlts9_4-20af740a2419+.conf with index 3 and kernel /boot/vmlinuz-5.14.0-_ppatel__ciqlts9_4-20af740a2419+
The default is /boot/loader/entries/c7e4b93193fb4a20bdffe656511b00d0-5.14.0-_ppatel__ciqlts9_4-20af740a2419+.conf with index 3 and kernel /boot/vmlinuz-5.14.0-_ppatel__ciqlts9_4-20af740a2419+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 9s
[TIMER]{BUILD}: 1425s
[TIMER]{MODULES}: 6s
[TIMER]{INSTALL}: 15s
[TIMER]{TOTAL} 1462s
Rebooting in 10 seconds
```
[build.log](https://github.com/user-attachments/files/21442223/build.log)

### Kselftests
**The tests for `lkdtm` were skipped because the kselftest would get stuck after displaying `# ./stack-entropy.sh: line 13: /sys/kernel/debug/provoke-crash/DIRECT: Permission denied`.**
```
$ grep '^ok ' ../logs/kselftest-before.log | wc -l && grep '^ok ' ../logs/kselftest-after.log | wc -l
368
368

$ grep '^not ok ' ../logs/kselftest-before.log | wc -l && grep '^not ok ' ../logs/kselftest-after.log | wc -l
89
89
```
[kselftest-before.log](https://github.com/user-attachments/files/21442225/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21442226/kselftest-after.log)
