### PR TITLE
[CBR-79] i2c: Fix a potential use after free

### DIFF
--- a/drivers/i2c/i2c-core.c
+++ b/drivers/i2c/i2c-core.c
@@ -2775,8 +2775,9 @@ void i2c_put_adapter(struct i2c_adapter *adap)
 	if (!adap)
 		return;
 
-	put_device(&adap->dev);
 	module_put(adap->owner);
+	/* Should be last, otherwise we risk use-after-free with 'adap' */
+	put_device(&adap->dev);
 }
 EXPORT_SYMBOL(i2c_put_adapter);
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-1497
cve CVE-2019-25162
commit-author Xu Wang <vulab@iscas.ac.cn>
commit e4c72c06c367758a14f227c847f9d623f1994ecf
upstream-diff There was a merge conflict because the file
    drivers/i2c/i2c-core.c was renamed to drivers/i2c/i2c-core-base.c in
    91ed53491f4f ("i2c: rename core source file to allow refactorization").

Free the adap structure only after we are done using it. This patch just moves the put_device() down a bit to avoid the use after free.

Fixes: 611e12ea0f12 ("i2c: core: manage i2c bus device refcount in i2c_[get|put]_adapter")
	Signed-off-by: Xu Wang <vulab@iscas.ac.cn>
[wsa: added comment to the code, added Fixes tag]
	Signed-off-by: Wolfram Sang <wsa@kernel.org>
(cherry picked from commit e4c72c06c367758a14f227c847f9d623f1994ecf)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
/home/pratham/kernel/kernel-src-tree
Running make mrproper...
  CLEAN   .
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/vdso
  CLEAN   arch/x86/lib
  CLEAN   crypto/asymmetric_keys
  CLEAN   crypto
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi/aic7xxx
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   firmware
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   security/selinux
  CLEAN   usr
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/tools
  CLEAN   .tmp_versions
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config usr/include include/generated arch/x86/include/generated
  CLEAN   .config .config.old .version include/generated/uapi/linux/version.h Module.symvers signing_key.priv signing_key.x509 x509.genkey
[TIMER]{MRPROPER}: 4s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
Setting Local Version for build
CONFIG_LOCALVERSION="-ppatel_ciqcbr7_9-ef9855c"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  SHIPPED scripts/kconfig/zconf.hash.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf --silentoldconfig Kconfig
Makefile:917: "Cannot use CONFIG_STACK_VALIDATION, please install libelf-dev or elfutils-libelf-devel"
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/syscalls/../include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_64.h
  HOSTCC  scripts/basic/bin2c
  WRAP    arch/x86/include/generated/asm/clkdev.h
  WRAP    arch/x86/include/generated/asm/mm-arch-hooks.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  CHK     include/generated/uapi/linux/version.h
  UPD     include/generated/uapi/linux/version.h
  CHK     include/generated/utsrelease.h
  UPD     include/generated/utsrelease.h
  CHK     include/generated/qrwlock.h
  UPD     include/generated/qrwlock.h
  CHK     include/generated/qrwlock_api_smp.h
  UPD     include/generated/qrwlock_api_smp.h
  CHK     include/generated/qrwlock_types.h
  UPD     include/generated/qrwlock_types.h
  CHK     kernel/qrwlock_gen.c
  CHK     lib/qrwlock_debug.c
  HOSTCC  scripts/kallsyms
[---snip---]
  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-ppatel_ciqcbr7_9-ef9855c+
[TIMER]{MODULES}: 10s
Making Install
Makefile:917: "Cannot use CONFIG_STACK_VALIDATION, please install libelf-dev or elfutils-libelf-devel"
sh ./arch/x86/boot/install.sh 3.10.0-ppatel_ciqcbr7_9-ef9855c+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 9s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-ef9855c+ and Index to 0
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7_9.ciqcbr.5.1.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7_9.ciqcbr.5.1.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-ef9855c+
Found initrd image: /boot/initramfs-3.10.0-ppatel_ciqcbr7_9-ef9855c+.img
Found linux image: /boot/vmlinuz-3.10.0-ciqcbr7_9-0b3fae6+
Found initrd image: /boot/initramfs-3.10.0-ciqcbr7_9-0b3fae6+.img
Found linux image: /boot/vmlinuz-0-rescue-328d40a8e41d44d58d4196f842cdb6e5
Found initrd image: /boot/initramfs-0-rescue-328d40a8e41d44d58d4196f842cdb6e5.img
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 4s
[TIMER]{BUILD}: 437s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 9s
[TIMER]{TOTAL} 464s
Rebooting in 10 seconds
```
[build.log](https://github.com/user-attachments/files/21453104/build.log)

### Kselftests
```
$ grep '^ok ' ../logs/kselftest-before.log | wc -l && grep '^ok ' ../logs/kselftest-after.log | wc -l
2
2

$ grep '^not ok ' ../logs/kselftest-before.log | wc -l && grep '^not ok ' ../logs/kselftest-after.log | wc -l
5
5
```
[kselftest-before.log](https://github.com/user-attachments/files/21453107/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21453109/kselftest-after.log)