### PR TITLE
[cbr-79] ceph: avoid putting the realm twice when decoding snaps fails

### DIFF
--- a/fs/ceph/snap.c
+++ b/fs/ceph/snap.c
@@ -665,7 +665,7 @@ int ceph_update_snap_trace(struct ceph_mds_client *mdsc,
 	struct ceph_mds_snap_realm *ri;    /* encoded */
 	__le64 *snaps;                     /* encoded */
 	__le64 *prior_parent_snaps;        /* encoded */
-	struct ceph_snap_realm *realm = NULL;
+	struct ceph_snap_realm *realm;
 	struct ceph_snap_realm *first_realm = NULL;
 	int invalidate = 0;
 	int err = -ENOMEM;
@@ -673,6 +673,7 @@ int ceph_update_snap_trace(struct ceph_mds_client *mdsc,
 
 	dout("update_snap_trace deletion=%d\n", deletion);
 more:
+	realm = NULL;
 	ceph_decode_need(&p, e, sizeof(*ri), bad);
 	ri = p;
 	p += sizeof(*ri);


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-65927
cve CVE-2022-49770
commit-author Xiubo Li <xiubli@redhat.com>
commit 51884d153f7ec85e18d607b2467820a90e0f4359
upstream-diff Absence of the following commit caused a merge conflict:
    2e586641c950 ("ceph: do not update snapshot context when there is no new snapshot")

When decoding the snaps fails it maybe leaving the 'first_realm' and 'realm' pointing to the same snaprealm memory. And then it'll put it twice and could cause random use-after-free, BUG_ON, etc issues.

	Cc: stable@vger.kernel.org
Link: https://tracker.ceph.com/issues/57686
	Signed-off-by: Xiubo Li <xiubli@redhat.com>
	Reviewed-by: Ilya Dryomov <idryomov@gmail.com>
	Signed-off-by: Ilya Dryomov <idryomov@gmail.com>
(cherry picked from commit 51884d153f7ec85e18d607b2467820a90e0f4359)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
/home/pratham/kernel/kernel-src-tree
Running make mrproper...
  CLEAN   .
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/vdso
  CLEAN   arch/x86/lib
  CLEAN   crypto/asymmetric_keys
  CLEAN   crypto
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi/aic7xxx
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   firmware
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   security/selinux
  CLEAN   usr
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/tools
  CLEAN   .tmp_versions
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config usr/include include/generated arch/x86/include/generated
  CLEAN   .config .config.old .version include/generated/uapi/linux/version.h Module.symvers signing_key.priv signing_key.x509 x509.genkey
[TIMER]{MRPROPER}: 4s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
Setting Local Version for build
CONFIG_LOCALVERSION="-ppatel_ciqcbr7_9-a33d0bf"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  SHIPPED scripts/kconfig/zconf.hash.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf --silentoldconfig Kconfig
Makefile:917: "Cannot use CONFIG_STACK_VALIDATION, please install libelf-dev or elfutils-libelf-devel"
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/syscalls/../include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_64.h
  HOSTCC  scripts/basic/bin2c
  WRAP    arch/x86/include/generated/asm/clkdev.h
  WRAP    arch/x86/include/generated/asm/mm-arch-hooks.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  CHK     include/generated/uapi/linux/version.h
  UPD     include/generated/uapi/linux/version.h
  CHK     include/generated/utsrelease.h
  UPD     include/generated/utsrelease.h
  CHK     include/generated/qrwlock.h
  UPD     include/generated/qrwlock.h
  CHK     include/generated/qrwlock_api_smp.h
  UPD     include/generated/qrwlock_api_smp.h
  CHK     include/generated/qrwlock_types.h
  UPD     include/generated/qrwlock_types.h
  CHK     kernel/qrwlock_gen.c
  CHK     lib/qrwlock_debug.c
  HOSTCC  scripts/kallsyms
  HOSTCC  scripts/pnmtologo
  HOSTCC  scripts/conmakehash
[---snip---]
  INSTALL /lib/firmware/whiteheat.fw
  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-ppatel_ciqcbr7_9-a33d0bf+
[TIMER]{MODULES}: 9s
Making Install
Makefile:917: "Cannot use CONFIG_STACK_VALIDATION, please install libelf-dev or elfutils-libelf-devel"
sh ./arch/x86/boot/install.sh 3.10.0-ppatel_ciqcbr7_9-a33d0bf+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 9s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-ef9855c+ and Index to 4
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-multiple-patches-8273541+
Found initrd image: /boot/initramfs-3.10.0-ppatel_ciqcbr7_9-multiple-patches-8273541+.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-multiple-patches-89a6b45+
Found initrd image: /boot/initramfs-3.10.0-ppatel_ciqcbr7_9-multiple-patches-89a6b45+.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-multiple-patches-ccf0692+
Found initrd image: /boot/initramfs-3.10.0-ppatel_ciqcbr7_9-multiple-patches-ccf0692+.img
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7_9.ciqcbr.5.1.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7_9.ciqcbr.5.1.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-ef9855c+
Found initrd image: /boot/initramfs-3.10.0-ppatel_ciqcbr7_9-ef9855c+.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-a33d0bf+
Found initrd image: /boot/initramfs-3.10.0-ppatel_ciqcbr7_9-a33d0bf+.img
Found linux image: /boot/vmlinuz-3.10.0-ciqcbr7_9-0b3fae6+
Found initrd image: /boot/initramfs-3.10.0-ciqcbr7_9-0b3fae6+.img
Found linux image: /boot/vmlinuz-0-rescue-328d40a8e41d44d58d4196f842cdb6e5
Found initrd image: /boot/initramfs-0-rescue-328d40a8e41d44d58d4196f842cdb6e5.img
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 4s
[TIMER]{BUILD}: 432s
[TIMER]{MODULES}: 9s
[TIMER]{INSTALL}: 9s
[TIMER]{TOTAL} 458s
Rebooting in 10 seconds
```
[build.log](https://github.com/user-attachments/files/21474848/build.log)

### Kselftests
```
$ grep '^ok ' ../logs/kselftest-before.log | wc -l && grep '^ok ' ../logs/kselftest-after.log | wc -l
2
2

$ grep '^not ok ' ../logs/kselftest-before.log | wc -l && grep '^not ok ' ../logs/kselftest-after.log | wc -l
5
5
```
[kselftest-before.log](https://github.com/user-attachments/files/21474844/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21474845/kselftest-after.log)