### PR TITLE
[CBR 7.9] netfilter: nf_tables: Reject tables of unsupported family

### DIFF
--- a/net/netfilter/nf_tables_api.c
+++ b/net/netfilter/nf_tables_api.c
@@ -702,6 +702,27 @@ err:
 	return ret;
 }
 
+static bool nft_supported_family(u8 family)
+{
+	return false
+#if IS_ENABLED(CONFIG_NF_TABLES_INET)
+		|| family == NFPROTO_INET
+#endif
+#if IS_ENABLED(CONFIG_NF_TABLES_IPV4)
+		|| family == NFPROTO_IPV4
+#endif
+#if IS_ENABLED(CONFIG_NF_TABLES_ARP)
+		|| family == NFPROTO_ARP
+#endif
+#if IS_ENABLED(CONFIG_NF_TABLES_BRIDGE)
+		|| family == NFPROTO_BRIDGE
+#endif
+#if IS_ENABLED(CONFIG_NF_TABLES_IPV6)
+		|| family == NFPROTO_IPV6
+#endif
+		;
+}
+
 static int nf_tables_newtable(struct net *net, struct sock *nlsk,
 			      struct sk_buff *skb, const struct nlmsghdr *nlh,
 			      const struct nlattr * const nla[])
@@ -714,6 +735,9 @@ static int nf_tables_newtable(struct net *net, struct sock *nlsk,
 	u32 flags = 0;
 	struct nft_ctx ctx;
 	int err;
+
+	if (!nft_supported_family(family))
+		return -EOPNOTSUPP;
 
 	afi = nf_tables_afinfo_lookup(net, family, true);
 	if (IS_ERR(afi))


### PR DESCRIPTION
[CBR 7.9]
CVE-2023-6040
VULN-7622


# Problem

<https://www.openwall.com/lists/oss-security/2024/01/12/1>

> An out-of-bounds access vulnerability involving netfilter was reported
> and fixed as:
> 
> <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f1082dd31fe461d482d69da2a8eccfeb7bf07ac2>
> 
> While creating a new netfilter table, lack of a safeguard against
> invalid nf\_tables family (pf) values within \`nf\_tables\_newtable\`
> function enables an attacker to achieve out-of-bounds access.
> 
> This out-of-bounds access can occur in two locations:
> 
> 1) \`xt\_find\_target\` function in \`x\_tables.c\` can dereference the \`xt\`
> array without a boundary check. This allows an attacker to fake an
> \`xt\_af\` data and achieve further ends.
> 
> 2) \`nf\_logger\_find\_get\` function in \`nf\_log.c\` uses \`pf\` as an index on
> \`loggers\` global which consists of \`struct nf\_logger\` members. An
> attacker can find a suitable global data to fake as \`struct nf\_logger\`
> and use the invalid \`pf\` to dereference adjacent global data.
> 
> Disabling unprivileged user namespaces mitigates the issue.
> 
> This issue was reported to Ubuntu Security directly by Lin Ma from Ant
> Security Light-Year Lab and has been assigned CVE-2023-6040.
> 
> It affects upstream stable 5.4.y, 5.10.y, 5.15.y. Those require the fix
> to be applied. Any upstream kernel newer than 5.18-rc1 should be safe.


# Applicability: yes

The `nf_tables` module is enabled in CBR 7.9:

    $ grep 'CONFIG_NF_TABLES\b' configs/*.config

    configs/kernel-3.10.0-x86_64-debug.config:CONFIG_NF_TABLES=m
    configs/kernel-3.10.0-x86_64.config:CONFIG_NF_TABLES=m

The fixing commit f1082dd31fe461d482d69da2a8eccfeb7bf07ac2 is not present in the affected file's `net/netfilter/nf_tables_api.c` history for `ciqcbr7_9`, nor was it backported.

The bug can't be blamed on a single commit - there is no "fixes" commit indicated in f1082dd31fe461d482d69da2a8eccfeb7bf07ac2 to check whether it exists in `ciqcbr7_9` history or not. However, without replicating Ant Security Lab's analysis it can be reasonably assumed that the bug is present in CBR 7.9 based on the following arguments:

1.  The `xt_find_target` function exists in `net/netfilter/x_tables.c` and it does dereference the `xt` array a couple of times without boundary checking:
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/netfilter/x_tables.c#L231>
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/netfilter/x_tables.c#L232>
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/netfilter/x_tables.c#L236>
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/netfilter/x_tables.c#L243>
2.  The `nf_logger_find_get` function exists in `net/netfilter/nf_log.c` and the global `loggers` variable is dereferenced with `pf`
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/netfilter/nf_log.c#L173>
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/netfilter/nf_log.c#L180>
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/netfilter/nf_log.c#L191>


# Solution

Naively cherry-picking the f1082dd31fe461d482d69da2a8eccfeb7bf07ac2 commit leads to many conflicts but they aren't indicative of any semantic mismatches between the patch and `net/netfilter/nf_tables_api.c` file under `ciqcbr7_9` revision. The changes were applied manually as they appear in the diff. Two changes compared to mainline were made:

1.  The `CONFIG_NF_TABLES_NETDEV` case was removed because that option is not even available in `ciqcbr7_9` yet.
2.  All table type CONFIGs were wrapped in `IS_ENABLED(...)` macro instead of just `CONFIG_NF_TABLES_BRIDGE` because all of them are of type "tristate" in `ciqcbr7_9`, unlike in the newer kernels where they are "bool" and a simple `#ifdef` is sufficient:
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/netfilter/Kconfig#L447>
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/ipv4/netfilter/Kconfig#L42>
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/ipv4/netfilter/Kconfig#L70>
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/bridge/netfilter/Kconfig#L7>
    <https://github.com/ctrliq/kernel-src-tree/blob/d93daad95942e6d27bc7f0e1bdf44f7abd2a4294/net/ipv6/netfilter/Kconfig#L31>
    Compare with `ciqlts9_2`, for example:
    <https://github.com/ctrliq/kernel-src-tree/blob/f85f16c42df6ef9d07290e809753fcc826605e62/net/netfilter/Kconfig#L489>
    <https://github.com/ctrliq/kernel-src-tree/blob/f85f16c42df6ef9d07290e809753fcc826605e62/net/ipv4/netfilter/Kconfig#L25>
    <https://github.com/ctrliq/kernel-src-tree/blob/f85f16c42df6ef9d07290e809753fcc826605e62/net/ipv4/netfilter/Kconfig#L54>
    <https://github.com/ctrliq/kernel-src-tree/blob/f85f16c42df6ef9d07290e809753fcc826605e62/net/netfilter/Kconfig#L494>
    <https://github.com/ctrliq/kernel-src-tree/blob/f85f16c42df6ef9d07290e809753fcc826605e62/net/bridge/netfilter/Kconfig#L9>
    <https://github.com/ctrliq/kernel-src-tree/blob/f85f16c42df6ef9d07290e809753fcc826605e62/net/ipv6/netfilter/Kconfig#L21>


# kABI check: passed

    [root@ciqcbr-7-9 pvts]# python /mnt/code/kernel-dist-git-el-7.9/SOURCES/check-kabi -k /mnt/code/kernel-dist-git-el-7.9/SOURCES/Module.kabi_x86_64 -s /mnt/build_files/kernel-src-tree-ciqcbr7_9-CVE-2023-6040/Module.symvers
    [root@ciqcbr-7-9 pvts]# echo $? 
    0


# Boot test: passed

See implied boot test passing in the [Specific tests](#orgec9d7d4) section.


# Selftests: skipped

It was attempted to use the `netfilter:*` selftests from Rocky LTS 8.6 version to test the nf tables module in CBR 7.9, as most of them are just bash scripts juggling `ip`, `nft`, `nc` and `conntrack` calls to create network setups. Unfortunately, the `nft` version available in CBR 7.9 didn't recognize the call syntax of reading from stdin

    nft -f -

used extensively in the scripts. Where the more explicit form was used

    nft -f /dev/stdin

it could not understand the provided configuration, like

    nft -f /dev/stdin <<EOF
    table $family nat {
    	chain output {
    		type nat hook output priority 0; policy accept;
    		ip6 daddr dead:1::99 dnat $IPF to dead:2:i:99
    	}
    }
    EOF

In short, the `nft` tool was too old.


<a id="orgec9d7d4"></a>

# Specific tests: passed

The modified function `nf_tables_newtable` can be quite easily reached from the userspace with the `nft add table…` command. With config options mapping to the third arguments as

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Config option</th>
<th scope="col" class="org-left">X: nft add table X</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">CONFIG&#95;NF&#95;TABLES&#95;INET</td>
<td class="org-left">inet</td>
</tr>


<tr>
<td class="org-left">CONFIG&#95;NF&#95;TABLES&#95;IPV4</td>
<td class="org-left">ip</td>
</tr>


<tr>
<td class="org-left">CONFIG&#95;NF&#95;TABLES&#95;IPV6</td>
<td class="org-left">ip6</td>
</tr>


<tr>
<td class="org-left">CONFIG&#95;NF&#95;TABLES&#95;ARP</td>
<td class="org-left">arp</td>
</tr>


<tr>
<td class="org-left">CONFIG&#95;NF&#95;TABLES&#95;BRIDGE</td>
<td class="org-left">bridge</td>
</tr>
</tbody>
</table>

all of supported table types are accepted in the patched kernel, just as they are in the reference kernel:

    [root@ciqcbr-7-9 pvts]# nft add table inet table_inet
    [root@ciqcbr-7-9 pvts]# echo $? 
    0
    [root@ciqcbr-7-9 pvts]# nft add table ip table_ip
    [root@ciqcbr-7-9 pvts]# echo $? 
    0
    [root@ciqcbr-7-9 pvts]# nft add table ip6 table_ip6
    [root@ciqcbr-7-9 pvts]# echo $? 
    0
    [root@ciqcbr-7-9 pvts]# nft add table arp table_arp
    [root@ciqcbr-7-9 pvts]# echo $? 
    0
    [root@ciqcbr-7-9 pvts]# nft add table bridge table_bridge
    [root@ciqcbr-7-9 pvts]# echo $? 
    0
    [root@ciqcbr-7-9 pvts]# nft list tables
    nft list tables
    table ip table_ip
    table ip6 table_ip6
    table inet table_inet
    table arp table_arp
    table bridge table_bridge

[specific-test-reference.log](<https://github.com/user-attachments/files/21496122/specific-test-reference.log>)
[specific-test-patch.log](<https://github.com/user-attachments/files/21496125/specific-test-patch.log>)

A test version of the kernel for both the reference and the patch was prepared, with the `CONFIG_NF_TABLES_ARP` option disabled

    CONFIG_NF_TABLES_ARP=n

to gauge `nft`'s reaction for creating the unsupported `arp` table.

-   Patch:
    
        [root@ciqcbr-7-9 pvts]# nft add table arp table_arp
        Error: Could not process rule: Operation not supported
        add table arp table_arp
        ^^^^^^^^^^^^^^^^^^^^^^^^
        [root@ciqcbr-7-9 pvts]# echo $? 
        1
    
    The "Operation not supported" message aligns with the `-EOPNOTSUPP` value returned in the branch added to `nf_tables_newtable` function:
    
        if (!nft_supported_family(family))
          	return -EOPNOTSUPP;
    
    [specific-test-patch-no-arp.log](<https://github.com/user-attachments/files/21496126/specific-test-patch-no-arp.log>)

-   Reference:
    
        [root@ciqcbr-7-9 pvts]# nft add table arp table_arp
        Error: Could not process rule: Address family not supported by protocol
        add table arp table_arp
        ^^^^^^^^^^^^^^^^^^^^^^^^
        [root@ciqcbr-7-9 pvts]#
    
    The `arp` argument is likewise rejected, as expected, although with a different message implying a later point in the code path, where the problems indicated in the CVE may manifest.
    
    [specific-test-reference-no-arp.log](<https://github.com/user-attachments/files/21496124/specific-test-reference-no-arp.log>)


# Commentary

Technically this bug may not be applicable to Rocky CBR 7.9, as no table type is unsupported - all of `NF_TABLES_INET`, `NF_TABLES_IPV4`, `NF_TABLES_ARP`, `NF_TABLES_BRIDGE`, `NF_TABLES_NETDEV`, `NF_TABLES_IPV6` options are enabled in `configs/kernel-3.10.0-x86_64.config` and the `nft_supported_family(family)` call may just as well always evaluate to `true` (same applies to <https://github.com/ctrliq/kernel-src-tree/pull/440> and <https://github.com/ctrliq/kernel-src-tree/pull/438>). However, this would require showing that `family` variable won't ever assume any other value than `NFPROTO_INET`, `NFPROTO_IPV4`, `NFPROTO_ARP`, `NFPROTO_BRIDGE`, `NFPROTO_IPV6`, which the `nft` calls given previously suggest, but which would nevertheless need to be proved by kernel code investigation. Considering that this was realized after the patch was already made and tested it's now cheaper to include it instead of pursuing this analysis.

