### PR TITLE
[LTS 9.2] perf: Disallow mis-matched inherited group reads

### DIFF
--- a/include/linux/perf_event.h
+++ b/include/linux/perf_event.h
@@ -61,6 +61,7 @@ struct perf_guest_info_callbacks {
 #include <linux/security.h>
 #include <linux/static_call.h>
 #include <linux/lockdep.h>
+#include <linux/rh_kabi.h>
 #include <asm/local.h>
 
 struct perf_callchain_entry {
@@ -803,6 +804,8 @@ struct perf_event {
 	void *security;
 #endif
 	struct list_head		sb_list;
+
+	RH_KABI_EXTEND(unsigned int	group_generation)
 #endif /* CONFIG_PERF_EVENTS */
 };
 

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -13143,7 +13143,8 @@ static int inherit_group(struct perf_event *parent_event,
 		    !perf_get_aux_event(child_ctr, leader))
 			return -EINVAL;
 	}
-	leader->group_generation = parent_event->group_generation;
+	if (leader)
+		leader->group_generation = parent_event->group_generation;
 	return 0;
 }
 

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -1956,6 +1956,7 @@ static void perf_group_attach(struct perf_event *event)
 
 	list_add_tail(&event->sibling_list, &group_leader->sibling_list);
 	group_leader->nr_siblings++;
+	group_leader->group_generation++;
 
 	perf_event__header_size(group_leader);
 
@@ -2150,6 +2151,7 @@ static void perf_group_detach(struct perf_event *event)
 	if (leader != event) {
 		list_del_init(&event->sibling_list);
 		event->group_leader->nr_siblings--;
+		event->group_leader->group_generation++;
 		goto out;
 	}
 
@@ -5239,7 +5241,7 @@ static int __perf_read_group_add(struct perf_event *leader,
 					u64 read_format, u64 *values)
 {
 	struct perf_event_context *ctx = leader->ctx;
-	struct perf_event *sub;
+	struct perf_event *sub, *parent;
 	unsigned long flags;
 	int n = 1; /* skip @nr */
 	int ret;
@@ -5249,6 +5251,33 @@ static int __perf_read_group_add(struct perf_event *leader,
 		return ret;
 
 	raw_spin_lock_irqsave(&ctx->lock, flags);
+	/*
+	 * Verify the grouping between the parent and child (inherited)
+	 * events is still in tact.
+	 *
+	 * Specifically:
+	 *  - leader->ctx->lock pins leader->sibling_list
+	 *  - parent->child_mutex pins parent->child_list
+	 *  - parent->ctx->mutex pins parent->sibling_list
+	 *
+	 * Because parent->ctx != leader->ctx (and child_list nests inside
+	 * ctx->mutex), group destruction is not atomic between children, also
+	 * see perf_event_release_kernel(). Additionally, parent can grow the
+	 * group.
+	 *
+	 * Therefore it is possible to have parent and child groups in a
+	 * different configuration and summing over such a beast makes no sense
+	 * what so ever.
+	 *
+	 * Reject this.
+	 */
+	parent = leader->parent;
+	if (parent &&
+	    (parent->group_generation != leader->group_generation ||
+	     parent->nr_siblings != leader->nr_siblings)) {
+		ret = -ECHILD;
+		goto unlock;
+	}
 
 	/*
 	 * Since we co-schedule groups, {enabled,running} times of siblings
@@ -5282,8 +5311,9 @@ static int __perf_read_group_add(struct perf_event *leader,
 			values[n++] = atomic64_read(&sub->lost_samples);
 	}
 
+unlock:
 	raw_spin_unlock_irqrestore(&ctx->lock, flags);
-	return 0;
+	return ret;
 }
 
 static int perf_read_group(struct perf_event *event,
@@ -5302,10 +5332,6 @@ static int perf_read_group(struct perf_event *event,
 
 	values[0] = 1 + leader->nr_siblings;
 
-	/*
-	 * By locking the child_mutex of the leader we effectively
-	 * lock the child list of all siblings.. XXX explain how.
-	 */
 	mutex_lock(&leader->child_mutex);
 
 	ret = __perf_read_group_add(leader, read_format, values);
@@ -13117,6 +13143,7 @@ static int inherit_group(struct perf_event *parent_event,
 		    !perf_get_aux_event(child_ctr, leader))
 			return -EINVAL;
 	}
+	leader->group_generation = parent_event->group_generation;
 	return 0;
 }
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-6760
pre-cve CVE-2023-5717
commit-author Peter Zijlstra <peterz@infradead.org>
commit 32671e3799ca2e4590773fd0e63aaa4229e50c06

Because group consistency is non-atomic between parent (filedesc) and children
(inherited) events, it is possible for PERF_FORMAT_GROUP read() to try and sum
non-matching counter groups -- with non-sensical results.

Add group_generation to distinguish the case where a parent group removes and
adds an event and thus has the same number, but a different configuration of
events as inherited groups.

This became a problem when commit fa8c269353d5 ("perf/core: Invert
perf_read_group() loops") flipped the order of child_list and sibling_list.
Previously it would iterate the group (sibling_list) first, and for each
sibling traverse the child_list. In this order, only the group composition of
the parent is relevant. By flipping the order the group composition of the
child (inherited) events becomes an issue and the mis-match in group
composition becomes evident.

That said; even prior to this commit, while reading of a group that is not
equally inherited was not broken, it still made no sense.

(Ab)use ECHILD as error return to indicate issues with child process group
composition.

Fixes: fa8c269353d5 ("perf/core: Invert perf_read_group() loops")
        Reported-by: Budimir Markovic <markovicbudimir@gmail.com>
        Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
Link: https://lkml.kernel.org/r/20231018115654.GK33217@noisy.programming.kicks-ass.net
(cherry picked from commit 32671e3799ca2e4590773fd0e63aaa4229e50c06)
        Signed-off-by: Shreeya Patel <spatel@ciq.com>

-------------------------------------------------------------------------------------------------------
perf: Fix kABI breakage in struct perf_event

jira VULN-6760
cve CVE-2023-5717
commit-author Shreeya Patel <spatel@ciq.com>

Fix kabi breakage in commit 32671e3 ("[Backport] perf: Disallow
mis-matched inherited group reads")

Fixes: 32671e3 ("perf: Disallow mis-matched inherited group reads")
Signed-off-by: Shreeya Patel <spatel@ciq.com>

```

### Kernel build logs
```
/mnt/scratch/kernel-src-tree
Running make mrproper...
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr/include
  CLEAN   usr
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/tools
  CLEAN   vmlinux.symvers modules-only.symvers modules.builtin modules.builtin.modinfo
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 8s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-spatel_ciqlts9_2-0622cb855261"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  <--snip-->
    SIGN    /lib/modules/5.14.0-spatel_ciqlts9_2-0622cb855261+/kernel/sound/usb/line6/snd-usb-podhd.ko
  SIGN    /lib/modules/5.14.0-spatel_ciqlts9_2-0622cb855261+/kernel/sound/usb/line6/snd-usb-toneport.ko
  INSTALL /lib/modules/5.14.0-spatel_ciqlts9_2-0622cb855261+/kernel/net/key/af_key.ko
  STRIP   /lib/modules/5.14.0-spatel_ciqlts9_2-0622cb855261+/kernel/net/key/af_key.ko
  SIGN    /lib/modules/5.14.0-spatel_ciqlts9_2-0622cb855261+/kernel/net/key/af_key.ko
  DEPMOD  /lib/modules/5.14.0-spatel_ciqlts9_2-0622cb855261+
[TIMER]{MODULES}: 8s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-spatel_ciqlts9_2-0622cb855261+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 20s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-spatel_ciqlts9_2-0622cb855261+ and Index to 1
The default is /boot/loader/entries/2d84c760132f4bab9836f9dd9e3ac547-5.14.0-spatel_ciqlts9_2-0622cb855261+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-spatel_ciqlts9_2-0622cb855261+
The default is /boot/loader/entries/2d84c760132f4bab9836f9dd9e3ac547-5.14.0-spatel_ciqlts9_2-0622cb855261+.conf with index 1 and kernel /boot/vmlinuz-5.14.0-spatel_ciqlts9_2-0622cb855261+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 8s
[TIMER]{BUILD}: 1325s
[TIMER]{MODULES}: 8s
[TIMER]{INSTALL}: 20s
[TIMER]{TOTAL} 1367s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21512130/kernel-build.log)


### Kselftests

```
shreeya@spatel-dev-bom:~/ciq/ciqlts9_2$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
296
297
shreeya@spatel-dev-bom:~/ciq/ciqlts9_2$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
71
70

```
[kselftest-before.log](https://github.com/user-attachments/files/21512141/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21512143/kselftest-after.log)

