### PR TITLE
[LTS 8.6] KVM: arm64: vgic-its: Avoid potential UAF in LPI translation cache

### DIFF
--- a/arch/arm64/kvm/vgic/vgic-its.c
+++ b/arch/arm64/kvm/vgic/vgic-its.c
@@ -595,7 +595,11 @@ static struct vgic_irq *vgic_its_check_cache(struct kvm *kvm, phys_addr_t db,
 	unsigned long flags;
 
 	raw_spin_lock_irqsave(&dist->lpi_list_lock, flags);
+
 	irq = __vgic_its_check_cache(dist, db, devid, eventid);
+	if (irq)
+		vgic_get_irq_kref(irq);
+
 	raw_spin_unlock_irqrestore(&dist->lpi_list_lock, flags);
 
 	return irq;
@@ -774,6 +778,7 @@ int vgic_its_inject_cached_translation(struct kvm *kvm, struct kvm_msi *msi)
 	raw_spin_lock_irqsave(&irq->irq_lock, flags);
 	irq->pending_latch = true;
 	vgic_queue_irq_unlock(kvm, irq, flags);
+	vgic_put_irq(kvm, irq);
 
 	return 0;
 }


### PR DESCRIPTION
[LTS 8.6]
CVE-2024-26598
VULN-8188


# Problem

<https://access.redhat.com/security/cve/CVE-2024-26598>
> A flaw was found in the Linux kernel pertaining to a potential use-after-free (UAF) scenario in a system involving Logical Partitioning Interrupts (LPI) translation cache operations. Specifically, the issue arises when a cache hit occurs concurrently with an operation that invalidates the cache, such as a DISCARD ITS command. The root cause is traced to vgic\_its\_check\_cache() not appropriately managing the reference count of the vgic\_irq object. Upon returning from this function, the reference count of vgic\_irq is not incremented. This issue can lead to the object being prematurely freed while still in use by other parts of the system, potentially resulting in undefined behavior or system instability.


# Applicability: yes

(The reasoning is similar as in <https://github.com/ctrliq/kernel-src-tree/pull/454>)

No clear "fixes" commit provided in the mainline fix ad362fe07fecf0aba839ff2cc59a3617bd42c33f to check `ciqlts8_6`'s history for, but the applicability of the bug is highly likely, given that:

1.  The patch was applied to Linux stable 5.15 in 12c2759ab1343c124ed46ba48f27bd1ef5d2dff4.
2.  The affected file `arch/arm64/kvm/vgic/vgic-its.c` barely differs between `linux-5.15.y` and `ciqlts8_6`. Compare the histories of `linux-5.15.y`, `ciqlts8_6` and `kernel-mainline` for reference (this is around 30% of its history, with the additional 106 commits of this file under previous path `virt/kvm/arm/vgic/vgic-its.c` shared one-to-one between all versions):
    
          kernel-mainline                                                                                linux-5.15.y            ciqlts8_6
          ---------------------------------------------------------------------------------------------  ----------------------  ----------------------
          fc4dafe87 2025-05-30 KVM: arm64: Protect vLPI translation with vgic_irq::irq_lock
          b586c5d21 2025-05-27 KVM: arm64: use kvm_trylock_all_vcpus when locking all vCPUs
          30deb51a6 2025-05-19 KVM: arm64: vgic-its: Add debugfs interface to expose ITS tables
          be7e61127 2024-12-03 KVM: arm64: vgic-its: Add error handling in vgic_its_cache_translation
          3b2c81d5f 2024-11-20 KVM: arm64: vgic-its: Add stronger type-checking to the ITS entry sizes
          add570b39 2024-11-20 KVM: arm64: vgic: Make vgic_get_irq() more robust
          7602ffd1d 2024-11-11 KVM: arm64: vgic-its: Clear ITE when DISCARD frees an ITE                 ~ a0e0f67f2 2024-12-14
          e9649129d 2024-11-11 KVM: arm64: vgic-its: Clear DTE when MAPD unmaps a device                 ~ fd92260b7 2024-12-14
          7fe28d7e6 2024-11-11 KVM: arm64: vgic-its: Add a data length check in vgic_its_save_*          ~ 065e075d4 2024-12-14
          0aa34b37a 2024-08-02 KVM: arm64: fix kdoc warnings in W=1 builds
          481c9ee84 2024-04-25 KVM: arm64: vgic-its: Get rid of the lpi_list_lock
          ec39bbfd5 2024-04-25 KVM: arm64: vgic-its: Rip out the global translation cache
          e64f2918c 2024-04-25 KVM: arm64: vgic-its: Use the per-ITS translation cache for injection
          dedfcd17f 2024-04-25 KVM: arm64: vgic-its: Spin off helper for finding ITS by doorbell addr
          8201d1028 2024-04-25 KVM: arm64: vgic-its: Maintain a translation cache per ITS
          c09c8ab99 2024-04-25 KVM: arm64: vgic-its: Scope translation cache invalidations to an ITS
          30a0ce9c4 2024-04-25 KVM: arm64: vgic-its: Get rid of vgic_copy_lpi_list()
          85d3ccc8b 2024-04-25 KVM: arm64: vgic-debug: Use an xarray mark for debug iterator
          11f4f8f3e 2024-04-25 KVM: arm64: vgic-its: Walk LPI xarray in vgic_its_cmd_handle_movall()
          c64115c80 2024-04-25 KVM: arm64: vgic-its: Walk LPI xarray in vgic_its_invall()
          720f73b75 2024-04-25 KVM: arm64: vgic-its: Walk LPI xarray in its_sync_lpi_pending_table()
          75841d89f 2024-02-24 KVM: arm64: Fix typos
          e27f2d561 2024-02-23 KVM: arm64: vgic: Don't acquire the lpi_list_lock in vgic_put_irq()
          50ac89bb7 2024-02-23 KVM: arm64: vgic: Ensure the irq refcount is nonzero when taking a ref
          05f4d4f5d 2024-02-23 KVM: arm64: vgic: Use atomics to count LPIs
          9880835af 2024-02-23 KVM: arm64: vgic: Get rid of the LPI linked-list
          2798683b8 2024-02-23 KVM: arm64: vgic-its: Walk the LPI xarray in vgic_copy_lpi_list()
          1d6f83f60 2024-02-23 KVM: arm64: vgic: Store LPIs in an xarray
          85a71ee9a 2024-02-21 KVM: arm64: vgic-its: Test for valid IRQ in MOVALL handler                ~ 4deb8413e 2024-03-01
          8d3a7dfb8 2024-02-21 KVM: arm64: vgic-its: Test for valid IRQ in its_sync_lpi_pending_table()  ~ d81e2dc20 2024-03-01
          f779d2c01 2024-02-01 KVM: arm64: vgic-its: fix kernel-doc warnings
        > ad362fe07 2024-01-04 KVM: arm64: vgic-its: Avoid potential UAF in LPI translation cache        ~ 12c2759ab 2024-01-25
          d455d366c 2023-09-30 KVM: arm64: vgic-its: Treat the collection target address as a vcpu_id
          9cf2f840c 2023-05-19 KVM: arm64: vgic: Wrap vgic_its_create() with config_lock
          49e5d16b6 2023-04-12 KVM: arm64: vgic: Don't acquire its_lock before config_lock
          f00327731 2023-03-29 KVM: arm64: Use config_lock to protect vgic state
          a23eaf936 2023-01-29 KVM: arm64: Add helper vgic_write_guest_lock()
          9cb1096f8 2022-11-10 KVM: arm64: Enable ring-based dirty memory tracking
          c000a2607 2022-10-15 KVM: arm64: vgic: Fix exit condition in scan_its_table()                  ~ 1e4e71f9e 2022-10-29
          096560dd1 2022-09-26 KVM: arm64: vgic: Remove duplicate check in update_affinity_collection()
          8c5e74c90 2022-05-16 KVM: arm64: vgic: Undo work in failed ITS restores
          a1ccfd6f6 2022-05-16 KVM: arm64: vgic: Do not ignore vgic_its_restore_cte failures
          243b1f6c8 2022-05-16 KVM: arm64: vgic: Add more checks when restoring ITS tables
          cafe7e544 2022-05-16 KVM: arm64: vgic: Check that new ITEs could be saved in guest memory
          4645d11f4 2022-05-04 KVM: arm64: vgic-v3: Implement MMIO-based LPI invalidation
          94828468a 2022-05-04 KVM: arm64: vgic-v3: Expose GICR_CTLR.RWP when disabling LPIs
          c707663e8 2022-04-06 KVM: arm64: vgic: Remove unnecessary type castings
          3ef231670 2021-10-17 KVM: arm64: vgic: Add memcg accounting to vgic allocations
          2ec02f6c6 2021-10-11 KVM: arm64: vgic-v3: Check ITS region is not above the VM IPA size
          4f0f586bf 2021-04-08 treewide: Change list_sort to use const pointers                          = 4f0f586bf 2021-04-08
          8082d50f4 2021-03-24 KVM: arm64: GICv4.1: Give a chance to save VLPI state                     = 8082d50f4 2021-03-24
          a47dee551 2020-07-05 KVM: arm64: Allow in-atomic injection of SPIs                             = a47dee551 2020-07-05  ~ b8cb8b91b 2024-09-11
          9ed24f4b7 2020-05-16 KVM: arm64: Move virt/kvm/arm to arch/arm64                               = 9ed24f4b7 2020-05-16  # a1c405ca1 2024-09-11
    
    The `ciqlts8_6` file's history is virtually the same before the ad362fe07fecf0aba839ff2cc59a3617bd42c33f patch as that of `linux-5.15.y`, sans three unrelated commits.
3.  The racing "DISCARD command" mentioned in the mainline's fix ad362fe07fecf0aba839ff2cc59a3617bd42c33f message can be found in `ciqlts8_6`'s version of the `arch/arm64/kvm/vgic/vgic-its.c` file: <https://github.com/ctrliq/kernel-src-tree/blob/a2c9ebdfa3e2fbca16708fb77322dcd917a6a713/arch/arm64/kvm/vgic/vgic-its.c#L848-L853>

The similarity argument (2) along with the appeal-to-authority (1) only makes sense if the prerequisites for the UAF scenario are contained within the `arch/arm64/kvm/vgic/vgic-its.c` file, but this, in turn, is strongly suggested by (3).

These arguments are heuristic, but fully understanding the potential UAF scenario described in the bug and checking `ciqlts8_6`'s code against it would be prohibitively time consuming.


# Solution

The mainline fix ad362fe07fecf0aba839ff2cc59a3617bd42c33f applies without any changes.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-2024-26598 ./ninja.sh _kabi_checked__aarch64--test--ciqlts8_6-CVE-2024-26598

    [0/1] Check ABI of kernel [ciqlts8_6-CVE-2024-26598]
    ++ uname -m
    + python3 /home/pvts/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /home/pvts/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_aarch64 -s vms/aarch64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2024-26598/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2024-26598/aarch64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21518999/boot-test.log>)


# Kselftests: passed relative

The tests were run on the same platform as those for `ciqlts9_2` in <https://github.com/ctrliq/kernel-src-tree/pull/454>. Regarding the `kvm:*` tests collection the exact same issue applies here as well - see <https://github.com/ctrliq/kernel-src-tree/pull/454> for details.


## Coverage

Including the eventually omitted tests.

`breakpoints` (except `breakpoint_test`, `step_after_suspend_test`), `capabilities`, `core`, `cpu-hotplug`, `cpufreq`, `efivarfs`, `exec`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `ipc`, `kcmp`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mount`, `net/forwarding` (except `sch_ets.sh`, `mirror_gre_vlan_bridge_1q.sh`, `ipip_hier_gre_keys.sh`, `sch_tbf_ets.sh`, `sch_tbf_prio.sh`, `mirror_gre_bridge_1d_vlan.sh`, `tc_actions.sh`, `sch_tbf_root.sh`), `net/mptcp` (except `mptcp_join.sh`, `simult_flows.sh`), `net` (except `ip_defrag.sh`, `udpgro_fwd.sh`, `reuseport_addr_any.sh`, `gro.sh`, `txtimestamp.sh`, `xfrm_policy.sh`, `udpgso_bench.sh`), `netfilter` (except `nft_trans_stress.sh`), `nsfs`, `proc` (except `setns-dcache`), `pstore`, `ptrace`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `tc-testing`, `timens`, `timers` (except `raw_skew`), `tpm2`, `vm`, `zram`.


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/21518998/kselftests--ciqlts8_6--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/21518997/kselftests--ciqlts8_6--run2.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2024-26598&#x2013;run1.log](<https://github.com/user-attachments/files/21518996/kselftests--ciqlts8_6-CVE-2024-26598--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2024-26598&#x2013;run2.log](<https://github.com/user-attachments/files/21518995/kselftests--ciqlts8_6-CVE-2024-26598--run2.log>)


## Comparison

The tests results for the reference kernel and the patch are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6--run2.log
    Status2   kselftests--ciqlts8_6-CVE-2024-26598--run1.log
    Status3   kselftests--ciqlts8_6-CVE-2024-26598--run2.log


# Specific tests: skipped

