### PR TITLE
[LTS 92] Bluetooth: Fix double free in hci_conn_cleanup

### DIFF
--- a/net/bluetooth/hci_conn.c
+++ b/net/bluetooth/hci_conn.c
@@ -144,13 +144,11 @@ static void hci_conn_cleanup(struct hci_conn *conn)
 			hdev->notify(hdev, HCI_NOTIFY_CONN_DEL);
 	}
 
-	hci_conn_del_sysfs(conn);
-
 	debugfs_remove_recursive(conn->debugfs);
 
-	hci_dev_put(hdev);
+	hci_conn_del_sysfs(conn);
 
-	hci_conn_put(conn);
+	hci_dev_put(hdev);
 }
 
 static void le_scan_cleanup(struct work_struct *work)

--- a/net/bluetooth/hci_sysfs.c
+++ b/net/bluetooth/hci_sysfs.c
@@ -33,7 +33,7 @@ void hci_conn_init_sysfs(struct hci_conn *conn)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("conn %p", conn);
+	bt_dev_dbg(hdev, "conn %p", conn);
 
 	conn->dev.type = &bt_link;
 	conn->dev.class = bt_class;
@@ -46,24 +46,27 @@ void hci_conn_add_sysfs(struct hci_conn *conn)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("conn %p", conn);
+	bt_dev_dbg(hdev, "conn %p", conn);
 
 	dev_set_name(&conn->dev, "%s:%d", hdev->name, conn->handle);
 
-	if (device_add(&conn->dev) < 0) {
+	if (device_add(&conn->dev) < 0)
 		bt_dev_err(hdev, "failed to register connection device");
-		return;
-	}
-
-	hci_dev_hold(hdev);
 }
 
 void hci_conn_del_sysfs(struct hci_conn *conn)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	if (!device_is_registered(&conn->dev))
+	bt_dev_dbg(hdev, "conn %p", conn);
+
+	if (!device_is_registered(&conn->dev)) {
+		/* If device_add() has *not* succeeded, use *only* put_device()
+		 * to drop the reference count.
+		 */
+		put_device(&conn->dev);
 		return;
+	}
 
 	while (1) {
 		struct device *dev;
@@ -75,9 +78,7 @@ void hci_conn_del_sysfs(struct hci_conn *conn)
 		put_device(dev);
 	}
 
-	device_del(&conn->dev);
-
-	hci_dev_put(hdev);
+	device_unregister(&conn->dev);
 }
 
 static void bt_host_release(struct device *dev)


### PR DESCRIPTION
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-334
cve CVE-2023-28464
commit-author ZhengHan Wang <wzhmmmmm@gmail.com>
commit a85fb91e3d728bdfc80833167e8162cce8bc7004

syzbot reports a slab use-after-free in hci_conn_hash_flush [1]. After releasing an object using hci_conn_del_sysfs in the hci_conn_cleanup function, releasing the same object again using the hci_dev_put and hci_conn_put functions causes a double free. Here's a simplified flow:

hci_conn_del_sysfs:
  hci_dev_put
    put_device
      kobject_put
        kref_put
          kobject_release
            kobject_cleanup
              kfree_const
                kfree(name)

hci_dev_put:
  ...
    kfree(name)

hci_conn_put:
  put_device
    ...
      kfree(name)

This patch drop the hci_dev_put and hci_conn_put function call in hci_conn_cleanup function, because the object is freed in hci_conn_del_sysfs function.

This patch also fixes the refcounting in hci_conn_add_sysfs() and hci_conn_del_sysfs() to take into account device_add() failures.

This fixes CVE-2023-28464.

Link: https://syzkaller.appspot.com/bug?id=1bb51491ca5df96a5f724899d1dbb87afda61419 [1]

	Signed-off-by: ZhengHan Wang <wzhmmmmm@gmail.com>
Co-developed-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
	Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
(cherry picked from commit a85fb91e3d728bdfc80833167e8162cce8bc7004)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 2s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-ajain__ciqlts9_2-99484019c"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  [--snip--]
  STRIP   /lib/modules/5.14.0-ajain__ciqlts9_2-99484019c+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain__ciqlts9_2-99484019c+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-ajain__ciqlts9_2-99484019c+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain__ciqlts9_2-99484019c+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-ajain__ciqlts9_2-99484019c+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain__ciqlts9_2-99484019c+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain__ciqlts9_2-99484019c+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain__ciqlts9_2-99484019c+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-ajain__ciqlts9_2-99484019c+
[TIMER]{MODULES}: 15s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-ajain__ciqlts9_2-99484019c+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 37s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-ajain__ciqlts9_2-f85f16c42+ and Index to 5
The default is /boot/loader/entries/65b5ae363fe94129b0075258ce5a010a-5.14.0-ajain__ciqlts9_2-f85f16c42+.conf with index 5 and kernel /boot/vmlinuz-5.14.0-ajain__ciqlts9_2-f85f16c42+
The default is /boot/loader/entries/65b5ae363fe94129b0075258ce5a010a-5.14.0-ajain__ciqlts9_2-f85f16c42+.conf with index 5 and kernel /boot/vmlinuz-5.14.0-ajain__ciqlts9_2-f85f16c42+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 2s
[TIMER]{BUILD}: 2920s
[TIMER]{MODULES}: 15s
[TIMER]{INSTALL}: 37s
[TIMER]{TOTAL} 2978s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21532306/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
319
319
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
65
65
```
[kselftest-after.log](https://github.com/user-attachments/files/21532308/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21532312/kselftest-before.log)
