### PR TITLE
[lts92] net/tipc: fix slab-use-after-free Read in tipc_aead_encrypt_done

### DIFF
--- a/net/tipc/crypto.c
+++ b/net/tipc/crypto.c
@@ -817,12 +817,16 @@ static int tipc_aead_encrypt(struct tipc_aead *aead, struct sk_buff *skb,
 		goto exit;
 	}
 
+	/* Get net to avoid freed tipc_crypto when delete namespace */
+	get_net(aead->crypto->net);
+
 	/* Now, do encrypt */
 	rc = crypto_aead_encrypt(req);
 	if (rc == -EINPROGRESS || rc == -EBUSY)
 		return rc;
 
 	tipc_bearer_put(b);
+	put_net(aead->crypto->net);
 
 exit:
 	kfree(ctx);
@@ -860,6 +864,7 @@ static void tipc_aead_encrypt_done(struct crypto_async_request *base, int err)
 	kfree(tx_ctx);
 	tipc_bearer_put(b);
 	tipc_aead_put(aead);
+	put_net(net);
 }
 
 /**


### PR DESCRIPTION
jira VULN-70868
cve CVE-2025-38052

```
commit-author Wang Liang <wangliang74@huawei.com>
commit e279024617134c94fd3e37470156534d5f2b3472

Syzbot reported a slab-use-after-free with the following call trace:

  ==================================================================
  BUG: KASAN: slab-use-after-free in tipc_aead_encrypt_done+0x4bd/0x510 net/tipc/crypto.c:840
  Read of size 8 at addr ffff88807a733000 by task kworker/1:0/25

  Call Trace:
   kasan_report+0xd9/0x110 mm/kasan/report.c:601
   tipc_aead_encrypt_done+0x4bd/0x510 net/tipc/crypto.c:840
   crypto_request_complete include/crypto/algapi.h:266
   aead_request_complete include/crypto/internal/aead.h:85
   cryptd_aead_crypt+0x3b8/0x750 crypto/cryptd.c:772
   crypto_request_complete include/crypto/algapi.h:266
   cryptd_queue_worker+0x131/0x200 crypto/cryptd.c:181
   process_one_work+0x9fb/0x1b60 kernel/workqueue.c:3231

  Allocated by task 8355:
   kzalloc_noprof include/linux/slab.h:778
   tipc_crypto_start+0xcc/0x9e0 net/tipc/crypto.c:1466
   tipc_init_net+0x2dd/0x430 net/tipc/core.c:72
   ops_init+0xb9/0x650 net/core/net_namespace.c:139
   setup_net+0x435/0xb40 net/core/net_namespace.c:343
   copy_net_ns+0x2f0/0x670 net/core/net_namespace.c:508
   create_new_namespaces+0x3ea/0xb10 kernel/nsproxy.c:110
   unshare_nsproxy_namespaces+0xc0/0x1f0 kernel/nsproxy.c:228
   ksys_unshare+0x419/0x970 kernel/fork.c:3323
   __do_sys_unshare kernel/fork.c:3394

  Freed by task 63:
   kfree+0x12a/0x3b0 mm/slub.c:4557
   tipc_crypto_stop+0x23c/0x500 net/tipc/crypto.c:1539
   tipc_exit_net+0x8c/0x110 net/tipc/core.c:119
   ops_exit_list+0xb0/0x180 net/core/net_namespace.c:173
   cleanup_net+0x5b7/0xbf0 net/core/net_namespace.c:640
   process_one_work+0x9fb/0x1b60 kernel/workqueue.c:3231

After freed the tipc_crypto tx by delete namespace, tipc_aead_encrypt_done may still visit it in cryptd_queue_worker workqueue.

I reproduce this issue by:
  ip netns add ns1
  ip link add veth1 type veth peer name veth2
  ip link set veth1 netns ns1
  ip netns exec ns1 tipc bearer enable media eth dev veth1
  ip netns exec ns1 tipc node set key this_is_a_master_key master
  ip netns exec ns1 tipc bearer disable media eth dev veth1
  ip netns del ns1

The key of reproduction is that, simd_aead_encrypt is interrupted, leading to crypto_simd_usable() return false. Thus, the cryptd_queue_worker is triggered, and the tipc_crypto tx will be visited.

  tipc_disc_timeout
    tipc_bearer_xmit_skb
      tipc_crypto_xmit
        tipc_aead_encrypt
          crypto_aead_encrypt
            // encrypt()
            simd_aead_encrypt
              // crypto_simd_usable() is false
              child = &ctx->cryptd_tfm->base;

  simd_aead_encrypt
    crypto_aead_encrypt
      // encrypt()
      cryptd_aead_encrypt_enqueue
        cryptd_aead_enqueue
          cryptd_enqueue_request
            // trigger cryptd_queue_worker
            queue_work_on(smp_processor_id(), cryptd_wq, &cpu_queue->work)

Fix this by holding net reference count before encrypt.

	Reported-by: syzbot+55c12726619ff85ce1f6@syzkaller.appspotmail.com
Closes: https://syzkaller.appspot.com/bug?extid=55c12726619ff85ce1f6
Fixes: fc1b6d6de220 ("tipc: introduce TIPC encryption & authentication")
	Signed-off-by: Wang Liang <wangliang74@huawei.com>
Link: https://patch.msgid.link/20250520101404.1341730-1-wangliang74@huawei.com
	Signed-off-by: Paolo Abeni <pabeni@redhat.com>

(cherry picked from commit e279024617134c94fd3e37470156534d5f2b3472)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 12s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
--
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  BTF [M] sound/xen/snd_xen_front.ko
  BTF [M] sound/virtio/virtio_snd.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 918s
Making Modules
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
--
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+
[TIMER]{MODULES}: 8s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 56s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 12s
[TIMER]{BUILD}: 918s
[TIMER]{MODULES}: 8s
[TIMER]{INSTALL}: 56s
[TIMER]{TOTAL} 1012s
Rebooting in 10 seconds

```

### Testing

[selftest-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.x86_64.log](https://github.com/user-attachments/files/21534714/selftest-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.x86_64.log)

[selftest-5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+.log](https://github.com/user-attachments/files/21534716/selftest-5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0%2B.log)

```
brett@lycia ~/ciq/vuln-70868 % grep ^ok selftest-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.x86_64.log | wc -l
297
brett@lycia ~/ciq/vuln-70868 % grep ^ok selftest-5.14.0-bmastbergen_ciqlts9_2_VULN-70868-a8bf40461ae0+.log | wc -l
296
brett@lycia ~/ciq/vuln-70868 %

```