### PR TITLE
[CBR-79] kbuild: fix error when building from src rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1208,6 +1208,7 @@ help:
 	@echo  '  gtags           - Generate GNU GLOBAL index'
 	@echo  '  kernelrelease	  - Output the release version string'
 	@echo  '  kernelversion	  - Output the version stored in Makefile'
+	@echo  '  image_name	  - Output the image name'
 	@echo  '  headers_install - Install sanitised kernel headers to INSTALL_HDR_PATH'; \
 	 echo  '                    (default: $(INSTALL_HDR_PATH))'; \
 	 echo  ''
@@ -1402,7 +1403,7 @@ export_report:
 endif #ifeq ($(config-targets),1)
 endif #ifeq ($(mixed-targets),1)
 
-PHONY += checkstack kernelrelease kernelversion
+PHONY += checkstack kernelrelease kernelversion image_name
 
 # UML needs a little special treatment here.  It wants to use the host
 # toolchain, so needs $(SUBARCH) passed to checkstack.pl.  Everyone
@@ -1422,6 +1423,9 @@ kernelrelease:
 
 kernelversion:
 	@echo $(KERNELVERSION)
+
+image_name:
+	@echo $(KBUILD_IMAGE)
 
 # Clear a bunch of variables before executing the submake
 tools/: FORCE

--- a/scripts/package/mkspec
+++ b/scripts/package/mkspec
@@ -74,6 +74,7 @@ echo ""
 fi
 
 echo "%install"
+echo 'KBUILD_IMAGE=$(make image_name)'
 echo "%ifarch ia64"
 echo 'mkdir -p $RPM_BUILD_ROOT/boot/efi $RPM_BUILD_ROOT/lib/modules'
 echo 'mkdir -p $RPM_BUILD_ROOT/lib/firmware'


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
commit-author Mike Marciniszyn <mike.marciniszyn@intel.com> commit c398ff00f55d56bec8eb116e9ad3d226998230fa

The following issue can be reproduced with Linus' tree on an x86_64 server.

>+ cp /home/user/rpmbuild-test/BUILDROOT/kernel-3.9.2.x86_64/boot/vmlinuz-3.9.2
>cp: missing destination file operand after
>/home/user/rpmbuild-test/BUILDROOT/kernel-3.9.2-1.x86_64/boot/vmlinuz-3.9.2'
>Try `cp --help' for more information.
>error: Bad exit status from /var/tmp/rpm-tmp.R4o0iI (%install)

Here are the commands to reproduce:

make defconfig
make rpm-pkg

Use the resulting src rpm to build as follows:

mkdir ~/rpmbuild-test
cd ~/rpmbuild-test
rpmbuild --rebuild --define "_topdir `pwd`" -vv ~/rpmbuild/SRPMS/kernel-3.10.0_rc1+-1.src.rpm

The issue is because the %install script uses $KBUILD_IMAGE and it hasn't been set since it is only available in the kbuild system and not in the %install script.

This patch adds a Makefile target to emit the image_name that can be used and modifies the mkspec to use the dynamic name in %install.

	Signed-off-by: Mike Marciniszyn <mike.marciniszyn@intel.com>
	Signed-off-by: Michal Marek <mmarek@suse.cz>
(cherry picked from commit c398ff00f55d56bec8eb116e9ad3d226998230fa)
	Signed-off-by: Pratham Patel <ppatel@ciq.com>
```

### Kernel build logs
```
/home/pratham/kernel/kernel-src-tree
Running make mrproper...
  CLEAN   .
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/vdso
  CLEAN   arch/x86/lib
  CLEAN   crypto/asymmetric_keys
  CLEAN   crypto
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/scsi/aic7xxx
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   firmware
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   security/selinux
  CLEAN   usr
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/tools
  CLEAN   .tmp_versions
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config usr/include include/generated arch/x86/include/generated
  CLEAN   .config .config.old .version include/generated/uapi/linux/version.h Module.symvers signing_key.priv signing_key.x509 x509.genkey
[TIMER]{MRPROPER}: 4s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
Setting Local Version for build
CONFIG_LOCALVERSION="-ppatel_ciqcbr7_9-8a851306"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  SHIPPED scripts/kconfig/zconf.hash.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf --silentoldconfig Kconfig
Makefile:917: "Cannot use CONFIG_STACK_VALIDATION, please install libelf-dev or elfutils-libelf-devel"
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_x32.h
  SYSHDR  arch/x86/syscalls/../include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/syscalls/../include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_64.h
  HOSTCC  scripts/basic/bin2c
  WRAP    arch/x86/include/generated/asm/clkdev.h
  WRAP    arch/x86/include/generated/asm/mm-arch-hooks.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  CHK     include/generated/uapi/linux/version.h
  UPD     include/generated/uapi/linux/version.h
  CHK     include/generated/utsrelease.h
  UPD     include/generated/utsrelease.h
  CHK     include/generated/qrwlock.h
  UPD     include/generated/qrwlock.h
  CHK     include/generated/qrwlock_api_smp.h
  UPD     include/generated/qrwlock_api_smp.h
  CHK     include/generated/qrwlock_types.h
  UPD     include/generated/qrwlock_types.h
  CHK     kernel/qrwlock_gen.c
  CHK     lib/qrwlock_debug.c
  HOSTCC  scripts/kallsyms
[---snip---]
  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-ppatel_ciqcbr7_9-8a851306+
[TIMER]{MODULES}: 9s
Making Install
Makefile:917: "Cannot use CONFIG_STACK_VALIDATION, please install libelf-dev or elfutils-libelf-devel"
sh ./arch/x86/boot/install.sh 3.10.0-ppatel_ciqcbr7_9-8a851306+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 9s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-8a851306+ and Index to 0
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-3.10.0-ppatel-batch-fixes-3174a95+
Found initrd image: /boot/initramfs-3.10.0-ppatel-batch-fixes-3174a95+.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel-batch-fixes-99df3fb+
Found initrd image: /boot/initramfs-3.10.0-ppatel-batch-fixes-99df3fb+.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel-batch-fixes-3f61ae9+
Found initrd image: /boot/initramfs-3.10.0-ppatel-batch-fixes-3f61ae9+.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel-batch-fixes-eb6d966+
Found initrd image: /boot/initramfs-3.10.0-ppatel-batch-fixes-eb6d966+.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel-batch-fixes-ca78f82+
Found initrd image: /boot/initramfs-3.10.0-ppatel-batch-fixes-ca78f82+.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel-batch-fixes-c7d0dc7+
Found initrd image: /boot/initramfs-3.10.0-ppatel-batch-fixes-c7d0dc7+.img
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7_9.ciqcbr.5.1.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7_9.ciqcbr.5.1.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-1160.119.1.el7.x86_64
Found initrd image: /boot/initramfs-3.10.0-1160.119.1.el7.x86_64.img
Found linux image: /boot/vmlinuz-3.10.0-ppatel_ciqcbr7_9-8a851306+
Found initrd image: /boot/initramfs-3.10.0-ppatel_ciqcbr7_9-8a851306+.img
Found linux image: /boot/vmlinuz-3.10.0-ciqcbr7_9-9a8dee3+
Found initrd image: /boot/initramfs-3.10.0-ciqcbr7_9-9a8dee3+.img
Found linux image: /boot/vmlinuz-0-rescue-328d40a8e41d44d58d4196f842cdb6e5
Found initrd image: /boot/initramfs-0-rescue-328d40a8e41d44d58d4196f842cdb6e5.img
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 4s
[TIMER]{BUILD}: 434s
[TIMER]{MODULES}: 9s
[TIMER]{INSTALL}: 9s
[TIMER]{TOTAL} 461s
Rebooting in 10 seconds
```
[build.log](https://github.com/user-attachments/files/21535400/build.log)

### Kselftests
```
$ grep '^ok ' ../logs/kselftest-before.log | wc -l && grep '^ok ' ../logs/kselftest-after.log | wc -l
2
2

$ grep '^not ok ' ../logs/kselftest-before.log | wc -l && grep '^not ok ' ../logs/kselftest-after.log | wc -l
5
5
```
[kselftest-before.log](https://github.com/user-attachments/files/21535396/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21535397/kselftest-after.log)