### PR TITLE
[fips 9.2] netfilter: nf_tables: skip bound chain on rule flush

### DIFF
--- a/net/netfilter/nf_tables_api.c
+++ b/net/netfilter/nf_tables_api.c
@@ -3729,6 +3729,8 @@ static int nf_tables_delrule(struct sk_buff *skb, const struct nfnl_info *info,
 		list_for_each_entry(chain, &table->chains, list) {
 			if (!nft_is_active_next(net, chain))
 				continue;
+			if (nft_chain_is_bound(chain))
+				continue;
 
 			ctx.chain = chain;
 			err = nft_delrule_by_chain(&ctx);


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-8826
cve CVE-2023-3777
commit-author Pablo Neira Ayuso <pablo@netfilter.org> commit 6eaf41e87a223ae6f8e7a28d6e78384ad7e407f8

Skip bound chain when flushing table rules, the rule that owns this chain releases these objects.

Otherwise, the following warning is triggered:

  WARNING: CPU: 2 PID: 1217 at net/netfilter/nf_tables_api.c:2013 nf_tables_chain_destroy+0x1f7/0x210 [nf_tables]
  CPU: 2 PID: 1217 Comm: chain-flush Not tainted 6.1.39 #1
  RIP: 0010:nf_tables_chain_destroy+0x1f7/0x210 [nf_tables]

Fixes: d0e2c7de92c7 ("netfilter: nf_tables: add NFT_CHAIN_BINDING")
	Reported-by: Kevin Rich <kevinrich1337@gmail.com>
	Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
	Signed-off-by: Florian Westphal <fw@strlen.de>
(cherry picked from commit 6eaf41e87a223ae6f8e7a28d6e78384ad7e407f8)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 2s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
[--snip--]
snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb+
[TIMER]{MODULES}: 15s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-408d794fb+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 37s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-c624b962d+ and Index to 2
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-c624b962d+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-c624b962d+
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-c624b962d+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-ajain__fips-9-compliant_5.14.0-284.30.1-c624b962d+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 2s
[TIMER]{BUILD}: 2929s
[TIMER]{MODULES}: 15s
[TIMER]{INSTALL}: 37s
[TIMER]{TOTAL} 2987s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21551860/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
300
316
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
68
67
```
[kselftest-after.log](https://github.com/user-attachments/files/21551857/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21551858/kselftest-before.log)

