### PR TITLE
[fips-9-compliant] perf: Disallow mis-matched inherited group reads

### DIFF
--- a/include/linux/perf_event.h
+++ b/include/linux/perf_event.h
@@ -61,6 +61,7 @@ struct perf_guest_info_callbacks {
 #include <linux/security.h>
 #include <linux/static_call.h>
 #include <linux/lockdep.h>
+#include <linux/rh_kabi.h>
 #include <asm/local.h>
 
 struct perf_callchain_entry {
@@ -803,6 +804,8 @@ struct perf_event {
 	void *security;
 #endif
 	struct list_head		sb_list;
+
+	RH_KABI_EXTEND(unsigned int	group_generation)
 #endif /* CONFIG_PERF_EVENTS */
 };
 

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -13143,7 +13143,8 @@ static int inherit_group(struct perf_event *parent_event,
 		    !perf_get_aux_event(child_ctr, leader))
 			return -EINVAL;
 	}
-	leader->group_generation = parent_event->group_generation;
+	if (leader)
+		leader->group_generation = parent_event->group_generation;
 	return 0;
 }
 

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -1956,6 +1956,7 @@ static void perf_group_attach(struct perf_event *event)
 
 	list_add_tail(&event->sibling_list, &group_leader->sibling_list);
 	group_leader->nr_siblings++;
+	group_leader->group_generation++;
 
 	perf_event__header_size(group_leader);
 
@@ -2150,6 +2151,7 @@ static void perf_group_detach(struct perf_event *event)
 	if (leader != event) {
 		list_del_init(&event->sibling_list);
 		event->group_leader->nr_siblings--;
+		event->group_leader->group_generation++;
 		goto out;
 	}
 
@@ -5239,7 +5241,7 @@ static int __perf_read_group_add(struct perf_event *leader,
 					u64 read_format, u64 *values)
 {
 	struct perf_event_context *ctx = leader->ctx;
-	struct perf_event *sub;
+	struct perf_event *sub, *parent;
 	unsigned long flags;
 	int n = 1; /* skip @nr */
 	int ret;
@@ -5249,6 +5251,33 @@ static int __perf_read_group_add(struct perf_event *leader,
 		return ret;
 
 	raw_spin_lock_irqsave(&ctx->lock, flags);
+	/*
+	 * Verify the grouping between the parent and child (inherited)
+	 * events is still in tact.
+	 *
+	 * Specifically:
+	 *  - leader->ctx->lock pins leader->sibling_list
+	 *  - parent->child_mutex pins parent->child_list
+	 *  - parent->ctx->mutex pins parent->sibling_list
+	 *
+	 * Because parent->ctx != leader->ctx (and child_list nests inside
+	 * ctx->mutex), group destruction is not atomic between children, also
+	 * see perf_event_release_kernel(). Additionally, parent can grow the
+	 * group.
+	 *
+	 * Therefore it is possible to have parent and child groups in a
+	 * different configuration and summing over such a beast makes no sense
+	 * what so ever.
+	 *
+	 * Reject this.
+	 */
+	parent = leader->parent;
+	if (parent &&
+	    (parent->group_generation != leader->group_generation ||
+	     parent->nr_siblings != leader->nr_siblings)) {
+		ret = -ECHILD;
+		goto unlock;
+	}
 
 	/*
 	 * Since we co-schedule groups, {enabled,running} times of siblings
@@ -5282,8 +5311,9 @@ static int __perf_read_group_add(struct perf_event *leader,
 			values[n++] = atomic64_read(&sub->lost_samples);
 	}
 
+unlock:
 	raw_spin_unlock_irqrestore(&ctx->lock, flags);
-	return 0;
+	return ret;
 }
 
 static int perf_read_group(struct perf_event *event,
@@ -5302,10 +5332,6 @@ static int perf_read_group(struct perf_event *event,
 
 	values[0] = 1 + leader->nr_siblings;
 
-	/*
-	 * By locking the child_mutex of the leader we effectively
-	 * lock the child list of all siblings.. XXX explain how.
-	 */
 	mutex_lock(&leader->child_mutex);
 
 	ret = __perf_read_group_add(leader, read_format, values);
@@ -13117,6 +13143,7 @@ static int inherit_group(struct perf_event *parent_event,
 		    !perf_get_aux_event(child_ctr, leader))
 			return -EINVAL;
 	}
+	leader->group_generation = parent_event->group_generation;
 	return 0;
 }
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-8891
cve CVE-2023-5717
commit-author Peter Zijlstra <peterz@infradead.org>
commit https://github.com/ctrliq/kernel-src-tree/commit/32671e3799ca2e4590773fd0e63aaa4229e50c06
upstream-diff This patch causes kABI breakage due to a change in the
struct perf_event layout after adding the group_generation field.
Hence, to preserve kABI compatibility, use RH_KABI_EXTEND macro
to safely append the new field without affecting the existing layout.

Because group consistency is non-atomic between parent (filedesc) and children
(inherited) events, it is possible for PERF_FORMAT_GROUP read() to try and sum
non-matching counter groups -- with non-sensical results.

Add group_generation to distinguish the case where a parent group removes and
adds an event and thus has the same number, but a different configuration of
events as inherited groups.

This became a problem when commit https://github.com/ctrliq/kernel-src-tree/commit/fa8c269353d560b7c28119ad7617029f92e40b15 ("perf/core: Invert
perf_read_group() loops") flipped the order of child_list and sibling_list.
Previously it would iterate the group (sibling_list) first, and for each
sibling traverse the child_list. In this order, only the group composition of
the parent is relevant. By flipping the order the group composition of the
child (inherited) events becomes an issue and the mis-match in group
composition becomes evident.

That said; even prior to this commit, while reading of a group that is not
equally inherited was not broken, it still made no sense.

(Ab)use ECHILD as error return to indicate issues with child process group
composition.

Fixes: https://github.com/ctrliq/kernel-src-tree/commit/fa8c269353d560b7c28119ad7617029f92e40b15 ("perf/core: Invert perf_read_group() loops")
	Reported-by: Budimir Markovic <markovicbudimir@gmail.com>
	Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
Link: https://lkml.kernel.org/r/20231018115654.GK33217@noisy.programming.kicks-ass.net
(cherry picked from commit https://github.com/ctrliq/kernel-src-tree/commit/32671e3799ca2e4590773fd0e63aaa4229e50c06)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>

Note :-
Above upstream patch has a NULL pointer deref issue, hence we added https://github.com/ctrliq/kernel-src-tree/commit/28a6c6e2cece9b3490c1ee8612559118cea2fddb ("perf/core: Fix potential NULL deref") to avoid any regression.

-------------------------------------------------------------------------------------------------------
perf/core: Fix potential NULL deref

jira VULN-8891
cve-bf CVE-2023-5717
commit-author Peter Zijlstra <peterz@infradead.org>
commit https://github.com/ctrliq/kernel-src-tree/commit/a71ef31485bb51b846e8db8b3a35e432cc15afb5

Smatch is awesome.

Fixes: https://github.com/ctrliq/kernel-src-tree/commit/32671e3799ca2e4590773fd0e63aaa4229e50c06 ("perf: Disallow mis-matched inherited group reads")
	Reported-by: Dan Carpenter <dan.carpenter@linaro.org>
	Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
	Signed-off-by: Ingo Molnar <mingo@kernel.org>
(cherry picked from commit https://github.com/ctrliq/kernel-src-tree/commit/a71ef31485bb51b846e8db8b3a35e432cc15afb5)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>
```

### Kernel build logs
```
/mnt/scratch/workspace/fips-9-compliant/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 5s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  <--snip-->
  STRIP   /lib/modules/5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+/kernel/sound/virtio/virtio_snd.ko
  DEPMOD  /lib/modules/5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+
[TIMER]{MODULES}: 11s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 20s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+ and Index to 2
The default is /boot/loader/entries/809410938d1447fc931cf787fb714082-5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+
The default is /boot/loader/entries/809410938d1447fc931cf787fb714082-5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-shreeya_fips-9-compliant_5.14.0-284.30.1-020b04cbbbeb+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 1326s
[TIMER]{MODULES}: 11s
[TIMER]{INSTALL}: 20s
[TIMER]{TOTAL} 1367s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21580886/kernel-build.log)


### Kselftests

```
shreeya@spatel-dev-bom:~/ciq/workspace/fips-9-compliant$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
290
291
shreeya@spatel-dev-bom:~/ciq/workspace/fips-9-compliant$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
68
67
```
[kselftest-after.log](https://github.com/user-attachments/files/21580948/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21580950/kselftest-before.log)


