### PR TITLE
[LTS 9.2] NFSD: fix use-after-free in nfsd4_ssc_setup_dul()

### DIFF
--- a/fs/nfsd/nfs4proc.c
+++ b/fs/nfsd/nfs4proc.c
@@ -1328,6 +1328,7 @@ try_again:
 			/* allow 20secs for mount/unmount for now - revisit */
 			if (signal_pending(current) ||
 					(schedule_timeout(20*HZ) == 0)) {
+				finish_wait(&nn->nfsd_ssc_waitq, &wait);
 				kfree(work);
 				return nfserr_eagain;
 			}


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-8056
cve CVE-2023-1652
commit-author Xingyuan Mo <hdthky0@gmail.com>
commit e6cf91b7b47ff82b624bdfe2fdcde32bb52e71dd

If signal_pending() returns true, schedule_timeout() will not be executed, causing the waiting task to remain in the wait queue. Fixed by adding a call to finish_wait(), which ensures that the waiting task will always be removed from the wait queue.

Fixes: f4e44b393389 ("NFSD: delay unmount source's export after inter-server copy completed.")
	Signed-off-by: Xingyuan Mo <hdthky0@gmail.com>
	Reviewed-by: Jeff Layton <jlayton@kernel.org>
	Signed-off-by: Chuck Lever <chuck.lever@oracle.com>
(cherry picked from commit e6cf91b7b47ff82b624bdfe2fdcde32bb52e71dd)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 3s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-ajain_ciqlts9_2-c24767756"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  [--snip--]
    STRIP   /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-ajain_ciqlts9_2-c24767756+
[TIMER]{MODULES}: 15s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-ajain_ciqlts9_2-c24767756+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 37s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-ajain_ciqlts9_2-c24767756+ and Index to 4
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-ajain_ciqlts9_2-c24767756+.conf with index 4 and kernel /boot/vmlinuz-5.14.0-ajain_ciqlts9_2-c24767756+
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-ajain_ciqlts9_2-c24767756+.conf with index 4 and kernel /boot/vmlinuz-5.14.0-ajain_ciqlts9_2-c24767756+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 3s
[TIMER]{BUILD}: 3032s
[TIMER]{MODULES}: 15s
[TIMER]{INSTALL}: 37s
[TIMER]{TOTAL} 3091s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21621485/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
317
317
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
67
67
```
[kselftest-after.log](https://github.com/user-attachments/files/21621488/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21621491/kselftest-before.log)
