### PR TITLE
[FIPS 9.2] NFSD: fix use-after-free in nfsd4_ssc_setup_dul()

### DIFF
--- a/fs/nfsd/nfs4proc.c
+++ b/fs/nfsd/nfs4proc.c
@@ -1328,6 +1328,7 @@ try_again:
 			/* allow 20secs for mount/unmount for now - revisit */
 			if (signal_pending(current) ||
 					(schedule_timeout(20*HZ) == 0)) {
+				finish_wait(&nn->nfsd_ssc_waitq, &wait);
 				kfree(work);
 				return nfserr_eagain;
 			}


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-8797
cve CVE-2023-1652
commit-author Xingyuan Mo <hdthky0@gmail.com>
commit e6cf91b7b47ff82b624bdfe2fdcde32bb52e71dd

If signal_pending() returns true, schedule_timeout() will not be executed, causing the waiting task to remain in the wait queue. Fixed by adding a call to finish_wait(), which ensures that the waiting task will always be removed from the wait queue.

Fixes: f4e44b393389 ("NFSD: delay unmount source's export after inter-server copy completed.")
	Signed-off-by: Xingyuan Mo <hdthky0@gmail.com>
	Reviewed-by: Jeff Layton <jlayton@kernel.org>
	Signed-off-by: Chuck Lever <chuck.lever@oracle.com>
(cherry picked from commit e6cf91b7b47ff82b624bdfe2fdcde32bb52e71dd)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 2s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/x86/include/generated/uapi/asm/param.h
[--snip--]
  SIGN    /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+
[TIMER]{MODULES}: 15s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 37s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+ and Index to 3
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+.conf with index 3 and kernel /boot/vmlinuz-5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+.conf with index 3 and kernel /boot/vmlinuz-5.14.0-ajain_fips-9-compliant_5.14.0-284.30.1-9f97a75bb+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 2s
[TIMER]{BUILD}: 2926s
[TIMER]{MODULES}: 15s
[TIMER]{INSTALL}: 37s
[TIMER]{TOTAL} 2984s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21662905/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
315
317
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
68
66
```
[kselftest-after.log](https://github.com/user-attachments/files/21662906/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21662907/kselftest-before.log)
