### PR TITLE
[LTS 9.4] net: inet: do not leave a dangling sk pointer in inet_create()

### DIFF
--- a/net/ipv4/af_inet.c
+++ b/net/ipv4/af_inet.c
@@ -375,31 +375,29 @@ lookup_protocol:
 		inet->inet_sport = htons(inet->inet_num);
 		/* Add to protocol hash chains. */
 		err = sk->sk_prot->hash(sk);
-		if (err) {
-			sk_common_release(sk);
-			goto out;
-		}
+		if (err)
+			goto out_sk_release;
 	}
 
 	if (sk->sk_prot->init) {
 		err = sk->sk_prot->init(sk);
-		if (err) {
-			sk_common_release(sk);
-			goto out;
-		}
+		if (err)
+			goto out_sk_release;
 	}
 
 	if (!kern) {
 		err = BPF_CGROUP_RUN_PROG_INET_SOCK(sk);
-		if (err) {
-			sk_common_release(sk);
-			goto out;
-		}
+		if (err)
+			goto out_sk_release;
 	}
 out:
 	return err;
 out_rcu_unlock:
 	rcu_read_unlock();
+	goto out;
+out_sk_release:
+	sk_common_release(sk);
+	sock->sk = NULL;
 	goto out;
 }
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-41186
cve CVE-2024-56601
commit-author Ignat Korchagin <ignat@cloudflare.com> commit 9365fa510c6f82e3aa550a09d0c5c6b44dbc78ff

sock_init_data() attaches the allocated sk object to the provided sock object. If inet_create() fails later, the sk object is freed, but the sock object retains the dangling pointer, which may create use-after-free later.

Clear the sk pointer in the sock object on error.

	Signed-off-by: Ignat Korchagin <ignat@cloudflare.com>
	Reviewed-by: Kuniyuki Iwashima <kuniyu@amazon.com>
	Reviewed-by: Eric Dumazet <edumazet@google.com>
Link: https://patch.msgid.link/20241014153808.51894-7-ignat@cloudflare.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 9365fa510c6f82e3aa550a09d0c5c6b44dbc78ff)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-ajain__ciqlts9_4-2ffb830eb"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/x86/include/generated/uapi/asm/param.h
[--snip--]
  SIGN    /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  SIGN    /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/virt/lib/irqbypass.ko
  STRIP   /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-ajain__ciqlts9_4-2ffb830eb+
[TIMER]{MODULES}: 17s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-ajain__ciqlts9_4-2ffb830eb+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 38s
Checking kABI
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-_ajain__ciqlts9_4-b8631ac27+ and Index to 5
The default is /boot/loader/entries/416082e4266e4ec8811b1527df4f2274-5.14.0-_ajain__ciqlts9_4-b8631ac27+.conf with index 5 and kernel /boot/vmlinuz-5.14.0-_ajain__ciqlts9_4-b8631ac27+
The default is /boot/loader/entries/416082e4266e4ec8811b1527df4f2274-5.14.0-_ajain__ciqlts9_4-b8631ac27+.conf with index 5 and kernel /boot/vmlinuz-5.14.0-_ajain__ciqlts9_4-b8631ac27+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 3508s
[TIMER]{MODULES}: 17s
[TIMER]{INSTALL}: 38s
[TIMER]{TOTAL} 3569s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21669731/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
375
375
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
80
80
```
[kselftest-after.log](https://github.com/user-attachments/files/21669733/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21669737/kselftest-before.log)
