### PR TITLE
[fips-legacy-8] perf: Disallow mis-matched inherited group reads

### DIFF
--- a/include/linux/perf_event.h
+++ b/include/linux/perf_event.h
@@ -59,6 +59,7 @@ struct perf_guest_info_callbacks {
 #include <linux/cgroup.h>
 #include <linux/refcount.h>
 #include <linux/security.h>
+#include <linux/rh_kabi.h>
 #include <asm/local.h>
 
 struct perf_callchain_entry {
@@ -811,6 +812,8 @@ struct perf_event {
 	RH_KABI_BROKEN_INSERT(void *security)
 #endif
 	struct list_head		sb_list;
+
+	RH_KABI_EXTEND(unsigned int	group_generation)
 #endif /* CONFIG_PERF_EVENTS */
 };
 

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -13031,7 +13031,8 @@ static int inherit_group(struct perf_event *parent_event,
 		    !perf_get_aux_event(child_ctr, leader))
 			return -EINVAL;
 	}
-	leader->group_generation = parent_event->group_generation;
+	if (leader)
+		leader->group_generation = parent_event->group_generation;
 	return 0;
 }
 

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -2022,6 +2022,7 @@ static void perf_group_attach(struct perf_event *event)
 
 	list_add_tail(&event->sibling_list, &group_leader->sibling_list);
 	group_leader->nr_siblings++;
+	group_leader->group_generation++;
 
 	perf_event__header_size(group_leader);
 
@@ -2216,6 +2217,7 @@ static void perf_group_detach(struct perf_event *event)
 	if (leader != event) {
 		list_del_init(&event->sibling_list);
 		event->group_leader->nr_siblings--;
+		event->group_leader->group_generation++;
 		goto out;
 	}
 
@@ -5282,7 +5284,7 @@ static int __perf_read_group_add(struct perf_event *leader,
 					u64 read_format, u64 *values)
 {
 	struct perf_event_context *ctx = leader->ctx;
-	struct perf_event *sub;
+	struct perf_event *sub, *parent;
 	unsigned long flags;
 	int n = 1; /* skip @nr */
 	int ret;
@@ -5292,6 +5294,33 @@ static int __perf_read_group_add(struct perf_event *leader,
 		return ret;
 
 	raw_spin_lock_irqsave(&ctx->lock, flags);
+	/*
+	 * Verify the grouping between the parent and child (inherited)
+	 * events is still in tact.
+	 *
+	 * Specifically:
+	 *  - leader->ctx->lock pins leader->sibling_list
+	 *  - parent->child_mutex pins parent->child_list
+	 *  - parent->ctx->mutex pins parent->sibling_list
+	 *
+	 * Because parent->ctx != leader->ctx (and child_list nests inside
+	 * ctx->mutex), group destruction is not atomic between children, also
+	 * see perf_event_release_kernel(). Additionally, parent can grow the
+	 * group.
+	 *
+	 * Therefore it is possible to have parent and child groups in a
+	 * different configuration and summing over such a beast makes no sense
+	 * what so ever.
+	 *
+	 * Reject this.
+	 */
+	parent = leader->parent;
+	if (parent &&
+	    (parent->group_generation != leader->group_generation ||
+	     parent->nr_siblings != leader->nr_siblings)) {
+		ret = -ECHILD;
+		goto unlock;
+	}
 
 	/*
 	 * Since we co-schedule groups, {enabled,running} times of siblings
@@ -5321,8 +5350,9 @@ static int __perf_read_group_add(struct perf_event *leader,
 			values[n++] = primary_event_id(sub);
 	}
 
+unlock:
 	raw_spin_unlock_irqrestore(&ctx->lock, flags);
-	return 0;
+	return ret;
 }
 
 static int perf_read_group(struct perf_event *event,
@@ -5341,10 +5371,6 @@ static int perf_read_group(struct perf_event *event,
 
 	values[0] = 1 + leader->nr_siblings;
 
-	/*
-	 * By locking the child_mutex of the leader we effectively
-	 * lock the child list of all siblings.. XXX explain how.
-	 */
 	mutex_lock(&leader->child_mutex);
 
 	ret = __perf_read_group_add(leader, read_format, values);
@@ -13005,6 +13031,7 @@ static int inherit_group(struct perf_event *parent_event,
 		    !perf_get_aux_event(child_ctr, leader))
 			return -EINVAL;
 	}
+	leader->group_generation = parent_event->group_generation;
 	return 0;
 }
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-8890
cve CVE-2023-5717
commit-author Peter Zijlstra <peterz@infradead.org>
commit https://github.com/ctrliq/kernel-src-tree/commit/32671e3799ca2e4590773fd0e63aaa4229e50c06
upstream-diff This patch causes kABI breakage due to a change in the
struct perf_event layout after adding the group_generation field.
Hence, to preserve kABI compatibility, use RH_KABI_EXTEND macro
to safely append the new field without affecting the existing layout.

Because group consistency is non-atomic between parent (filedesc) and children
(inherited) events, it is possible for PERF_FORMAT_GROUP read() to try and sum
non-matching counter groups -- with non-sensical results.

Add group_generation to distinguish the case where a parent group removes and
adds an event and thus has the same number, but a different configuration of
events as inherited groups.

This became a problem when commit https://github.com/ctrliq/kernel-src-tree/commit/fa8c269353d560b7c28119ad7617029f92e40b15 ("perf/core: Invert
perf_read_group() loops") flipped the order of child_list and sibling_list.
Previously it would iterate the group (sibling_list) first, and for each
sibling traverse the child_list. In this order, only the group composition of
the parent is relevant. By flipping the order the group composition of the
child (inherited) events becomes an issue and the mis-match in group
composition becomes evident.

That said; even prior to this commit, while reading of a group that is not
equally inherited was not broken, it still made no sense.

(Ab)use ECHILD as error return to indicate issues with child process group
composition.

Fixes: https://github.com/ctrliq/kernel-src-tree/commit/fa8c269353d560b7c28119ad7617029f92e40b15 ("perf/core: Invert perf_read_group() loops")
	Reported-by: Budimir Markovic <markovicbudimir@gmail.com>
	Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
Link: https://lkml.kernel.org/r/20231018115654.GK33217@noisy.programming.kicks-ass.net
(cherry picked from commit https://github.com/ctrliq/kernel-src-tree/commit/32671e3799ca2e4590773fd0e63aaa4229e50c06)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>
-------------------------------------------------------------------------------------------------------
perf/core: Fix potential NULL deref
jira VULN-8890
cve CVE-2023-5717
commit-author Peter Zijlstra <peterz@infradead.org>
commit https://github.com/ctrliq/kernel-src-tree/commit/a71ef31485bb51b846e8db8b3a35e432cc15afb5

Smatch is awesome.

Fixes: https://github.com/ctrliq/kernel-src-tree/commit/32671e3799ca2e4590773fd0e63aaa4229e50c06 ("perf: Disallow mis-matched inherited group reads")
	Reported-by: Dan Carpenter <dan.carpenter@linaro.org>
	Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
	Signed-off-by: Ingo Molnar <mingo@kernel.org>
(cherry picked from commit https://github.com/ctrliq/kernel-src-tree/commit/a71ef31485bb51b846e8db8b3a35e432cc15afb5)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>
```

### Kernel build logs
```
/mnt/scratch/workspace/fips-legacy-8-compliant/kernel-src-tree
Skipping make mrproper
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-fips-legacy-8-compliant_4.18.0-425.13.1-98daf831f893"
Making olddefconfig
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  UPD     include/config/kernel.release
  DESCEND objtool
  DESCEND bpf/resolve_btfids
  UPD     include/generated/utsrelease.h
  CC      arch/x86/kernel/asm-offsets.s
  CALL    scripts/checksyscalls.sh
  CC      arch/x86/ia32/sys_ia32.o
  CC      init/main.o
  CC      arch/x86/entry/common.o
  CC      arch/x86/events/core.o
  CC      arch/x86/hyperv/mmu.o
  CC      arch/x86/events/amd/core.o
  CC      arch/x86/mm/init.o
  CC      arch/x86/events/amd/uncore.o
  CC [M]  arch/x86/kvm/../../../virt/kvm/kvm_main.o
  AR      arch/x86/ia32/built-in.a
  CHK     include/generated/compile.h
  CC      kernel/fork.o
  CC      arch/x86/events/amd/ibs.o
  CC      arch/x86/events/intel/core.o
  CC [M]  arch/x86/kvm/../../../virt/kvm/eventfd.o
  CC      arch/x86/kernel/process_64.o
  AR      arch/x86/hyperv/built-in.a
  CC [M]  arch/x86/kvm/../../../virt/kvm/binary_stats.o
  CC      arch/x86/entry/vsyscall/vsyscall_64.o
  CC [M]  arch/x86/kvm/../../../virt/kvm/vfio.o
  CC      arch/x86/events/amd/iommu.o
  CC      arch/x86/mm/fault.o
  CC      init/do_mounts.o
  <--snip-->
    INSTALL sound/usb/hiface/snd-usb-hiface.ko
  INSTALL sound/usb/line6/snd-usb-line6.ko
  INSTALL sound/usb/line6/snd-usb-podhd.ko
  INSTALL sound/usb/line6/snd-usb-pod.ko
  INSTALL sound/usb/line6/snd-usb-toneport.ko
  INSTALL sound/usb/line6/snd-usb-variax.ko
  INSTALL sound/usb/snd-usb-audio.ko
  INSTALL sound/usb/snd-usbmidi-lib.ko
  INSTALL sound/usb/misc/snd-ua101.ko
  INSTALL sound/usb/usx2y/snd-usb-us122l.ko
  INSTALL sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-fips-legacy-8-compliant_4.18.0-425.13.1-98daf831f893+
[TIMER]{MODULES}: 9s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-fips-legacy-8-compliant_4.18.0-425.13.1-98daf831f893+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 15s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-fips-legacy-8-compliant_4.18.0-425.13.1-98daf831f893+ and Index to 1
The default is /boot/loader/entries/1cf5e9bb44ed480cb5927d321c03acfc-4.18.0-fips-legacy-8-compliant_4.18.0-425.13.1-98daf831f893+.conf with index 1 and kernel /boot/vmlinuz-4.18.0-fips-legacy-8-compliant_4.18.0-425.13.1-98daf831f893+
The default is /boot/loader/entries/1cf5e9bb44ed480cb5927d321c03acfc-4.18.0-fips-legacy-8-compliant_4.18.0-425.13.1-98daf831f893+.conf with index 1 and kernel /boot/vmlinuz-4.18.0-fips-legacy-8-compliant_4.18.0-425.13.1-98daf831f893+
Generating grub configuration file ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 387s
[TIMER]{MODULES}: 9s
[TIMER]{INSTALL}: 15s
[TIMER]{TOTAL} 414s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21673173/kernel-build.log)


### Kselftests

```
shreeya@spatel-dev-bom:~/ciq/workspace/fips-legacy-8-compliant$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
204
204
shreeya@spatel-dev-bom:~/ciq/workspace/fips-legacy-8-compliant$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
53
53
```
[kselftest-after.log](https://github.com/user-attachments/files/21673208/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21673209/kselftest-before.log)



