### PR TITLE
[lts92] github actions: Add upstream commit checker

### DIFF
--- a/.github/workflows/upstream-commit-check.yml
+++ b/.github/workflows/upstream-commit-check.yml
@@ -1,0 +1,54 @@
+name: Check Kernel Commits for Upstream Fixes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-upstream-fixes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: Checkout base branch
+        run: |
+          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+
+      - name: Download check_kernel_commits.py
+        run: |
+          curl -sL \
+            https://raw.githubusercontent.com/ctrliq/kernel-src-tree-tools/mainline/check_kernel_commits.py \
+            -o check_kernel_commits.py
+          chmod +x check_kernel_commits.py
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run upstream fixes check
+        id: checkkernel
+        run: |
+          python3 check_kernel_commits.py --repo . --pr_branch "${{ github.head_ref }}" --base_branch "${{ github.base_ref }}" --markdown | tee result.txt
+          # Save non-empty results for PR comment
+          if grep -q -v "All referenced commits exist upstream and have no Fixes: tags." result.txt; then
+            echo "has_findings=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment on PR if issues found
+        if: steps.checkkernel.outputs.has_findings == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "$(cat result.txt)" \
+            --repo ${{ github.repository }}


### PR DESCRIPTION
LE-3768

Same as https://github.com/ctrliq/kernel-src-tree/pull/474

This github action checks the PR commits for references to upstream linux commits (lines starting with "commit <hash>") and does two things:

1.  Checks that this hash exists in the upstream linux kernel history

2.  Checks if there are any Fixes: references for the referenced commit in the upstream linux kernel history

If either of those are found to be true a comment is added to the PR with the pertinent information.

The logic for the check is provided by the check_upstream_commits.py script from kernel-src-tree-tools