### PR TITLE
[CBR 7.9] perf: Disallow mis-matched inherited group reads

### DIFF
--- a/include/linux/perf_event.h
+++ b/include/linux/perf_event.h
@@ -611,6 +611,8 @@ struct perf_event {
 #endif
 	RH_KABI_EXTEND(unsigned long			rcu_batches)
 	RH_KABI_EXTEND(int				rcu_pending)
+
+	RH_KABI_EXTEND(unsigned int			group_generation)
 #endif /* CONFIG_PERF_EVENTS */
 };
 

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -1773,6 +1773,7 @@ static void perf_group_attach(struct perf_event *event)
 
 	list_add_tail(&event->group_entry, &group_leader->sibling_list);
 	group_leader->nr_siblings++;
+	group_leader->group_generation++;
 
 	perf_event__header_size(group_leader);
 
@@ -1858,6 +1859,7 @@ static void perf_group_detach(struct perf_event *event)
 	if (event->group_leader != event) {
 		list_del_init(&event->group_entry);
 		event->group_leader->nr_siblings--;
+		event->group_leader->group_generation++;
 		goto out;
 	}
 
@@ -4561,7 +4563,7 @@ static int __perf_read_group_add(struct perf_event *leader,
 					u64 read_format, u64 *values)
 {
 	struct perf_event_context *ctx = leader->ctx;
-	struct perf_event *sub;
+	struct perf_event *sub, *parent;
 	unsigned long flags;
 	int n = 1; /* skip @nr */
 	int ret;
@@ -4571,6 +4573,33 @@ static int __perf_read_group_add(struct perf_event *leader,
 		return ret;
 
 	raw_spin_lock_irqsave(&ctx->lock, flags);
+	/*
+	 * Verify the grouping between the parent and child (inherited)
+	 * events is still in tact.
+	 *
+	 * Specifically:
+	 *  - leader->ctx->lock pins leader->sibling_list
+	 *  - parent->child_mutex pins parent->child_list
+	 *  - parent->ctx->mutex pins parent->sibling_list
+	 *
+	 * Because parent->ctx != leader->ctx (and child_list nests inside
+	 * ctx->mutex), group destruction is not atomic between children, also
+	 * see perf_event_release_kernel(). Additionally, parent can grow the
+	 * group.
+	 *
+	 * Therefore it is possible to have parent and child groups in a
+	 * different configuration and summing over such a beast makes no sense
+	 * what so ever.
+	 *
+	 * Reject this.
+	 */
+	parent = leader->parent;
+	if (parent &&
+	    (parent->group_generation != leader->group_generation ||
+	     parent->nr_siblings != leader->nr_siblings)) {
+		ret = -ECHILD;
+		goto unlock;
+	}
 
 	/*
 	 * Since we co-schedule groups, {enabled,running} times of siblings
@@ -4600,8 +4629,9 @@ static int __perf_read_group_add(struct perf_event *leader,
 			values[n++] = primary_event_id(sub);
 	}
 
+unlock:
 	raw_spin_unlock_irqrestore(&ctx->lock, flags);
-	return 0;
+	return ret;
 }
 
 static int perf_read_group(struct perf_event *event,
@@ -4620,10 +4650,6 @@ static int perf_read_group(struct perf_event *event,
 
 	values[0] = 1 + leader->nr_siblings;
 
-	/*
-	 * By locking the child_mutex of the leader we effectively
-	 * lock the child list of all siblings.. XXX explain how.
-	 */
 	mutex_lock(&leader->child_mutex);
 
 	ret = __perf_read_group_add(leader, read_format, values);
@@ -11005,6 +11031,7 @@ static int inherit_group(struct perf_event *parent_event,
 		if (IS_ERR(child_ctr))
 			return PTR_ERR(child_ctr);
 	}
+	leader->group_generation = parent_event->group_generation;
 	return 0;
 }
 

--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -11031,7 +11031,8 @@ static int inherit_group(struct perf_event *parent_event,
 		if (IS_ERR(child_ctr))
 			return PTR_ERR(child_ctr);
 	}
-	leader->group_generation = parent_event->group_generation;
+	if (leader)
+		leader->group_generation = parent_event->group_generation;
 	return 0;
 }
 


### PR DESCRIPTION
[CBR 7.9]
CVE-2023-5717
VULN-7623


# Problem

<https://www.cve.org/CVERecord?id=CVE-2023-5717>
> A heap out-of-bounds write vulnerability in the Linux kernel's Linux Kernel Performance Events (perf) component can be exploited to achieve local privilege escalation. If perf\_read\_group() is called while an event's sibling\_list is smaller than its child's sibling\_list, it can increment or write to memory locations outside of the allocated buffer.


# Applicability: yes

The perf component is included with the `CONFIG_PERF_EVENTS` option, which is enabled in all `ciqcbr7_9` configs

    grep 'CONFIG_PERF_EVENTS\b' configs/*.config

    configs/kernel-3.10.0-x86_64-debug.config:CONFIG_PERF_EVENTS=y
    configs/kernel-3.10.0-x86_64.config:CONFIG_PERF_EVENTS=y

The commit "flipping the order of child\_list and sibling\_list" which introduced the bug - fa8c269353d560b7c28119ad7617029f92e40b15 - was backported to `ciqcbr7_9` in 170ca9a728940ce2e4cb4af6abcb224ca2031f94. The fixing commit 32671e3799ca2e4590773fd0e63aaa4229e50c06 is missing and wasn't backported.


# Solution

The mainline fix 32671e3799ca2e4590773fd0e63aaa4229e50c06 adds a new `group_generation` field to the `perf_event` struct. This breaks CBR 7.9 kABI. The field was preserved, but moved to the end of the struct and wrapped in the `RH_KABI_EXTEND` macro. Unlike in the case of LTS 8.6 (<https://github.com/ctrliq/kernel-src-tree/pull/475>) the investigation of whether it's safe to do was not necessary, because the struct already contained multiple `RH_KABI_EXTEND(…)` field at the end, which could not have been added otherwise: <https://github.com/ctrliq/kernel-src-tree/blob/10329e467b1ccd8689d06a797d7b44b1b665c3f2/include/linux/perf_event.h#L586-L615>

Additionally, a fix-of-the-fix on the mainlie was commited in a71ef31485bb51b846e8db8b3a35e432cc15afb5 which was also included in this backport.


# kABI check: passed

    $ python /mnt/code/kernel-dist-git-el-7.9/SOURCES/check-kabi -k /mnt/code/kernel-dist-git-el-7.9/SOURCES/Module.kabi_x86_64 -s /mnt/build_files/kernel-src-tree-ciqcbr7_9-CVE-2023-5717/Module.symvers
    $ echo $?
    0


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21718100/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqcbr7\_9&#x2013;run1.log](<https://github.com/user-attachments/files/21718098/kselftests--ciqcbr7_9--run1.log>)
[kselftests&#x2013;ciqcbr7\_9&#x2013;run2.log](<https://github.com/user-attachments/files/21718096/kselftests--ciqcbr7_9--run2.log>)
[kselftests&#x2013;ciqcbr7\_9&#x2013;run3.log](<https://github.com/user-attachments/files/21718094/kselftests--ciqcbr7_9--run3.log>)


## Patch

[kselftests&#x2013;ciqcbr7\_9-CVE-2023-5717&#x2013;run1.log](<https://github.com/user-attachments/files/21718093/kselftests--ciqcbr7_9-CVE-2023-5717--run1.log>)
[kselftests&#x2013;ciqcbr7\_9-CVE-2023-5717&#x2013;run2.log](<https://github.com/user-attachments/files/21718092/kselftests--ciqcbr7_9-CVE-2023-5717--run2.log>)
[kselftests&#x2013;ciqcbr7\_9-CVE-2023-5717&#x2013;run3.log](<https://github.com/user-attachments/files/21718090/kselftests--ciqcbr7_9-CVE-2023-5717--run3.log>)


## Comparison

The results were compared manually with Meld. No differences indicative of a problem introduced by the patch were found.


# Specific tests: passed

While not strictly testing the provided patch, a very basic sanity check of the perf\_events module was done to see if it remains functional.


## Reference

    $ uname -r 
    3.10.0-ciqcbr7_9
    $ sudo perf stat -B dd if=/dev/zero of=/dev/null count=1000000

    1000000+0 records in
    1000000+0 records out
    512000000 bytes (512 MB) copied, 1.36361 s, 375 MB/s
    
     Performance counter stats for 'dd if=/dev/zero of=/dev/null count=1000000':
    
              1,366.22 msec task-clock                #    0.995 CPUs utilized          
                     3      context-switches          #    0.002 K/sec                  
                     0      cpu-migrations            #    0.000 K/sec                  
                   217      page-faults               #    0.159 K/sec                  
         5,856,326,009      cycles                    #    4.287 GHz                    
         2,520,750,706      instructions              #    0.43  insn per cycle         
           544,415,208      branches                  #  398.483 M/sec                  
            11,042,875      branch-misses             #    2.03% of all branches        
    
           1.372717065 seconds time elapsed
    
           0.602402000 seconds user
           0.770071000 seconds sys


## Patch

    $ uname -r 
    3.10.0-ciqcbr7_9-CVE-2023-5717
    $ sudo perf stat -B dd if=/dev/zero of=/dev/null count=1000000

    1000000+0 records in
    1000000+0 records out
    512000000 bytes (512 MB) copied, 1.39469 s, 367 MB/s
    
     Performance counter stats for 'dd if=/dev/zero of=/dev/null count=1000000':
    
              1,396.45 msec task-clock                #    0.995 CPUs utilized          
                     5      context-switches          #    0.004 K/sec                  
                     0      cpu-migrations            #    0.000 K/sec                  
                   218      page-faults               #    0.156 K/sec                  
         5,900,275,843      cycles                    #    4.225 GHz                    
         2,520,173,133      instructions              #    0.43  insn per cycle         
           544,174,329      branches                  #  389.684 M/sec                  
            11,045,660      branch-misses             #    2.03% of all branches        
    
           1.404119544 seconds time elapsed
    
           0.669277000 seconds user
           0.734597000 seconds sys

