### PR TITLE
[FIPS 9.2] net: inet: do not leave a dangling sk pointer in inet_create()

### DIFF
--- a/net/ipv4/af_inet.c
+++ b/net/ipv4/af_inet.c
@@ -367,31 +367,29 @@ lookup_protocol:
 		inet->inet_sport = htons(inet->inet_num);
 		/* Add to protocol hash chains. */
 		err = sk->sk_prot->hash(sk);
-		if (err) {
-			sk_common_release(sk);
-			goto out;
-		}
+		if (err)
+			goto out_sk_release;
 	}
 
 	if (sk->sk_prot->init) {
 		err = sk->sk_prot->init(sk);
-		if (err) {
-			sk_common_release(sk);
-			goto out;
-		}
+		if (err)
+			goto out_sk_release;
 	}
 
 	if (!kern) {
 		err = BPF_CGROUP_RUN_PROG_INET_SOCK(sk);
-		if (err) {
-			sk_common_release(sk);
-			goto out;
-		}
+		if (err)
+			goto out_sk_release;
 	}
 out:
 	return err;
 out_rcu_unlock:
 	rcu_read_unlock();
+	goto out;
+out_sk_release:
+	sk_common_release(sk);
+	sock->sk = NULL;
 	goto out;
 }
 


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-41187
cve CVE-2024-56601
commit-author Ignat Korchagin <ignat@cloudflare.com> commit 9365fa510c6f82e3aa550a09d0c5c6b44dbc78ff

sock_init_data() attaches the allocated sk object to the provided sock object. If inet_create() fails later, the sk object is freed, but the sock object retains the dangling pointer, which may create use-after-free later.

Clear the sk pointer in the sock object on error.

	Signed-off-by: Ignat Korchagin <ignat@cloudflare.com>
	Reviewed-by: Kuniyuki Iwashima <kuniyu@amazon.com>
	Reviewed-by: Eric Dumazet <edumazet@google.com>
Link: https://patch.msgid.link/20241014153808.51894-7-ignat@cloudflare.com
	Signed-off-by: Jakub Kicinski <kuba@kernel.org>
(cherry picked from commit 9365fa510c6f82e3aa550a09d0c5c6b44dbc78ff)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
[kernel-build.log](https://github.com/user-attachments/files/21732728/kernel-build.log)

### Kernel build logs
```
/home/anmol/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 3s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/x86/include/generated/uapi/asm/param.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
[--snip--]
  STRIP   /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+
[TIMER]{MODULES}: 16s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-355a7d0e2+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 37s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-7d64bb94c+ and Index to 5
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-7d64bb94c+.conf with index 5 and kernel /boot/vmlinuz-5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-7d64bb94c+
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-7d64bb94c+.conf with index 5 and kernel /boot/vmlinuz-5.14.0-__ajain_fips-9-compliant_5.14.0-284.30.1-7d64bb94c+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 3s
[TIMER]{BUILD}: 2915s
[TIMER]{MODULES}: 16s
[TIMER]{INSTALL}: 37s
[TIMER]{TOTAL} 2975s
Rebooting in 10 seconds
```
### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
317
317
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
66
66
```

[kselftest-before.log](https://github.com/user-attachments/files/21732725/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21732726/kselftest-after.log)
