### PR TITLE
[LTS 9.2] can: j1939: j1939_netdev_start(): fix UAF for rx_kref of j1939_priv

### DIFF
--- a/net/can/j1939/main.c
+++ b/net/can/j1939/main.c
@@ -253,11 +253,14 @@ struct j1939_priv *j1939_netdev_start(struct net_device *ndev)
 	struct j1939_priv *priv, *priv_new;
 	int ret;
 
-	priv = j1939_priv_get_by_ndev(ndev);
+	spin_lock(&j1939_netdev_lock);
+	priv = j1939_priv_get_by_ndev_locked(ndev);
 	if (priv) {
 		kref_get(&priv->rx_kref);
+		spin_unlock(&j1939_netdev_lock);
 		return priv;
 	}
+	spin_unlock(&j1939_netdev_lock);
 
 	priv = j1939_priv_create(ndev);
 	if (!priv)
@@ -273,10 +276,10 @@ struct j1939_priv *j1939_netdev_start(struct net_device *ndev)
 		/* Someone was faster than us, use their priv and roll
 		 * back our's.
 		 */
+		kref_get(&priv_new->rx_kref);
 		spin_unlock(&j1939_netdev_lock);
 		dev_put(ndev);
 		kfree(priv);
-		kref_get(&priv_new->rx_kref);
 		return priv_new;
 	}
 	j1939_priv_set(ndev, priv);


### PR DESCRIPTION
- [x] Commit Message Requirements
- [x] Built against Vault/LTS Environment
- [x] kABI Check Passed, where Valid (Pre 9.4 RT does not have kABI stability)
- [x] Boot Test
- [x] Kernel SelfTest results
- [ ] Additional Tests as determined relevant

### Commit message
```
jira VULN-63435
cve CVE-2021-47459
commit-author Ziyang Xuan <william.xuanziyang@huawei.com> commit d9d52a3ebd284882f5562c88e55991add5d01586

It will trigger UAF for rx_kref of j1939_priv as following.

        cpu0                                    cpu1
j1939_sk_bind(socket0, ndev0, ...)
j1939_netdev_start
                                        j1939_sk_bind(socket1, ndev0, ...)
                                        j1939_netdev_start
j1939_priv_set
                                        j1939_priv_get_by_ndev_locked
j1939_jsk_add
.....
j1939_netdev_stop
kref_put_lock(&priv->rx_kref, ...)
                                        kref_get(&priv->rx_kref, ...)
                                        REFCOUNT_WARN("addition on 0;...")

==================================================== refcount_t: addition on 0; use-after-free.
WARNING: CPU: 1 PID: 20874 at lib/refcount.c:25 refcount_warn_saturate+0x169/0x1e0 RIP: 0010:refcount_warn_saturate+0x169/0x1e0
Call Trace:
 j1939_netdev_start+0x68b/0x920
 j1939_sk_bind+0x426/0xeb0
 ? security_socket_bind+0x83/0xb0

The rx_kref's kref_get() and kref_put() should use j1939_netdev_lock to protect.

Fixes: 9d71dd0c70099 ("can: add support of SAE J1939 protocol") Link: https://lore.kernel.org/all/20210926104757.2021540-1-william.xuanziyang@huawei.com
	Cc: stable@vger.kernel.org
	Reported-by: syzbot+85d9878b19c94f9019ad@syzkaller.appspotmail.com
	Signed-off-by: Ziyang Xuan <william.xuanziyang@huawei.com>
	Acked-by: Oleksij Rempel <o.rempel@pengutronix.de>
	Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>
(cherry picked from commit d9d52a3ebd284882f5562c88e55991add5d01586)
	Signed-off-by: Anmol Jain <ajain@ciq.com>
```
### Kernel build logs
```
/home/anmol/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 2s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-ajain_ciqlts9_2-975fc2bd8"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
[--snip--]
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/usb/usx2y/snd-usb-us122l.ko
  STRIP   /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  INSTALL /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/virtio/virtio_snd.ko
  INSTALL /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/virtio/virtio_snd.ko
  STRIP   /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/xen/snd_xen_front.ko
  INSTALL /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/sound/xen/snd_xen_front.ko
  STRIP   /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-ajain_ciqlts9_2-975fc2bd8+
[TIMER]{MODULES}: 15s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-ajain_ciqlts9_2-975fc2bd8+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 37s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-ajain_ciqlts9_2-bd7c69d35+ and Index to 12
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-ajain_ciqlts9_2-bd7c69d35+.conf with index 12 and kernel /boot/vmlinuz-5.14.0-ajain_ciqlts9_2-bd7c69d35+
The default is /boot/loader/entries/ae61a3a10eaf425d8b67751abc382f2d-5.14.0-ajain_ciqlts9_2-bd7c69d35+.conf with index 12 and kernel /boot/vmlinuz-5.14.0-ajain_ciqlts9_2-bd7c69d35+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 2s
[TIMER]{BUILD}: 2918s
[TIMER]{MODULES}: 15s
[TIMER]{INSTALL}: 37s
[TIMER]{TOTAL} 2977s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21739364/kernel-build.log)

### Kselftests
```
$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
317
317
$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
67
67
```
[kselftest-after.log](https://github.com/user-attachments/files/21739368/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21739372/kselftest-before.log)
