### PR TITLE
[LTS 9.2] net_sched: hfsc: Address reentrant enqueue adding class to eltree twice

### DIFF
--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -1568,7 +1568,7 @@ hfsc_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff **to_free)
 		return err;
 	}
 
-	if (first) {
+	if (first && !cl->cl_nactive) {
 		if (cl->cl_flags & HFSC_RSC)
 			init_ed(cl, len);
 		if (cl->cl_flags & HFSC_FSC)

--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -176,6 +176,11 @@ struct hfsc_sched {
 
 #define	HT_INFINITY	0xffffffffffffffffULL	/* infinite time value */
 
+static bool cl_in_el_or_vttree(struct hfsc_class *cl)
+{
+	return ((cl->cl_flags & HFSC_FSC) && cl->cl_nactive) ||
+		((cl->cl_flags & HFSC_RSC) && !RB_EMPTY_NODE(&cl->el_node));
+}
 
 /*
  * eligible tree holds backlogged classes being sorted by their eligible times.
@@ -1033,6 +1038,8 @@ hfsc_change_class(struct Qdisc *sch, u32 classid, u32 parentid,
 	if (cl == NULL)
 		return -ENOBUFS;
 
+	RB_CLEAR_NODE(&cl->el_node);
+
 	err = tcf_block_get(&cl->block, &cl->filter_list, sch, extack);
 	if (err) {
 		kfree(cl);
@@ -1568,7 +1575,7 @@ hfsc_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff **to_free)
 		return err;
 	}
 
-	if (first && !cl->cl_nactive) {
+	if (first && !cl_in_el_or_vttree(cl)) {
 		if (cl->cl_flags & HFSC_RSC)
 			init_ed(cl, len);
 		if (cl->cl_flags & HFSC_FSC)


### PR DESCRIPTION
[LTS 9.2]
CVE-2025-37890
VULN-68295


# Problem

<https://access.redhat.com/security/cve/CVE-2025-37890>
> A use-after-free vulnerability has been identified in the Linux kernel's HFSC (Hierarchical Fair Service Curve) queuing discipline when it is configured with NETEM (Network Emulation) as a child. This flaw can lead to a kernel panic or crash due to incorrect assumptions about the queue state. Exploitation of this vulnerability requires local access with CAP\_NET\_ADMIN privileges and control over the qdisc (queueing discipline) setup. A local attacker could leverage this flaw to achieve denial of service or escalate privileges. Given that it affects kernel memory structures, successful exploitation could result in memory corruption, data leaks, or arbitrary write capabilities, leading to a full kernel crash.


# Applicability: yes

The patch relates to the `sch_hfsc` module, enabled with the `NET_SCH_HFSC` option. It's set to `m` in all configs of LTS 9.2:

    $ grep 'NET_SCH_HFSC\b' configs/*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-ppc64le-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64-rhel.config:CONFIG_NET_SCH_HFSC=m

The commit 37d9cf1a3ce35de3df6f7d209bfb1f50cf188cea marked as introducing the bug is present in the `ciqlts9_2`'s history. The mainline fix 141d34391abbb315d68556b7c67ad97885407547 wasn't backported. For the full picture please refer to the *Appendix: Bug timeline* section in <https://github.com/ctrliq/kernel-src-tree/pull/490>.


# Solution

The same situation as in <https://github.com/ctrliq/kernel-src-tree/pull/490>, which see.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-2025-37890 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_2-CVE-2025-37890

    [0/1] Check ABI of kernel [ciqlts9_2-CVE-2025-37890]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_2/build_files/kernel-src-tree-ciqlts9_2-CVE-2025-37890/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2025-37890/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21744889/boot-test.log>)


# Kselftests: passed relative


## Coverage

Only the net-related tests were run. Arguably the most important are the tests in `net/forwarding` collection.

`net/forwarding` (except `vxlan_bridge_1d_ipv6.sh`, `sch_tbf_prio.sh`, `sch_tbf_ets.sh`, `tc_actions.sh`, `tc_police.sh`, `sch_ets.sh`, `sch_tbf_root.sh`, `sch_red.sh`), `net/mptcp` (except `userspace_pm.sh`, `simult_flows.sh`, `mptcp_join.sh`), `net`, `netfilter` (except `nft_trans_stress.sh`).


## Reference

Batch 1:
[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/21744788/kselftests--ciqlts9_2--run1.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/21744787/kselftests--ciqlts9_2--run2.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run3.log](<https://github.com/user-attachments/files/21744786/kselftests--ciqlts9_2--run3.log>)
Batch 2:
[kselftests&#x2013;ciqlts9\_2&#x2013;run4.log](<https://github.com/user-attachments/files/21744785/kselftests--ciqlts9_2--run4.log>)


## Patch

Batch 1:
[kselftests&#x2013;ciqlts9\_2-CVE-2025-37890&#x2013;run1.log](<https://github.com/user-attachments/files/21744784/kselftests--ciqlts9_2-CVE-2025-37890--run1.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-2025-37890&#x2013;run2.log](<https://github.com/user-attachments/files/21744783/kselftests--ciqlts9_2-CVE-2025-37890--run2.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-2025-37890&#x2013;run3.log](<https://github.com/user-attachments/files/21744782/kselftests--ciqlts9_2-CVE-2025-37890--run3.log>)
Batch 2:
[kselftests&#x2013;ciqlts9\_2-CVE-2025-37890&#x2013;run4.log](<https://github.com/user-attachments/files/21744781/kselftests--ciqlts9_2-CVE-2025-37890--run4.log>)


## Comparison

There are some differences in the results but they're all for the tests marked before as unstable (see <https://gitlab.conclusive.pl/devices/rocky-patching/-/blob/master/rocky.yml?ref_type=heads>). They were just run by a mistake.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2--run2.log
    Status2   kselftests--ciqlts9_2--run3.log
    Status3   kselftests--ciqlts9_2--run4.log
    Status4   kselftests--ciqlts9_2-CVE-2025-37890--run1.log
    Status5   kselftests--ciqlts9_2-CVE-2025-37890--run2.log
    Status6   kselftests--ciqlts9_2-CVE-2025-37890--run3.log
    Status7   kselftests--ciqlts9_2-CVE-2025-37890--run4.log
    
    TestCase            Status0  Status1  Status2  Status3  Status4  Status5  Status6  Status7  Summary
    net:gro.sh          pass     fail     pass              pass     fail     pass              diff
    net:txtimestamp.sh  fail     pass     pass              pass     pass     fail              diff


# Specific tests: skipped

