### PR TITLE
[lts94] github actions: Add kabi checks

### DIFF
--- a/.github/workflows/build-check_aarch64.yml
+++ b/.github/workflows/build-check_aarch64.yml
@@ -32,3 +32,8 @@ jobs:
           cp configs/kernel-aarch64-rhel.config .config
           make ARCH=arm64 CROSS_COMPILE=./scripts/dummy-tools/ olddefconfig
           make -j8
+      - name: Check kabi
+        run: |
+          git clone --branch r9 --single-branch https://git.rockylinux.org/staging/rpms/kernel.git kernel-dist-git
+          git -C kernel-dist-git reset --hard imports/r9/kernel-5.14.0-427.42.1.el9_4
+          ./kernel-dist-git/SOURCES/check-kabi -k ./kernel-dist-git/SOURCES/Module.kabi_aarch64 -s Module.symvers

--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -32,3 +32,8 @@ jobs:
           cp configs/kernel-x86_64-rhel.config .config
           make ARCH=x86_64 CROSS_COMPILE=./scripts/dummy-tools/ olddefconfig
           make -j8
+      - name: Check kabi
+        run: |
+          git clone --branch r9 --single-branch https://git.rockylinux.org/staging/rpms/kernel.git kernel-dist-git
+          git -C kernel-dist-git reset --hard imports/r9/kernel-5.14.0-427.42.1.el9_4
+          ./kernel-dist-git/SOURCES/check-kabi -k ./kernel-dist-git/SOURCES/Module.kabi_x86_64 -s Module.symvers


### PR DESCRIPTION
LE-3795

After the build check, perform a kabi check

Note: There are no -rt Module.kabi_* files.  So we are only checking the kabi for x86_64 and aarch64