### PR TITLE
[cbr79] github actions: Fix upstream commit check for forks

### DIFF
--- a/.github/workflows/upstream-commit-check.yml
+++ b/.github/workflows/upstream-commit-check.yml
@@ -16,12 +16,14 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 
       - name: Checkout base branch
         run: |
-          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+          git remote add base_repo https://github.com/${{ github.repository }}.git
+          git fetch base_repo ${{ github.base_ref }}:${{ github.base_ref }}
 
       - name: Download check_kernel_commits.py
         run: |


### PR DESCRIPTION
The upstream commit check workflow was failing for pull requests originating from forked repositories. The previous implementation incorrectly assumed the pull request branch existed on the base repository.

This commit corrects the workflow to ensure the pull request branch is checked out from the correct source repository, while the base branch is fetched from the target repository.