### PR TITLE
[LTS 9.4] net_sched: hfsc: Address reentrant enqueue adding class to eltree twice

### DIFF
--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -176,6 +176,11 @@ struct hfsc_sched {
 
 #define	HT_INFINITY	0xffffffffffffffffULL	/* infinite time value */
 
+static bool cl_in_el_or_vttree(struct hfsc_class *cl)
+{
+	return ((cl->cl_flags & HFSC_FSC) && cl->cl_nactive) ||
+		((cl->cl_flags & HFSC_RSC) && !RB_EMPTY_NODE(&cl->el_node));
+}
 
 /*
  * eligible tree holds backlogged classes being sorted by their eligible times.
@@ -1033,6 +1038,8 @@ hfsc_change_class(struct Qdisc *sch, u32 classid, u32 parentid,
 	if (cl == NULL)
 		return -ENOBUFS;
 
+	RB_CLEAR_NODE(&cl->el_node);
+
 	err = tcf_block_get(&cl->block, &cl->filter_list, sch, extack);
 	if (err) {
 		kfree(cl);
@@ -1561,7 +1568,7 @@ hfsc_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff **to_free)
 		return err;
 	}
 
-	if (first && !cl->cl_nactive) {
+	if (first && !cl_in_el_or_vttree(cl)) {
 		if (cl->cl_flags & HFSC_RSC)
 			init_ed(cl, len);
 		if (cl->cl_flags & HFSC_FSC)


### PR DESCRIPTION
[LTS 9.4]
CVE-2025-37890
VULN-68296


# Problem

<https://access.redhat.com/security/cve/CVE-2025-37890>
> A use-after-free vulnerability has been identified in the Linux kernel's HFSC (Hierarchical Fair Service Curve) queuing discipline when it is configured with NETEM (Network Emulation) as a child. This flaw can lead to a kernel panic or crash due to incorrect assumptions about the queue state. Exploitation of this vulnerability requires local access with CAP\_NET\_ADMIN privileges and control over the qdisc (queueing discipline) setup. A local attacker could leverage this flaw to achieve denial of service or escalate privileges. Given that it affects kernel memory structures, successful exploitation could result in memory corruption, data leaks, or arbitrary write capabilities, leading to a full kernel crash.


# Applicability: yes

The patch relates to the `sch_hfsc` module, enabled with the `NET_SCH_HFSC` option. It's set to `m` in all configs of LTS 9.4:

    $ grep 'NET_SCH_HFSC\b' configs/*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64-rt-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64-rt-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-ppc64le-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64-rt-debug-rhel.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64-rt-rhel.config:CONFIG_NET_SCH_HFSC=m

The commit 37d9cf1a3ce35de3df6f7d209bfb1f50cf188cea marked as introducing the bug is present in the `ciqlts9_4`'s history. The mainline fix 141d34391abbb315d68556b7c67ad97885407547 wasn't backported. For the full picture please refer to the *Appendix: Bug timeline* section in <https://github.com/ctrliq/kernel-src-tree/pull/490>.


# Solution

The same situation as in <https://github.com/ctrliq/kernel-src-tree/pull/490>, which see.


# kABI check: passed

    DEBUG=1 CVE=CVE-2025-37890 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_4-CVE-2025-37890

    [0/1] Check ABI of kernel [ciqlts9_4-CVE-2025-37890]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-2025-37890/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-2025-37890/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21761091/boot-test.log>)


# Kselftests: passed relative


## Coverage

Only the net-related tests were run.

`net/forwarding` (except `dual_vxlan_bridge.sh`, `ipip_hier_gre_keys.sh`, `sch_ets.sh`, `router_bridge_1d_lag.sh`, `ip6gre_inner_v6_multipath.sh`, `mirror_gre_bridge_1d_vlan.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_tbf_ets.sh`, `sch_tbf_prio.sh`, `router_bridge_lag.sh`, `q_in_vni.sh`, `vxlan_bridge_1d_ipv6.sh`, `gre_inner_v6_multipath.sh`, `sch_tbf_root.sh`, `tc_actions.sh`, `sch_red.sh`, `tc_police.sh`), `net/hsr`, `net/mptcp` (except `mptcp_join.sh`, `simult_flows.sh`, `userspace_pm.sh`), `net` (except `txtimestamp.sh`, `reuseaddr_conflict`, `fib_nexthops.sh`, `srv6_end_dt46_l3vpn_test.sh`, `reuseport_addr_any.sh`, `srv6_end_flavors_test.sh`, `udpgro_fwd.sh`, `srv6_end_dt4_l3vpn_test.sh`, `udpgso_bench.sh`, `gro.sh`, `srv6_end_dt6_l3vpn_test.sh`, `xfrm_policy.sh`, `ip_defrag.sh`), `netfilter` (except `nft_trans_stress.sh`)


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/21761090/kselftests--ciqlts9_4--run1.log>)
[kselftests&#x2013;ciqlts9\_4&#x2013;run2.log](<https://github.com/user-attachments/files/21761089/kselftests--ciqlts9_4--run2.log>)
[kselftests&#x2013;ciqlts9\_4&#x2013;run3.log](<https://github.com/user-attachments/files/21761088/kselftests--ciqlts9_4--run3.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-2025-37890&#x2013;run1.log](<https://github.com/user-attachments/files/21761085/kselftests--ciqlts9_4-CVE-2025-37890--run1.log>)
[kselftests&#x2013;ciqlts9\_4-CVE-2025-37890&#x2013;run2.log](<https://github.com/user-attachments/files/21761084/kselftests--ciqlts9_4-CVE-2025-37890--run2.log>)
[kselftests&#x2013;ciqlts9\_4-CVE-2025-37890&#x2013;run3.log](<https://github.com/user-attachments/files/21761083/kselftests--ciqlts9_4-CVE-2025-37890--run3.log>)


## Comparison

The tests results for the reference and patch are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4--run2.log
    Status2   kselftests--ciqlts9_4--run3.log
    Status3   kselftests--ciqlts9_4-CVE-2025-37890--run1.log
    Status4   kselftests--ciqlts9_4-CVE-2025-37890--run2.log
    Status5   kselftests--ciqlts9_4-CVE-2025-37890--run3.log


# Specific tests: skipped

