### PR TITLE
[fips-9] netfilter: nf_tables: Reject tables of unsupported family

### DIFF
--- a/net/netfilter/nf_tables_api.c
+++ b/net/netfilter/nf_tables_api.c
@@ -1164,6 +1164,30 @@ static int nft_objname_hash_cmp(struct rhashtable_compare_arg *arg,
 	return strcmp(obj->key.name, k->name);
 }
 
+static bool nft_supported_family(u8 family)
+{
+	return false
+#ifdef CONFIG_NF_TABLES_INET
+		|| family == NFPROTO_INET
+#endif
+#ifdef CONFIG_NF_TABLES_IPV4
+		|| family == NFPROTO_IPV4
+#endif
+#ifdef CONFIG_NF_TABLES_ARP
+		|| family == NFPROTO_ARP
+#endif
+#ifdef CONFIG_NF_TABLES_NETDEV
+		|| family == NFPROTO_NETDEV
+#endif
+#if IS_ENABLED(CONFIG_NF_TABLES_BRIDGE)
+		|| family == NFPROTO_BRIDGE
+#endif
+#ifdef CONFIG_NF_TABLES_IPV6
+		|| family == NFPROTO_IPV6
+#endif
+		;
+}
+
 static int nf_tables_newtable(struct sk_buff *skb, const struct nfnl_info *info,
 			      const struct nlattr * const nla[])
 {
@@ -1177,6 +1201,9 @@ static int nf_tables_newtable(struct sk_buff *skb, const struct nfnl_info *info,
 	struct nft_ctx ctx;
 	u32 flags = 0;
 	int err;
+
+	if (!nft_supported_family(family))
+		return -EOPNOTSUPP;
 
 	lockdep_assert_held(&nft_net->commit_mutex);
 	attr = nla[NFTA_TABLE_NAME];


### PR DESCRIPTION
jira VULN-8895
cve CVE-2023-6040

```
commit-author Phil Sutter <phil@nwl.cc>
commit f1082dd31fe461d482d69da2a8eccfeb7bf07ac2

An nftables family is merely a hollow container, its family just a number and such not reliant on compile-time options other than nftables support itself. Add an artificial check so attempts at using a family the kernel can't support fail as early as possible. This helps user space detect kernels which lack e.g. NFPROTO_INET.

	Signed-off-by: Phil Sutter <phil@nwl.cc>
	Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
(cherry picked from commit f1082dd31fe461d482d69da2a8eccfeb7bf07ac2)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 12s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
--
  LD [M]  sound/xen/snd_xen_front.ko
  BTF [M] sound/virtio/virtio_snd.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] virt/lib/irqbypass.ko
  BTF [M] sound/xen/snd_xen_front.ko
[TIMER]{BUILD}: 1457s
Making Modules
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+/kernel/sound/usb/bcd2000/snd-bcd2000.ko
  STRIP   /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+
[TIMER]{MODULES}: 10s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 50s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 12s
[TIMER]{BUILD}: 1457s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 50s
[TIMER]{TOTAL} 1548s
Rebooting in 10 seconds

```

### Testing

[selftest-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64.log](https://github.com/user-attachments/files/21779852/selftest-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64.log)

[selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+.log](https://github.com/user-attachments/files/21779863/selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360%2B.log)

```
brett@lycia ~/ciq/vuln-8895 % grep ^ok selftest-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64.log | wc -l
295
brett@lycia ~/ciq/vuln-8895 % grep ^ok selftest-5.14.0-b_f-9-c_5.14.0-284.30.1_VULN-8895-3542efcae360+.log | wc -l
295
brett@lycia ~/ciq/vuln-8895 %

```