### PR TITLE
[fips-8] netfilter: nf_tables: Reject tables of unsupported family

### DIFF
--- a/net/netfilter/nf_tables_api.c
+++ b/net/netfilter/nf_tables_api.c
@@ -1077,6 +1077,30 @@ static int nft_objname_hash_cmp(struct rhashtable_compare_arg *arg,
 	return strcmp(obj->key.name, k->name);
 }
 
+static bool nft_supported_family(u8 family)
+{
+	return false
+#ifdef CONFIG_NF_TABLES_INET
+		|| family == NFPROTO_INET
+#endif
+#ifdef CONFIG_NF_TABLES_IPV4
+		|| family == NFPROTO_IPV4
+#endif
+#ifdef CONFIG_NF_TABLES_ARP
+		|| family == NFPROTO_ARP
+#endif
+#ifdef CONFIG_NF_TABLES_NETDEV
+		|| family == NFPROTO_NETDEV
+#endif
+#if IS_ENABLED(CONFIG_NF_TABLES_BRIDGE)
+		|| family == NFPROTO_BRIDGE
+#endif
+#ifdef CONFIG_NF_TABLES_IPV6
+		|| family == NFPROTO_IPV6
+#endif
+		;
+}
+
 static int nf_tables_newtable(struct net *net, struct sock *nlsk,
 			      struct sk_buff *skb, const struct nlmsghdr *nlh,
 			      const struct nlattr * const nla[],
@@ -1090,6 +1114,9 @@ static int nf_tables_newtable(struct net *net, struct sock *nlsk,
 	u32 flags = 0;
 	struct nft_ctx ctx;
 	int err;
+
+	if (!nft_supported_family(family))
+		return -EOPNOTSUPP;
 
 	lockdep_assert_held(&net->nft_commit_mutex);
 	attr = nla[NFTA_TABLE_NAME];


### PR DESCRIPTION
jira VULN-8892
jira VULN-8893
cve CVE-2023-6040

```
commit-author Phil Sutter <phil@nwl.cc>
commit f1082dd31fe461d482d69da2a8eccfeb7bf07ac2

An nftables family is merely a hollow container, its family just a number and such not reliant on compile-time options other than nftables support itself. Add an artificial check so attempts at using a family the kernel can't support fail as early as possible. This helps user space detect kernels which lack e.g. NFPROTO_INET.

	Signed-off-by: Phil Sutter <phil@nwl.cc>
	Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
(cherry picked from commit f1082dd31fe461d482d69da2a8eccfeb7bf07ac2)
	Signed-off-by: Brett Mastbergen <bmastbergen@ciq.com>
```

### Build Log

```
/home/brett/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 12s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-b_f-8-c_4.18.0-553.16.1_VULN-8893-4cb3698565dc"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-us122l.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1073s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-8893-4cb3698565dc+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-8893-4cb3698565dc+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 118s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-8893-4cb3698565dc+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 12s
[TIMER]{BUILD}: 1073s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 118s
[TIMER]{TOTAL} 1234s
Rebooting in 10 seconds

```

### Testing

[selftest-4.18.0-553.16.1.el8_6.ciqfips.0.9.1.x86_64.log](https://github.com/user-attachments/files/21779803/selftest-4.18.0-553.16.1.el8_6.ciqfips.0.9.1.x86_64.log)

[selftest-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-8893-4cb3698565dc+.log](https://github.com/user-attachments/files/21779804/selftest-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-8893-4cb3698565dc%2B.log)

```
brett@lycia ~/ciq/vuln-8893 % grep ^ok selftest-4.18.0-553.16.1.el8_6.ciqfips.0.9.1.x86_64.log | wc -l
296
brett@lycia ~/ciq/vuln-8893 % grep ^ok selftest-4.18.0-b_f-8-c_4.18.0-553.16.1_VULN-8893-4cb3698565dc+.log | wc -l
297
brett@lycia ~/ciq/vuln-8893 %

```