### PR TITLE
[FIPS 8.7 Legacy] net_sched: hfsc: Address reentrant enqueue adding class to eltree twice

### DIFF
--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -176,6 +176,11 @@ struct hfsc_sched {
 
 #define	HT_INFINITY	0xffffffffffffffffULL	/* infinite time value */
 
+static bool cl_in_el_or_vttree(struct hfsc_class *cl)
+{
+	return ((cl->cl_flags & HFSC_FSC) && cl->cl_nactive) ||
+		((cl->cl_flags & HFSC_RSC) && !RB_EMPTY_NODE(&cl->el_node));
+}
 
 /*
  * eligible tree holds backlogged classes being sorted by their eligible times.
@@ -1033,6 +1038,8 @@ hfsc_change_class(struct Qdisc *sch, u32 classid, u32 parentid,
 	if (cl == NULL)
 		return -ENOBUFS;
 
+	RB_CLEAR_NODE(&cl->el_node);
+
 	err = tcf_block_get(&cl->block, &cl->filter_list, sch, extack);
 	if (err) {
 		kfree(cl);
@@ -1568,7 +1575,7 @@ hfsc_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff **to_free)
 		return err;
 	}
 
-	if (first && !cl->cl_nactive) {
+	if (first && !cl_in_el_or_vttree(cl)) {
 		if (cl->cl_flags & HFSC_RSC)
 			init_ed(cl, len);
 		if (cl->cl_flags & HFSC_FSC)


### PR DESCRIPTION
[FIPS 8.7 Legacy]
CVE-2025-37890
VULN-68294


# Problem

<https://access.redhat.com/security/cve/CVE-2025-37890>
> A use-after-free vulnerability has been identified in the Linux kernel's HFSC (Hierarchical Fair Service Curve) queuing discipline when it is configured with NETEM (Network Emulation) as a child. This flaw can lead to a kernel panic or crash due to incorrect assumptions about the queue state. Exploitation of this vulnerability requires local access with CAP\_NET\_ADMIN privileges and control over the qdisc (queueing discipline) setup. A local attacker could leverage this flaw to achieve denial of service or escalate privileges. Given that it affects kernel memory structures, successful exploitation could result in memory corruption, data leaks, or arbitrary write capabilities, leading to a full kernel crash.


# Applicability: yes

The patch relates to the `sch_hfsc` module, enabled with the `NET_SCH_HFSC` option. It's set to `m` in all configs of FIPS 8.7 Legacy:

    $ grep 'NET_SCH_HFSC\b' configs/*.config

    configs/kernel-aarch64-debug.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-ppc64le-debug.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-ppc64le.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-debug.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-zfcpdump.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64-debug.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64.config:CONFIG_NET_SCH_HFSC=m

The commit 37d9cf1a3ce35de3df6f7d209bfb1f50cf188cea marked as introducing the bug was backported to FIPS 8.7 Legacy in f3e1778ab44512570f4702dd88030d89d9d85518. The mainline fix 141d34391abbb315d68556b7c67ad97885407547 wasn't backported. For the full picture please refer to the [Appendix: Bug timeline](#org9803cbd)


# Solution

The same situation as in <https://github.com/ctrliq/kernel-src-tree/pull/490>, which see.


# kABI check: passed

    DEBUG=1 CVE=CVE-2025-37890 ./ninja.sh _kabi_checked__x86_64--test--fips8l-CVE-2025-37890

    [0/1] Check ABI of kernel [fips8l-CVE-2025-37890]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_6/build_files/kernel-src-tree-fips8l-CVE-2025-37890/Module.symvers
    kABI check passed
    + touch state/kernels/fips8l-CVE-2025-37890/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21844710/boot-test.log>)


# Kselftests: passed relative


## Coverage

Only the net-related tests were run.

-   `net/forwarding` (except `sch_tbf_prio.sh`, `ipip_hier_gre_keys.sh`, `sch_tbf_ets.sh`, `mirror_gre_vlan_bridge_1q.sh`, `sch_ets.sh`, `mirror_gre_bridge_1d_vlan.sh`, `bridge_igmp.sh`, `sch_tbf_root.sh`, `tc_actions.sh`),
-   `net/mptcp` (except `mptcp_join.sh`, `simult_flows.sh`),
-   `net` (except `udpgro_fwd.sh`, `udpgso_bench.sh`, `txtimestamp.sh`, `xfrm_policy.sh`, `ip_defrag.sh`, `gro.sh`, `reuseport_addr_any.sh`),
-   `netfilter` (except `nft_trans_stress.sh`)


## Reference

[kselftests&#x2013;fips8l&#x2013;run1.log](<https://github.com/user-attachments/files/21844709/kselftests--fips8l--run1.log>)
[kselftests&#x2013;fips8l&#x2013;run2.log](<https://github.com/user-attachments/files/21844707/kselftests--fips8l--run2.log>)


## Patch

[kselftests&#x2013;fips8l-CVE-2025-37890&#x2013;run1.log](<https://github.com/user-attachments/files/21844706/kselftests--fips8l-CVE-2025-37890--run1.log>)
[kselftests&#x2013;fips8l-CVE-2025-37890&#x2013;run2.log](<https://github.com/user-attachments/files/21844705/kselftests--fips8l-CVE-2025-37890--run2.log>)


## Comparison

The tests results for the reference and patch are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  -------------------------------------------
    Status0   kselftests--fips8l--run1.log
    Status1   kselftests--fips8l--run2.log
    Status2   kselftests--fips8l-CVE-2025-37890--run1.log
    Status3   kselftests--fips8l-CVE-2025-37890--run2.log


# Specific tests: skipped


<a id="org9803cbd"></a>

# Appendix: Bug timeline

(This is a version of "Appendix: Bug timeline" from <https://github.com/ctrliq/kernel-src-tree/pull/490> augmented with FIPS kernels)

The following table summarizes the timeline of the `net/sched/sch_hfsc.c` file on 9 branches:

-   Rocky LTS: `ciqlts9_4`, `ciqlts9_2`, `ciqlts8_6`,
-   Rocky FIPS: `fips-legacy-8-compliant/4.18.0-425.13.1` (as `fips8l`), `fips-8-compliant/4.18.0-553.16.1` (as `fips8c`), `fips-9-compliant/5.14.0-284.30.1` (as `fips9c`),
-   upstream: `kernel-mainline`, `linux-5.15.y`, `linux-4.19.y`,

ordered from the newest to the oldest (roughly).

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-right" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-right">0</td>
<td class="org-left">Commit introducing the bug CVE-2025-37890</td>
</tr>


<tr>
<td class="org-right">1</td>
<td class="org-left">Official fix of CVE-2025-37890</td>
</tr>


<tr>
<td class="org-right">2</td>
<td class="org-left">The fix of the fix of CVE-2025-37890</td>
</tr>
</tbody>
</table>

       kernel-mainline                                                                                                        linux-5.15.y            ciqlts9_4               fips9c                  ciqlts9_2               linux-4.19.y            fips8c                  fips8l                  ciqlts8_6
       ---------------------------------------------------------------------------------------------------------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------
       dd831ac82 2025-07-10 net/sched: sch_qfq: Fix null-deref in agg_dequeue
    2> ac9fe7dd8 2025-05-28 net_sched: hfsc: Address reentrant enqueue adding class to eltree twice                           ~ 2c928b3a0 2025-06-04
       3f9811381 2025-05-22 sch_hfsc: Fix qlen accounting bug when using peek in hfsc_enqueue()                               ~ 89c301e92 2025-06-04
    1> 141d34391 2025-04-28 net_sched: hfsc: Fix a UAF vulnerability in class with netem as child qdisc                       ~ e3e949a39 2025-05-09
       6ccbda44e 2025-04-23 net_sched: hfsc: Fix a potential UAF in hfsc_dequeue() too                                        ~ da7936518 2025-05-02
       3df275ef0 2025-04-23 net_sched: hfsc: Fix a UAF vulnerability in class handling                                        ~ fcc8ede66 2025-05-02
       51eb3b655 2025-04-08 sch_hfsc: make hfsc_qlen_notify() idempotent
       49e8ae537 2024-04-19 net_sched: sch_hfsc: implement lockless accesses to q->defcls
       241a94abc 2024-02-02 net/sched: Add module aliases for cls_,sch_,act_ modules
       f96118c5d 2023-11-01 net: sched: Fill in missing MODULE_DESCRIPTION for qdiscs
       a13b67c9a 2023-10-18 net/sched: sch_hfsc: upgrade 'rt' to 'sc' when it becomes a inner curve                           ~ b33179dbf 2023-10-25  ~ 9950d4d93 2023-10-26  ~ 1d92bc1fc 2025-05-06  ~ 963fd188b 2025-02-21  ~ a39a303c0 2023-10-25  ~ ae71642ce 2024-09-11  ~ 62831c7fb 2025-04-29  ~ 7a44a1754 2025-02-21
       b3d26c570 2023-08-25 net/sched: sch_hfsc: Ensure inner classes have fsc curve                                          ~ 4cf994d3f 2023-09-19  ~ ff4452fb0 2023-10-26  ~ 6eac08331 2025-05-06  ~ 8bb8fbc62 2025-02-21  ~ 7c62e0c3c 2023-09-23  ~ 1a61f0a5d 2024-09-11  ~ 9657abee6 2025-04-29  ~ 1b3b94f37 2024-09-13
       8e4553ef3 2023-08-01 net/sched: sch_hfsc: warn about class in use while deleting                                                               ~ 24c91e176 2023-12-11
       8798481b6 2023-08-01 net/sched: wrap open coded Qdics class filter counter
       e046fa895 2022-09-22 net/sched: use tc_qdisc_stats_dump() in qdisc                                                                             ~ c25ea5b55 2023-05-10                                                                          ~ 425f58a2b 2024-09-11
       a102c8973 2022-09-01 net: sched: remove redundant NULL check in change hook function                                                           ~ c26048684 2023-05-10                                                                          ~ cbb52db96 2024-09-11
       c19d893fb 2022-08-25 net: sched: delete duplicate cleanup of backlog and qlen                                          ~ 34f2a4eed 2022-10-29  ~ 3b0715d0c 2023-05-10                                                                          # 61fc01147 2024-09-11
       29cbcd858 2021-10-18 net: sched: Remove Qdisc::running sequence counter                                                                        ~ 43c09223c 2022-06-06  ~ 43c09223c 2022-06-06  ~ 43c09223c 2022-06-06                          ~ f683b275d 2024-09-11  ~ 47144ea4e 2024-09-12
       50dc9a857 2021-10-18 net: sched: Merge Qdisc::bstats and Qdisc::cpu_bstats data types                                                          ~ 07089a02e 2022-06-06  ~ 07089a02e 2022-06-06  ~ 07089a02e 2022-06-06                          ~ 4d6ceedf8 2024-09-11  ~ e60c20816 2024-09-12
       67c9e6270 2021-10-18 net: sched: Protect Qdisc::bstats with u64_stats                                                                          ~ 899676622 2022-06-06  ~ 899676622 2022-06-06  ~ 899676622 2022-06-06                          ~ a1d655fee 2024-09-11  ~ 6037cb9d1 2024-09-12
       3aa260559 2021-07-29 net/sched: store the last executed chain also for clsact egress                                   = 3aa260559 2021-07-29  ~ bee2c235e 2021-12-09  ~ bee2c235e 2021-12-09  ~ bee2c235e 2021-12-09                          ~ ffb881ce7 2024-09-11  ~ ffb881ce7 2024-09-11  ~ ffb881ce7 2024-09-11
       4dd78a737 2021-01-22 net: sched: Add extack to Qdisc_class_ops.delete                                                  = 4dd78a737 2021-01-22  = 4dd78a737 2021-01-22  = 4dd78a737 2021-01-22  = 4dd78a737 2021-01-22                          ~ d73d5e5ed 2024-09-11  ~ d73d5e5ed 2024-09-11  ~ d73d5e5ed 2024-09-11
       ac5c66f26 2020-07-16 Revert "net: sched: Pass root lock to Qdisc_ops.enqueue"                                          = ac5c66f26 2020-07-16  = ac5c66f26 2020-07-16  = ac5c66f26 2020-07-16  = ac5c66f26 2020-07-16
       3f649ab72 2020-07-16 treewide: Remove uninitialized_var() usage                                                        = 3f649ab72 2020-07-16  = 3f649ab72 2020-07-16  = 3f649ab72 2020-07-16  = 3f649ab72 2020-07-16
       964201de6 2020-07-07 net/sched: Use fallthrough pseudo-keyword                                                         = 964201de6 2020-07-07  = 964201de6 2020-07-07  = 964201de6 2020-07-07  = 964201de6 2020-07-07                          ~ 1dada1b74 2024-09-11  ~ 1dada1b74 2024-09-11  ~ 1dada1b74 2024-09-11
       aebe4426c 2020-06-29 net: sched: Pass root lock to Qdisc_ops.enqueue                                                   = aebe4426c 2020-06-29  = aebe4426c 2020-06-29  = aebe4426c 2020-06-29  = aebe4426c 2020-06-29
       8cb081746 2019-04-27 netlink: make validation more configurable for future strictness                                  = 8cb081746 2019-04-27  = 8cb081746 2019-04-27  = 8cb081746 2019-04-27  = 8cb081746 2019-04-27                          # 9c3767b38 2024-09-11  # 9c3767b38 2024-09-11  # 9c3767b38 2024-09-11
       ae0be8de9 2019-04-27 netlink: make nla_nest_start() add NLA_F_NESTED flag                                              = ae0be8de9 2019-04-27  = ae0be8de9 2019-04-27  = ae0be8de9 2019-04-27  = ae0be8de9 2019-04-27                          # 9c3767b38 2024-09-11  # 9c3767b38 2024-09-11  # 9c3767b38 2024-09-11
       e5f0e8f8e 2019-04-01 net: sched: introduce and use qdisc tree flush/purge helpers                                      = e5f0e8f8e 2019-04-01  = e5f0e8f8e 2019-04-01  = e5f0e8f8e 2019-04-01  = e5f0e8f8e 2019-04-01                          ~ 8eebb4e4c 2024-09-11  ~ 8eebb4e4c 2024-09-11  ~ 8eebb4e4c 2024-09-11
       5dd431b6b 2019-04-01 net: sched: introduce and use qstats read helpers                                                 = 5dd431b6b 2019-04-01  = 5dd431b6b 2019-04-01  = 5dd431b6b 2019-04-01  = 5dd431b6b 2019-04-01                          ~ ce56c8fb0 2024-09-11  ~ ce56c8fb0 2024-09-11  ~ ce56c8fb0 2024-09-11
    0> 37d9cf1a3 2019-01-15 sched: Fix detection of empty queues in child qdiscs                                              = 37d9cf1a3 2019-01-15  = 37d9cf1a3 2019-01-15  = 37d9cf1a3 2019-01-15  = 37d9cf1a3 2019-01-15                          ~ f3e1778ab 2024-09-11  ~ f3e1778ab 2024-09-11  ~ f3e1778ab 2024-09-11
       f6bab1993 2019-01-15 sched: Avoid dereferencing skb pointer after child enqueue                                        = f6bab1993 2019-01-15  = f6bab1993 2019-01-15  = f6bab1993 2019-01-15  = f6bab1993 2019-01-15                          ~ aded77caa 2024-09-11  ~ aded77caa 2024-09-11  ~ aded77caa 2024-09-11
       …

