### PR TITLE
[FIPS 8.10] net_sched: hfsc: Address reentrant enqueue adding class to eltree twice

### DIFF
--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -1559,7 +1559,7 @@ hfsc_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff **to_free)
 		return err;
 	}
 
-	if (first) {
+	if (first && !cl->cl_nactive) {
 		if (cl->cl_flags & HFSC_RSC)
 			init_ed(cl, len);
 		if (cl->cl_flags & HFSC_FSC)

--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -176,6 +176,11 @@ struct hfsc_sched {
 
 #define	HT_INFINITY	0xffffffffffffffffULL	/* infinite time value */
 
+static bool cl_in_el_or_vttree(struct hfsc_class *cl)
+{
+	return ((cl->cl_flags & HFSC_FSC) && cl->cl_nactive) ||
+		((cl->cl_flags & HFSC_RSC) && !RB_EMPTY_NODE(&cl->el_node));
+}
 
 /*
  * eligible tree holds backlogged classes being sorted by their eligible times.
@@ -1033,6 +1038,8 @@ hfsc_change_class(struct Qdisc *sch, u32 classid, u32 parentid,
 	if (cl == NULL)
 		return -ENOBUFS;
 
+	RB_CLEAR_NODE(&cl->el_node);
+
 	err = tcf_block_get(&cl->block, &cl->filter_list, sch, extack);
 	if (err) {
 		kfree(cl);
@@ -1559,7 +1566,7 @@ hfsc_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff **to_free)
 		return err;
 	}
 
-	if (first && !cl->cl_nactive) {
+	if (first && !cl_in_el_or_vttree(cl)) {
 		if (cl->cl_flags & HFSC_RSC)
 			init_ed(cl, len);
 		if (cl->cl_flags & HFSC_FSC)


### PR DESCRIPTION
[FIPS 8.10]
CVE-2025-37890
VULN-68293
VULN-68292


# Problem

<https://access.redhat.com/security/cve/CVE-2025-37890>
> A use-after-free vulnerability has been identified in the Linux kernel's HFSC (Hierarchical Fair Service Curve) queuing discipline when it is configured with NETEM (Network Emulation) as a child. This flaw can lead to a kernel panic or crash due to incorrect assumptions about the queue state. Exploitation of this vulnerability requires local access with CAP\_NET\_ADMIN privileges and control over the qdisc (queueing discipline) setup. A local attacker could leverage this flaw to achieve denial of service or escalate privileges. Given that it affects kernel memory structures, successful exploitation could result in memory corruption, data leaks, or arbitrary write capabilities, leading to a full kernel crash.


# Applicability: yes

The patch relates to the `sch_hfsc` module, enabled with the `NET_SCH_HFSC` option. It's set to `m` in all configs of FIPS 8.10:

    $ grep 'NET_SCH_HFSC\b' configs/*.config

    configs/kernel-aarch64-debug.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-aarch64.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-ppc64le-debug.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-ppc64le.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-debug.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x-zfcpdump.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-s390x.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64-debug.config:CONFIG_NET_SCH_HFSC=m
    configs/kernel-x86_64.config:CONFIG_NET_SCH_HFSC=m

The commit 37d9cf1a3ce35de3df6f7d209bfb1f50cf188cea marked as introducing the bug was backported to FIPS 8.10 in f3e1778ab44512570f4702dd88030d89d9d85518. The mainline fix 141d34391abbb315d68556b7c67ad97885407547 wasn't backported. For the full picture please refer to the "Appendix: Bug timeline" section in <https://github.com/ctrliq/kernel-src-tree/pull/510>.


# Solution

The same situation as in <https://github.com/ctrliq/kernel-src-tree/pull/490>, which see.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-2025-37890 ./ninja.sh _kabi_checked__x86_64--test--fips8c-CVE-2025-37890

    [0/1] Check ABI of kernel [fips8c-CVE-2025-37890]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_10/build_files/kernel-src-tree-fips8c-CVE-2025-37890/Module.symvers
    kABI check passed
    + touch state/kernels/fips8c-CVE-2025-37890/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21865867/boot-test.log>)


# Kselftests: passed relative


## Coverage

Only the net-related tests were run.

-   `net/forwarding` (except `sch_ets.sh`, `sch_tbf_root.sh`, `mirror_gre_bridge_1d_vlan.sh`, `mirror_gre_vlan_bridge_1q.sh`, `tc_actions.sh`, `bridge_igmp.sh`, `sch_tbf_prio.sh`, `sch_tbf_ets.sh`, `ipip_hier_gre_keys.sh`),
-   `net/mptcp` (except `mptcp_join.sh`, `simult_flows.sh`),
-   `net` (except `udpgso_bench.sh`, `gro.sh`, `ip_defrag.sh`, `txtimestamp.sh`, `xfrm_policy.sh`, `reuseport_addr_any.sh`, `udpgro_fwd.sh`),
-   `netfilter` (except `nft_trans_stress.sh`)


## Reference

[kselftests&#x2013;fips8c&#x2013;run1.log](<https://github.com/user-attachments/files/21865184/kselftests--fips8c--run1.log>)
[kselftests&#x2013;fips8c&#x2013;run2.log](<https://github.com/user-attachments/files/21865180/kselftests--fips8c--run2.log>)


## Patch

[kselftests&#x2013;fips8c-CVE-2025-37890&#x2013;run1.log](<https://github.com/user-attachments/files/21865178/kselftests--fips8c-CVE-2025-37890--run1.log>)
[kselftests&#x2013;fips8c-CVE-2025-37890&#x2013;run2.log](<https://github.com/user-attachments/files/21865173/kselftests--fips8c-CVE-2025-37890--run2.log>)


## Comparison

The results for the reference and the patch are the same:

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  -------------------------------------------
    Status0   kselftests--fips8l--run1.log
    Status1   kselftests--fips8l--run2.log
    Status2   kselftests--fips8l-CVE-2025-37890--run1.log
    Status3   kselftests--fips8l-CVE-2025-37890--run2.log


# Specific tests: skipped

