### PR TITLE
[LE-3813] RDMA/mana_ib: use the correct page table index based on hardware page size

### DIFF
--- a/drivers/infiniband/hw/mana/main.c
+++ b/drivers/infiniband/hw/mana/main.c
@@ -511,13 +511,13 @@ int mana_ib_mmap(struct ib_ucontext *ibcontext, struct vm_area_struct *vma)
 	      PAGE_SHIFT;
 	prot = pgprot_writecombine(vma->vm_page_prot);
 
-	ret = rdma_user_mmap_io(ibcontext, vma, pfn, gc->db_page_size, prot,
+	ret = rdma_user_mmap_io(ibcontext, vma, pfn, PAGE_SIZE, prot,
 				NULL);
 	if (ret)
 		ibdev_dbg(ibdev, "can't rdma_user_mmap_io ret %d\n", ret);
 	else
-		ibdev_dbg(ibdev, "mapped I/O pfn 0x%llx page_size %u, ret %d\n",
-			  pfn, gc->db_page_size, ret);
+		ibdev_dbg(ibdev, "mapped I/O pfn 0x%llx page_size %lu, ret %d\n",
+			  pfn, PAGE_SIZE, ret);
 
 	return ret;
 }

--- a/drivers/infiniband/hw/mana/main.c
+++ b/drivers/infiniband/hw/mana/main.c
@@ -383,7 +383,7 @@ static int mana_ib_gd_create_dma_region(struct mana_ib_dev *dev, struct ib_umem 
 
 	create_req->length = umem->length;
 	create_req->offset_in_page = ib_umem_dma_offset(umem, page_sz);
-	create_req->gdma_page_type = order_base_2(page_sz) - PAGE_SHIFT;
+	create_req->gdma_page_type = order_base_2(page_sz) - MANA_PAGE_SHIFT;
 	create_req->page_count = num_pages_total;
 
 	ibdev_dbg(&dev->ib_dev, "size_dma_region %lu num_pages_total %lu\n",


### PR DESCRIPTION

### Commit message
```
RDMA/mana_ib: use the correct page table index based on hardware page size
jira LE-3813
commit-author Long Li <longli@microsoft.com>
commit 9e517a8

MANA hardware uses 4k page size. When calculating the page table index,
it should use the hardware page size, not the system page size.

	Cc: stable@vger.kernel.org
Fixes: 0266a17 ("RDMA/mana_ib: Add a driver for Microsoft Azure Network Adapter")
	Signed-off-by: Long Li <longli@microsoft.com>
Link: https://patch.msgid.link/1725030993-16213-1-git-send-email-longli@linuxonhyperv.com
	Signed-off-by: Leon Romanovsky <leon@kernel.org>
(cherry picked from commit 9e517a8)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>

---------------------------------------------------------------------------------------------------

RDMA/mana_ib: use the correct page size for mapping user-mode doorbell page
jira LE-3813
commit-author Long Li <longli@microsoft.com>
commit 4a3b99b

When mapping doorbell page from user-mode, the driver should use the system
page size as this memory is allocated via mmap() from user-mode.

	Cc: stable@vger.kernel.org
Fixes: 0266a17 ("RDMA/mana_ib: Add a driver for Microsoft Azure Network Adapter")
	Signed-off-by: Long Li <longli@microsoft.com>
Link: https://patch.msgid.link/1725030993-16213-2-git-send-email-longli@linuxonhyperv.com
	Signed-off-by: Leon Romanovsky <leon@kernel.org>
(cherry picked from commit 4a3b99b)
	Signed-off-by: Shreeya Patel <spatel@ciq.com>```

### Kernel build logs
```
/mnt/scratch/workspace/sig-cloud-9/kernel-src-tree
Running make mrproper...
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/kvm
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/tools
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/gpu/drm/xe
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr/include
  CLEAN   usr
  CLEAN   vmlinux.symvers modules-only.symvers modules.builtin modules.builtin.modinfo
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 8s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  <--snip-->
  sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+/kernel/drivers/hwmon/adm1031.ko
  DEPMOD  /lib/modules/5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+
[TIMER]{MODULES}: 11s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+ \
	arch/x86/boot/bzImage System.map "/boot"
sed: can't read /boot/.vmlinuz-5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+.hmac: No such file or directory
Can't create '/boot/.vmlinuz-0-rescue-c3004629c739468680b07075d6fee68a.hmac' from '/boot/.vmlinuz-5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+.hmac'!
[TIMER]{INSTALL}: 40s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+ and Index to 2
The default is /boot/loader/entries/c3004629c739468680b07075d6fee68a-5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+
The default is /boot/loader/entries/c3004629c739468680b07075d6fee68a-5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-shreeya_sig-cloud-9_5.14.0-570.30.1.el9_6-512aa8d1edc0+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 8s
[TIMER]{BUILD}: 1826s
[TIMER]{MODULES}: 11s
[TIMER]{INSTALL}: 40s
[TIMER]{TOTAL} 1891s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21896973/kernel-build.log)


### Kselftests
```
shreeya@spatel-dev-bom ~/c/w/sig-cloud-9> grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
382
382
shreeya@spatel-dev-bom ~/c/w/sig-cloud-9> grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
89
89
```
[kselftest-after.log](https://github.com/user-attachments/files/21896979/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/21896980/kselftest-before.log)


