### PR TITLE
[lts94] CVE-2025-38380 and CVE-38471

### DIFF
--- a/drivers/i2c/busses/i2c-designware-master.c
+++ b/drivers/i2c/busses/i2c-designware-master.c
@@ -298,6 +298,7 @@ static int amd_i2c_dw_xfer_quirk(struct i2c_adapter *adap, struct i2c_msg *msgs,
 
 	dev->msgs = msgs;
 	dev->msgs_num = num_msgs;
+	dev->msg_write_idx = 0;
 	i2c_dw_xfer_init(dev);
 	i2c_dw_disable_int(dev);
 

--- a/net/tls/tls_strp.c
+++ b/net/tls/tls_strp.c
@@ -510,9 +510,8 @@ static int tls_strp_read_sock(struct tls_strparser *strp)
 	if (inq < strp->stm.full_len)
 		return tls_strp_read_copy(strp, true);
 
+	tls_strp_load_anchor_with_queue(strp, inq);
 	if (!strp->stm.full_len) {
-		tls_strp_load_anchor_with_queue(strp, inq);
-
 		sz = tls_rx_msg_size(strp, strp->anchor);
 		if (sz < 0) {
 			tls_strp_abort_strp(strp, sz);


### PR DESCRIPTION
```
tls: always refresh the queue when reading sock
jira VULN-89195
cve CVE-2025-38471
commit-author Jakub Kicinski <kuba@kernel.org>
commit 4ab26bce3969f8fd925fe6f6f551e4d1a508c68b
```

```
i2c/designware: Fix an initialization issue
jira VULN-79510
cve CVE-2025-38380
commit-author Michael J. Ruhl <michael.j.ruhl@intel.com>
commit 3d30048958e0d43425f6d4e76565e6249fa71050
```

### Build Log

```
/home/brett/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 10s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
--
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  BTF [M] sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1258s
Making Modules
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  STRIP   /lib/modules/5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+
[TIMER]{MODULES}: 7s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 126s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 10s
[TIMER]{BUILD}: 1258s
[TIMER]{MODULES}: 7s
[TIMER]{INSTALL}: 126s
[TIMER]{TOTAL} 1419s
Rebooting in 10 seconds

```

### Testing

[selftest-5.14.0-427.42.1.el9_4.94ciq_lts.6.2.x86_64.log](https://github.com/user-attachments/files/21925431/selftest-5.14.0-427.42.1.el9_4.94ciq_lts.6.2.x86_64.log)

[selftest-5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+.log](https://github.com/user-attachments/files/21925432/selftest-5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9%2B.log)

```
brett@lycia ~/ciq/many-vulns-94-8-21-25
 % grep ^ok selftest-5.14.0-427.42.1.el9_4.94ciq_lts.6.2.x86_64.log | wc -l
336
brett@lycia ~/ciq/many-vulns-94-8-21-25
 % grep ^ok selftest-5.14.0-bmastbergen_ciqlts9_4_many-vulns-8-21-25-5c89329c35c9+.log | wc -l
336

```
