### PR TITLE
[SIG-CLOUD-8] Rebase custom chages to kernel-4.18.0-553.66.1.el8_10

### DIFF
--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1041,6 +1041,10 @@ static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 
 		c->x86_virt_bits = (eax >> 8) & 0xff;
 		c->x86_phys_bits = eax & 0xff;
+
+		/* Provide a sane default if not enumerated: */
+		if (!c->x86_clflush_size)
+			c->x86_clflush_size = 32;
 	}
 
 	c->x86_cache_bits = c->x86_phys_bits;

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1020,18 +1020,9 @@ void get_cpu_cap(struct cpuinfo_x86 *c)
 static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 {
 	u32 eax, ebx, ecx, edx;
-	bool vp_bits_from_cpuid = true;
 
 	if (!cpu_has(c, X86_FEATURE_CPUID) ||
-	    (c->extended_cpuid_level < 0x80000008))
-		vp_bits_from_cpuid = false;
-
-	if (vp_bits_from_cpuid) {
-		cpuid(0x80000008, &eax, &ebx, &ecx, &edx);
-
-		c->x86_virt_bits = (eax >> 8) & 0xff;
-		c->x86_phys_bits = eax & 0xff;
-	} else {
+	    (c->extended_cpuid_level < 0x80000008)) {
 		if (IS_ENABLED(CONFIG_X86_64)) {
 			c->x86_clflush_size = 64;
 			c->x86_phys_bits = 36;
@@ -1045,7 +1036,13 @@ static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 			    cpu_has(c, X86_FEATURE_PSE36))
 				c->x86_phys_bits = 36;
 		}
+	} else {
+		cpuid(0x80000008, &eax, &ebx, &ecx, &edx);
+
+		c->x86_virt_bits = (eax >> 8) & 0xff;
+		c->x86_phys_bits = eax & 0xff;
 	}
+
 	c->x86_cache_bits = c->x86_phys_bits;
 	c->x86_cache_alignment = c->x86_clflush_size;
 }

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1020,17 +1020,32 @@ void get_cpu_cap(struct cpuinfo_x86 *c)
 static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 {
 	u32 eax, ebx, ecx, edx;
+	bool vp_bits_from_cpuid = true;
 
-	if (c->extended_cpuid_level >= 0x80000008) {
+	if (!cpu_has(c, X86_FEATURE_CPUID) ||
+	    (c->extended_cpuid_level < 0x80000008))
+		vp_bits_from_cpuid = false;
+
+	if (vp_bits_from_cpuid) {
 		cpuid(0x80000008, &eax, &ebx, &ecx, &edx);
 
 		c->x86_virt_bits = (eax >> 8) & 0xff;
 		c->x86_phys_bits = eax & 0xff;
+	} else {
+		if (IS_ENABLED(CONFIG_X86_64)) {
+			c->x86_clflush_size = 64;
+			c->x86_phys_bits = 36;
+			c->x86_virt_bits = 48;
+		} else {
+			c->x86_clflush_size = 32;
+			c->x86_virt_bits = 32;
+			c->x86_phys_bits = 32;
+
+			if (cpu_has(c, X86_FEATURE_PAE) ||
+			    cpu_has(c, X86_FEATURE_PSE36))
+				c->x86_phys_bits = 36;
+		}
 	}
-#ifdef CONFIG_X86_32
-	else if (cpu_has(c, X86_FEATURE_PAE) || cpu_has(c, X86_FEATURE_PSE36))
-		c->x86_phys_bits = 36;
-#endif
 	c->x86_cache_bits = c->x86_phys_bits;
 }
 
@@ -1468,15 +1483,6 @@ static void __init cpu_parse_early_param(void)
  */
 static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 {
-#ifdef CONFIG_X86_64
-	c->x86_clflush_size = 64;
-	c->x86_phys_bits = 36;
-	c->x86_virt_bits = 48;
-#else
-	c->x86_clflush_size = 32;
-	c->x86_phys_bits = 32;
-	c->x86_virt_bits = 32;
-#endif
 	c->x86_cache_alignment = c->x86_clflush_size;
 
 	memset(&c->x86_capability, 0, sizeof(c->x86_capability));
@@ -1488,7 +1494,6 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 		get_cpu_vendor(c);
 		get_cpu_cap(c);
 		get_model_name(c); /* RHEL8: get model name for unsupported check */
-		get_cpu_address_sizes(c);
 		setup_force_cpu_cap(X86_FEATURE_CPUID);
 		cpu_parse_early_param();
 
@@ -1504,6 +1509,8 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 		identify_cpu_without_cpuid(c);
 		setup_clear_cpu_cap(X86_FEATURE_CPUID);
 	}
+
+	get_cpu_address_sizes(c);
 
 	setup_force_cpu_cap(X86_FEATURE_ALWAYS);
 

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1494,6 +1494,7 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 		get_cpu_cap(c);
 		get_model_name(c); /* RHEL8: get model name for unsupported check */
 		setup_force_cpu_cap(X86_FEATURE_CPUID);
+		get_cpu_address_sizes(c);
 		cpu_parse_early_param();
 
 		if (this_cpu->c_early_init)
@@ -1507,9 +1508,8 @@ static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 	} else {
 		identify_cpu_without_cpuid(c);
 		setup_clear_cpu_cap(X86_FEATURE_CPUID);
+		get_cpu_address_sizes(c);
 	}
-
-	get_cpu_address_sizes(c);
 
 	setup_force_cpu_cap(X86_FEATURE_ALWAYS);
 

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -1047,6 +1047,7 @@ static void get_cpu_address_sizes(struct cpuinfo_x86 *c)
 		}
 	}
 	c->x86_cache_bits = c->x86_phys_bits;
+	c->x86_cache_alignment = c->x86_clflush_size;
 }
 
 static void identify_cpu_without_cpuid(struct cpuinfo_x86 *c)
@@ -1483,8 +1484,6 @@ static void __init cpu_parse_early_param(void)
  */
 static void __init early_identify_cpu(struct cpuinfo_x86 *c)
 {
-	c->x86_cache_alignment = c->x86_clflush_size;
-
 	memset(&c->x86_capability, 0, sizeof(c->x86_capability));
 	c->extended_cpuid_level = 0;
 

--- a/drivers/infiniband/hw/mana/main.c
+++ b/drivers/infiniband/hw/mana/main.c
@@ -359,7 +359,7 @@ int mana_ib_gd_create_dma_region(struct mana_ib_dev *dev, struct ib_umem *umem,
 
 	create_req->length = umem->length;
 	create_req->offset_in_page = ib_umem_dma_offset(umem, page_sz);
-	create_req->gdma_page_type = order_base_2(page_sz) - PAGE_SHIFT;
+	create_req->gdma_page_type = order_base_2(page_sz) - MANA_PAGE_SHIFT;
 	create_req->page_count = num_pages_total;
 
 	ibdev_dbg(&dev->ib_dev, "size_dma_region %lu num_pages_total %lu\n",

--- a/drivers/infiniband/hw/mana/main.c
+++ b/drivers/infiniband/hw/mana/main.c
@@ -358,7 +358,7 @@ int mana_ib_gd_create_dma_region(struct mana_ib_dev *dev, struct ib_umem *umem,
 			     sizeof(struct gdma_create_dma_region_resp));
 
 	create_req->length = umem->length;
-	create_req->offset_in_page = umem->address & (page_sz - 1);
+	create_req->offset_in_page = ib_umem_dma_offset(umem, page_sz);
 	create_req->gdma_page_type = order_base_2(page_sz) - PAGE_SHIFT;
 	create_req->page_count = num_pages_total;
 

--- a/drivers/infiniband/hw/mana/main.c
+++ b/drivers/infiniband/hw/mana/main.c
@@ -460,13 +460,13 @@ int mana_ib_mmap(struct ib_ucontext *ibcontext, struct vm_area_struct *vma)
 	      PAGE_SHIFT;
 	prot = pgprot_writecombine(vma->vm_page_prot);
 
-	ret = rdma_user_mmap_io(ibcontext, vma, pfn, gc->db_page_size, prot,
+	ret = rdma_user_mmap_io(ibcontext, vma, pfn, PAGE_SIZE, prot,
 				NULL);
 	if (ret)
 		ibdev_dbg(ibdev, "can't rdma_user_mmap_io ret %d\n", ret);
 	else
-		ibdev_dbg(ibdev, "mapped I/O pfn 0x%llx page_size %u, ret %d\n",
-			  pfn, gc->db_page_size, ret);
+		ibdev_dbg(ibdev, "mapped I/O pfn 0x%llx page_size %lu, ret %d\n",
+			  pfn, PAGE_SIZE, ret);
 
 	return ret;
 }

--- a/drivers/net/ethernet/microsoft/Kconfig
+++ b/drivers/net/ethernet/microsoft/Kconfig
@@ -17,7 +17,8 @@ if NET_VENDOR_MICROSOFT
 
 config MICROSOFT_MANA
 	tristate "Microsoft Azure Network Adapter (MANA) support"
-	depends on PCI_MSI && X86_64
+	depends on PCI_MSI
+	depends on X86_64 || (ARM64 && !CPU_BIG_ENDIAN && ARM64_4K_PAGES)
 	depends on PCI_HYPERV
 	select AUXILIARY_BUS
 	help

--- a/drivers/net/ethernet/microsoft/Kconfig
+++ b/drivers/net/ethernet/microsoft/Kconfig
@@ -18,7 +18,7 @@ if NET_VENDOR_MICROSOFT
 config MICROSOFT_MANA
 	tristate "Microsoft Azure Network Adapter (MANA) support"
 	depends on PCI_MSI
-	depends on X86_64 || (ARM64 && !CPU_BIG_ENDIAN && ARM64_4K_PAGES)
+	depends on X86_64 || (ARM64 && !CPU_BIG_ENDIAN)
 	depends on PCI_HYPERV
 	select AUXILIARY_BUS
 	help

--- a/drivers/net/ethernet/microsoft/mana/gdma_main.c
+++ b/drivers/net/ethernet/microsoft/mana/gdma_main.c
@@ -182,7 +182,7 @@ int mana_gd_alloc_memory(struct gdma_context *gc, unsigned int length,
 	dma_addr_t dma_handle;
 	void *buf;
 
-	if (length < PAGE_SIZE || !is_power_of_2(length))
+	if (length < MANA_PAGE_SIZE || !is_power_of_2(length))
 		return -EINVAL;
 
 	gmi->dev = gc->dev;
@@ -717,7 +717,7 @@ EXPORT_SYMBOL(mana_gd_destroy_dma_region);
 static int mana_gd_create_dma_region(struct gdma_dev *gd,
 				     struct gdma_mem_info *gmi)
 {
-	unsigned int num_page = gmi->length / PAGE_SIZE;
+	unsigned int num_page = gmi->length / MANA_PAGE_SIZE;
 	struct gdma_create_dma_region_req *req = NULL;
 	struct gdma_create_dma_region_resp resp = {};
 	struct gdma_context *gc = gd->gdma_context;
@@ -727,10 +727,10 @@ static int mana_gd_create_dma_region(struct gdma_dev *gd,
 	int err;
 	int i;
 
-	if (length < PAGE_SIZE || !is_power_of_2(length))
+	if (length < MANA_PAGE_SIZE || !is_power_of_2(length))
 		return -EINVAL;
 
-	if (offset_in_page(gmi->virt_addr) != 0)
+	if (!MANA_PAGE_ALIGNED(gmi->virt_addr))
 		return -EINVAL;
 
 	hwc = gc->hwc.driver_data;
@@ -751,7 +751,7 @@ static int mana_gd_create_dma_region(struct gdma_dev *gd,
 	req->page_addr_list_len = num_page;
 
 	for (i = 0; i < num_page; i++)
-		req->page_addr_list[i] = gmi->dma_handle +  i * PAGE_SIZE;
+		req->page_addr_list[i] = gmi->dma_handle +  i * MANA_PAGE_SIZE;
 
 	err = mana_gd_send_request(gc, req_msg_size, req, sizeof(resp), &resp);
 	if (err)

--- a/drivers/net/ethernet/microsoft/mana/hw_channel.c
+++ b/drivers/net/ethernet/microsoft/mana/hw_channel.c
@@ -361,12 +361,12 @@ static int mana_hwc_create_cq(struct hw_channel_context *hwc, u16 q_depth,
 	int err;
 
 	eq_size = roundup_pow_of_two(GDMA_EQE_SIZE * q_depth);
-	if (eq_size < MINIMUM_SUPPORTED_PAGE_SIZE)
-		eq_size = MINIMUM_SUPPORTED_PAGE_SIZE;
+	if (eq_size < MANA_MIN_QSIZE)
+		eq_size = MANA_MIN_QSIZE;
 
 	cq_size = roundup_pow_of_two(GDMA_CQE_SIZE * q_depth);
-	if (cq_size < MINIMUM_SUPPORTED_PAGE_SIZE)
-		cq_size = MINIMUM_SUPPORTED_PAGE_SIZE;
+	if (cq_size < MANA_MIN_QSIZE)
+		cq_size = MANA_MIN_QSIZE;
 
 	hwc_cq = kzalloc(sizeof(*hwc_cq), GFP_KERNEL);
 	if (!hwc_cq)
@@ -428,7 +428,7 @@ static int mana_hwc_alloc_dma_buf(struct hw_channel_context *hwc, u16 q_depth,
 
 	dma_buf->num_reqs = q_depth;
 
-	buf_size = PAGE_ALIGN(q_depth * max_msg_size);
+	buf_size = MANA_PAGE_ALIGN(q_depth * max_msg_size);
 
 	gmi = &dma_buf->mem_info;
 	err = mana_gd_alloc_memory(gc, buf_size, gmi);
@@ -496,8 +496,8 @@ static int mana_hwc_create_wq(struct hw_channel_context *hwc,
 	else
 		queue_size = roundup_pow_of_two(GDMA_MAX_SQE_SIZE * q_depth);
 
-	if (queue_size < MINIMUM_SUPPORTED_PAGE_SIZE)
-		queue_size = MINIMUM_SUPPORTED_PAGE_SIZE;
+	if (queue_size < MANA_MIN_QSIZE)
+		queue_size = MANA_MIN_QSIZE;
 
 	hwc_wq = kzalloc(sizeof(*hwc_wq), GFP_KERNEL);
 	if (!hwc_wq)

--- a/drivers/net/ethernet/microsoft/mana/mana_en.c
+++ b/drivers/net/ethernet/microsoft/mana/mana_en.c
@@ -1867,10 +1867,10 @@ static int mana_create_txq(struct mana_port_context *apc,
 	 *  to prevent overflow.
 	 */
 	txq_size = MAX_SEND_BUFFERS_PER_QUEUE * 32;
-	BUILD_BUG_ON(!PAGE_ALIGNED(txq_size));
+	BUILD_BUG_ON(!MANA_PAGE_ALIGNED(txq_size));
 
 	cq_size = MAX_SEND_BUFFERS_PER_QUEUE * COMP_ENTRY_SIZE;
-	cq_size = PAGE_ALIGN(cq_size);
+	cq_size = MANA_PAGE_ALIGN(cq_size);
 
 	gc = gd->gdma_context;
 
@@ -2128,8 +2128,8 @@ static struct mana_rxq *mana_create_rxq(struct mana_port_context *apc,
 	if (err)
 		goto out;
 
-	rq_size = PAGE_ALIGN(rq_size);
-	cq_size = PAGE_ALIGN(cq_size);
+	rq_size = MANA_PAGE_ALIGN(rq_size);
+	cq_size = MANA_PAGE_ALIGN(cq_size);
 
 	/* Create RQ */
 	memset(&spec, 0, sizeof(spec));

--- a/drivers/net/ethernet/microsoft/mana/shm_channel.c
+++ b/drivers/net/ethernet/microsoft/mana/shm_channel.c
@@ -6,6 +6,7 @@
 #include <linux/io.h>
 #include <linux/mm.h>
 
+#include <net/mana/gdma.h>
 #include <net/mana/shm_channel.h>
 
 #define PAGE_FRAME_L48_WIDTH_BYTES 6
@@ -155,8 +156,8 @@ int mana_smc_setup_hwc(struct shm_channel *sc, bool reset_vf, u64 eq_addr,
 		return err;
 	}
 
-	if (!PAGE_ALIGNED(eq_addr) || !PAGE_ALIGNED(cq_addr) ||
-	    !PAGE_ALIGNED(rq_addr) || !PAGE_ALIGNED(sq_addr))
+	if (!MANA_PAGE_ALIGNED(eq_addr) || !MANA_PAGE_ALIGNED(cq_addr) ||
+	    !MANA_PAGE_ALIGNED(rq_addr) || !MANA_PAGE_ALIGNED(sq_addr))
 		return -EINVAL;
 
 	if ((eq_msix_index & VECTOR_MASK) != eq_msix_index)
@@ -183,7 +184,7 @@ int mana_smc_setup_hwc(struct shm_channel *sc, bool reset_vf, u64 eq_addr,
 
 	/* EQ addr: low 48 bits of frame address */
 	shmem = (u64 *)ptr;
-	frame_addr = PHYS_PFN(eq_addr);
+	frame_addr = MANA_PFN(eq_addr);
 	*shmem = frame_addr & PAGE_FRAME_L48_MASK;
 	all_addr_h4bits |= (frame_addr >> PAGE_FRAME_L48_WIDTH_BITS) <<
 		(frame_addr_seq++ * PAGE_FRAME_H4_WIDTH_BITS);
@@ -191,7 +192,7 @@ int mana_smc_setup_hwc(struct shm_channel *sc, bool reset_vf, u64 eq_addr,
 
 	/* CQ addr: low 48 bits of frame address */
 	shmem = (u64 *)ptr;
-	frame_addr = PHYS_PFN(cq_addr);
+	frame_addr = MANA_PFN(cq_addr);
 	*shmem = frame_addr & PAGE_FRAME_L48_MASK;
 	all_addr_h4bits |= (frame_addr >> PAGE_FRAME_L48_WIDTH_BITS) <<
 		(frame_addr_seq++ * PAGE_FRAME_H4_WIDTH_BITS);
@@ -199,7 +200,7 @@ int mana_smc_setup_hwc(struct shm_channel *sc, bool reset_vf, u64 eq_addr,
 
 	/* RQ addr: low 48 bits of frame address */
 	shmem = (u64 *)ptr;
-	frame_addr = PHYS_PFN(rq_addr);
+	frame_addr = MANA_PFN(rq_addr);
 	*shmem = frame_addr & PAGE_FRAME_L48_MASK;
 	all_addr_h4bits |= (frame_addr >> PAGE_FRAME_L48_WIDTH_BITS) <<
 		(frame_addr_seq++ * PAGE_FRAME_H4_WIDTH_BITS);
@@ -207,7 +208,7 @@ int mana_smc_setup_hwc(struct shm_channel *sc, bool reset_vf, u64 eq_addr,
 
 	/* SQ addr: low 48 bits of frame address */
 	shmem = (u64 *)ptr;
-	frame_addr = PHYS_PFN(sq_addr);
+	frame_addr = MANA_PFN(sq_addr);
 	*shmem = frame_addr & PAGE_FRAME_L48_MASK;
 	all_addr_h4bits |= (frame_addr >> PAGE_FRAME_L48_WIDTH_BITS) <<
 		(frame_addr_seq++ * PAGE_FRAME_H4_WIDTH_BITS);

--- a/include/net/mana/gdma.h
+++ b/include/net/mana/gdma.h
@@ -224,7 +224,15 @@ struct gdma_dev {
 	struct auxiliary_device *adev;
 };
 
-#define MINIMUM_SUPPORTED_PAGE_SIZE PAGE_SIZE
+/* MANA_PAGE_SIZE is the DMA unit */
+#define MANA_PAGE_SHIFT 12
+#define MANA_PAGE_SIZE BIT(MANA_PAGE_SHIFT)
+#define MANA_PAGE_ALIGN(x) ALIGN((x), MANA_PAGE_SIZE)
+#define MANA_PAGE_ALIGNED(addr) IS_ALIGNED((unsigned long)(addr), MANA_PAGE_SIZE)
+#define MANA_PFN(a) ((a) >> MANA_PAGE_SHIFT)
+
+/* Required by HW */
+#define MANA_MIN_QSIZE MANA_PAGE_SIZE
 
 #define GDMA_CQE_SIZE 64
 #define GDMA_EQE_SIZE 16

--- a/include/net/mana/mana.h
+++ b/include/net/mana/mana.h
@@ -40,7 +40,8 @@ enum TRI_STATE {
 
 #define MAX_SEND_BUFFERS_PER_QUEUE 256
 
-#define EQ_SIZE (8 * PAGE_SIZE)
+#define EQ_SIZE (8 * MANA_PAGE_SIZE)
+
 #define LOG2_EQ_THROTTLE 3
 
 #define MAX_PORTS_IN_MANA_DEV 256


### PR DESCRIPTION
## Update process (This kernel CentOS base for `4.18.0-553`)
* Kernel History Rebuild Process for all `src.rpm`s hosted by RESF
* Create `sig-cloud-8/4.18.0-553.53.1.el8_10` branch
* Check if any maintained code is included in the new `el` release.
* Cherry-pick all code from previous branch into new branch (skipping unneeded code) 
  * Fix conflicts as they arise 
* Build and Test

## Removed Commits
None

## Rebase Resutls
```
[jmaple@devbox code]$ cat RR.resf_kernel-4.18.0-553.66.1.el8_10-30-g98b6d02b3b85.log
[rolling release update] Rolling Product:  sig-cloud-8
[rolling release update] Checking out branch:  sig-cloud-8/4.18.0-553.62.1.el8_10
[rolling release update] Gathering all the RESF kernel Tags
b'e252413ceae1 (tag: resf_kernel-4.18.0-553.62.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.62.1.el8_10'
b'5c89e3d2c056 (tag: resf_kernel-4.18.0-553.60.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.60.1.el8_10'
b'2e416d167715 (tag: resf_kernel-4.18.0-553.58.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.58.1.el8_10'
b'1ad2baf0efe1 (tag: resf_kernel-4.18.0-553.56.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.56.1.el8_10'
b'6f9106f46020 (tag: resf_kernel-4.18.0-553.54.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.54.1.el8_10'
b'32f87806bbd4 (tag: resf_kernel-4.18.0-553.53.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.53.1.el8_10'
b'e99974a02d4f (tag: resf_kernel-4.18.0-553.52.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.52.1.el8_10'
b'bda8b8ebc7b7 (tag: resf_kernel-4.18.0-553.51.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.51.1.el8_10'
b'32fa0f457b22 (tag: resf_kernel-4.18.0-553.50.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.50.1.el8_10'
b'01aef32f4a9b (tag: resf_kernel-4.18.0-553.47.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.47.1.el8_10'
b'e622eefa811c (tag: resf_kernel-4.18.0-553.46.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.46.1.el8_10'
b'f025379c5d08 (tag: resf_kernel-4.18.0-553.45.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.45.1.el8_10'
b'16dc63866351 (tag: resf_kernel-4.18.0-553.44.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.44.1.el8_10'
b'5b691f92af91 (tag: resf_kernel-4.18.0-553.42.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.42.1.el8_10'
b'0dbf87712115 (tag: resf_kernel-4.18.0-553.40.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.40.1.el8_10'
b'26d9a06a4a5f (tag: resf_kernel-4.18.0-553.37.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.37.1.el8_10'
b'4673f9b8360d (tag: resf_kernel-4.18.0-553.36.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.36.1.el8_10'
b'7e4fb1a14fcd (tag: resf_kernel-4.18.0-553.34.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.34.1.el8_10'
b'72ceaa9ab31e (tag: resf_kernel-4.18.0-553.33.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.33.1.el8_10'
b'0570eb3e10e4 (tag: resf_kernel-4.18.0-553.32.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.32.1.el8_10'
b'657b4d21132b (tag: resf_kernel-4.18.0-553.30.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.30.1.el8_10'
b'c1970aa3f569 (tag: resf_kernel-4.18.0-553.27.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.27.1.el8_10'
b'8bf75aa29fd0 (tag: resf_kernel-4.18.0-553.22.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.22.1.el8_10'
b'ea7f8a5da93b (tag: resf_kernel-4.18.0-553.16.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.16.1.el8_10'
b'2fd9e62e45de (tag: resf_kernel-4.18.0-553.8.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.8.1.el8_10'
b'a2d1b1a06ff8 (tag: resf_kernel-4.18.0-553.5.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.5.1.el8_10'
b'4533b19a3a3e (tag: resf_kernel-4.18.0-553.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.el8_10'
[rolling release update] Old Rolling Branch Tags:  [b'e252413ceae1', b'5c89e3d2c056', b'2e416d167715', b'1ad2baf0efe1', b'6f9106f46020', b'32f87806bbd4', b'e99974a02d4f', b'bda8b8ebc7b7', b'32fa0f457b22', b'01aef32f4a9b', b'e622eefa811c', b'f025379c5d08', b'16dc63866351', b'5b691f92af91', b'0dbf87712115', b'26d9a06a4a5f', b'4673f9b8360d', b'7e4fb1a14fcd', b'72ceaa9ab31e', b'0570eb3e10e4', b'657b4d21132b', b'c1970aa3f569', b'8bf75aa29fd0', b'ea7f8a5da93b', b'2fd9e62e45de', b'a2d1b1a06ff8', b'4533b19a3a3e']
[rolling release update] Checking out branch:  rocky8_10
[rolling release update] Gathering all the RESF kernel Tags
b'4216b549e41e (tag: resf_kernel-4.18.0-553.66.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.66.1.el8_10'
b'4e0e0ed3bcbc (tag: resf_kernel-4.18.0-553.64.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.64.1.el8_10'
b'3bb436b64f59 (tag: resf_kernel-4.18.0-553.63.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.63.1.el8_10'
b'e252413ceae1 (tag: resf_kernel-4.18.0-553.62.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.62.1.el8_10'
b'5c89e3d2c056 (tag: resf_kernel-4.18.0-553.60.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.60.1.el8_10'
b'2e416d167715 (tag: resf_kernel-4.18.0-553.58.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.58.1.el8_10'
b'1ad2baf0efe1 (tag: resf_kernel-4.18.0-553.56.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.56.1.el8_10'
b'6f9106f46020 (tag: resf_kernel-4.18.0-553.54.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.54.1.el8_10'
b'32f87806bbd4 (tag: resf_kernel-4.18.0-553.53.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.53.1.el8_10'
b'e99974a02d4f (tag: resf_kernel-4.18.0-553.52.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.52.1.el8_10'
b'bda8b8ebc7b7 (tag: resf_kernel-4.18.0-553.51.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.51.1.el8_10'
b'32fa0f457b22 (tag: resf_kernel-4.18.0-553.50.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.50.1.el8_10'
b'01aef32f4a9b (tag: resf_kernel-4.18.0-553.47.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.47.1.el8_10'
b'e622eefa811c (tag: resf_kernel-4.18.0-553.46.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.46.1.el8_10'
b'f025379c5d08 (tag: resf_kernel-4.18.0-553.45.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.45.1.el8_10'
b'16dc63866351 (tag: resf_kernel-4.18.0-553.44.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.44.1.el8_10'
b'5b691f92af91 (tag: resf_kernel-4.18.0-553.42.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.42.1.el8_10'
b'0dbf87712115 (tag: resf_kernel-4.18.0-553.40.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.40.1.el8_10'
b'26d9a06a4a5f (tag: resf_kernel-4.18.0-553.37.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.37.1.el8_10'
b'4673f9b8360d (tag: resf_kernel-4.18.0-553.36.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.36.1.el8_10'
b'7e4fb1a14fcd (tag: resf_kernel-4.18.0-553.34.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.34.1.el8_10'
b'72ceaa9ab31e (tag: resf_kernel-4.18.0-553.33.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.33.1.el8_10'
b'0570eb3e10e4 (tag: resf_kernel-4.18.0-553.32.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.32.1.el8_10'
b'657b4d21132b (tag: resf_kernel-4.18.0-553.30.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.30.1.el8_10'
b'c1970aa3f569 (tag: resf_kernel-4.18.0-553.27.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.27.1.el8_10'
b'8bf75aa29fd0 (tag: resf_kernel-4.18.0-553.22.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.22.1.el8_10'
b'ea7f8a5da93b (tag: resf_kernel-4.18.0-553.16.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.16.1.el8_10'
b'2fd9e62e45de (tag: resf_kernel-4.18.0-553.8.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.8.1.el8_10'
b'a2d1b1a06ff8 (tag: resf_kernel-4.18.0-553.5.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.5.1.el8_10'
b'4533b19a3a3e (tag: resf_kernel-4.18.0-553.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.el8_10'
[rolling release update] New Base Branch Tags:  [b'4216b549e41e', b'4e0e0ed3bcbc', b'3bb436b64f59', b'e252413ceae1', b'5c89e3d2c056', b'2e416d167715', b'1ad2baf0efe1', b'6f9106f46020', b'32f87806bbd4', b'e99974a02d4f', b'bda8b8ebc7b7', b'32fa0f457b22', b'01aef32f4a9b', b'e622eefa811c', b'f025379c5d08', b'16dc63866351', b'5b691f92af91', b'0dbf87712115', b'26d9a06a4a5f', b'4673f9b8360d', b'7e4fb1a14fcd', b'72ceaa9ab31e', b'0570eb3e10e4', b'657b4d21132b', b'c1970aa3f569', b'8bf75aa29fd0', b'ea7f8a5da93b', b'2fd9e62e45de', b'a2d1b1a06ff8', b'4533b19a3a3e']
[rolling release update] Latest RESF tag sha:  b'e252413ceae1'
"e252413ceae167615681bc6ed1a57105e2fe3c0b Rebuild rocky8_10 with kernel-4.18.0-553.62.1.el8_10"
[rolling release update] Checking out old rolling branch:  sig-cloud-8/4.18.0-553.62.1.el8_10
[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD
[rolling release update] Last RESF tag sha:  b'e252413ceae1'
[rolling release update] Total Commit in old branch:  10
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
{
  "a54465ddf03e1f5fac116acb578542cae7db62a4": "9e517a8e9d9a303bf9bde35e5c5374795544c152",
  "2bdcf03f7e78132f55553afb85aa587fce5637f4": "4a3b99bc04e501b816db78f70064e26a01257910",
  "6b470f6b5d6338872fe1ae4c20f255d7da2ae34a": "e02497fb654689049ba8b46f098f17d5f19e0b3c",
  "512dc90f8dc0ae21f899400474492b2771e2471b": "382d1741b5b2feffef7942dd074206372afe1a96",
  "113aabc2c5ebb4e2deeeab791482ea6f52092d7c": "40a1d11fc670ac03c5dc2e5a9724b330e74f38b0",
  "2e23f271b6bd2f8e630188bd51b1de53e0602bdb": "2a38e4ca302280fdcce370ba2bee79bac16c4587",
  "67f44b1d4837fe0b4d905f64e6339053d6964f53": "95bfb35269b2e85cff0dd2c957b2d42ebf95ae5f",
  "057be2df38c60cece515dd3c787f1d386990ca04": "9a458198eba98b7207669a166e64d04b04cb651b",
  "10d89e91a865ac07f14e9453bf128b3593fa2da9": "3e32552652917f10c0aa8ac75cdc8f0b8d257dec",
  "2ed5cb82ecebd4e609f446c1dbc02b420291601e": "fbf6449f84bf5e4ad09f2c09ee70ed7d629b5ff6"
}
[rolling release update] Checking out new base branch:  rocky8_10
[rolling release update] Finding the kernel version for the new rolling release
b'4216b549e41e (tag: resf_kernel-4.18.0-553.66.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.66.1.el8_10'
<re.Match object; span=(0, 53), match=b'4216b549e41e (tag: resf_kernel-4.18.0-553.66.1.e>
[rolling release update} New Branch to create  sig-cloud-8/4.18.0-553.66.1.el8_10
[rolling release update] Check if branch Exists:  sig-cloud-8/4.18.0-553.66.1.el8_10
Branch sig-cloud-8/4.18.0-553.66.1.el8_10 does not exists creating
[rolling release update] Creating new branch for PR:  jmaple_sig-cloud-8/4.18.0-553.66.1.el8_10
[rolling release update] Creating Map of all new commits from last rolling release fork
[rolling release update] Total Commit in new branch:  61
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
Printing first 5 and last 5 commits
{
  "98b6d02b3b856a0de35746f66bb532a91b1e3b2d": "",
  "5e5855182df1b213245d07cbd0a21ec0258ed7e8": "5ba8b837b522d7051ef81bacf3d95383ff8edce5",
  "17cf4816f5829a644d54b9f3ce205b7babc98274": "df008598b3a00be02a8051fde89ca0fbc416bd55",
  "7d9858626418a1240d67c8e11e3691a2465c3bb7": "55f9eca4bfe30a15d8656f915922e8c98b7f0728",
  "f8ac26ef4005480478179a965d8ebf9e4d731e1a": "342debc12183b51773b3345ba267e9263bdfaaef"
}
{
  "ed6a9a6d3ddc0d2375aa38847ca1e390447cfefc": "e8c526f2bdf1845bedaf6a478816a3d06fa78b8f",
  "d17eb913c1bc37a9f9efd18588a1873dc045ffce": "9ad0452c0277b816a435433cca601304cfac7c21",
  "88a18607bae925197be1d086021177e6d1361b36": "7717fc1a12f88701573f9ed897cc4f6699c661e3",
  "1649f6c1bd3ff84426eea42ea51eb98c29e9e16f": "b98333c67daf887c724cd692e88e2db9418c0861",
  "466611123feb2fcc8a2a59ef452654b269e8120e": "9ac8ba46a701b863be3f197d7eece4c635d0afe4"
}
[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch
[rolling release update] Removing commits from the new branch
[rolling release update] Applying the remaining commits to the new branch
Applying commit  "2ed5cb82ecebd4e609f446c1dbc02b420291601e x86/sev-es: Set x86_virt_bits to the correct value straight away, instead of a two-phase approach"
Applying commit  "10d89e91a865ac07f14e9453bf128b3593fa2da9 x86/boot: Move x86_cache_alignment initialization to correct spot"
Applying commit  "057be2df38c60cece515dd3c787f1d386990ca04 x86/cpu: Allow reducing x86_phys_bits during early_identify_cpu()"
Applying commit  "67f44b1d4837fe0b4d905f64e6339053d6964f53 x86/cpu: Get rid of an unnecessary local variable in get_cpu_address_sizes()"
Applying commit  "2e23f271b6bd2f8e630188bd51b1de53e0602bdb x86/cpu: Provide default cache line size if not enumerated"
Applying commit  "113aabc2c5ebb4e2deeeab791482ea6f52092d7c net: mana: Enable MANA driver on ARM64 with 4K page size"
Applying commit  "512dc90f8dc0ae21f899400474492b2771e2471b net: mana: Add support for page sizes other than 4KB on ARM64"
Applying commit  "6b470f6b5d6338872fe1ae4c20f255d7da2ae34a RDMA/mana_ib: Fix bug in creation of dma regions"
Applying commit  "2bdcf03f7e78132f55553afb85aa587fce5637f4 RDMA/mana_ib: use the correct page size for mapping user-mode doorbell page"
Applying commit  "a54465ddf03e1f5fac116acb578542cae7db62a4 RDMA/mana_ib: use the correct page table index based on hardware page size"
```

## Build
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kbuild* | head -n1)
/mnt/code/kernel-src-tree-build
Running make mrproper...
[TIMER]{MRPROPER}: 5s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_sig-cloud-8_4.18.0-553.66.1.el8_10-0c35fa329ed"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1920s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-jmaple_sig-cloud-8_4.18.0-553.66.1.el8_10-0c35fa329ed+
[TIMER]{MODULES}: 15s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-jmaple_sig-cloud-8_4.18.0-553.66.1.el8_10-0c35fa329ed+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 21s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-jmaple_sig-cloud-8_4.18.0-553.66.1.el8_10-0c35fa329ed+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 1920s
[TIMER]{MODULES}: 15s
[TIMER]{INSTALL}: 21s
[TIMER]{TOTAL} 1967s
Rebooting in 10 seconds
```

## KselfTest
```
[jmaple@devbox code]$ ls -rt kselftest.* | tail -n2 | while read line; do echo $line; grep '^ok ' $line | wc -l ; done
kselftest.4.18.0-jmaple_sig-cloud-8_4.18.0-553.62.1.el8_10-2e23f271b6bd+.log
206
kselftest.4.18.0-jmaple_sig-cloud-8_4.18.0-553.66.1.el8_10-0c35fa329ed+.log
206
```