### PR TITLE
[LE-3545] scsi: storvsc: Increase the timeouts to storvsc_timeout

### DIFF
--- a/drivers/scsi/storvsc_drv.c
+++ b/drivers/scsi/storvsc_drv.c
@@ -356,7 +356,7 @@ MODULE_PARM_DESC(ring_avail_percent_lowater,
 /*
  * Timeout in seconds for all devices managed by this driver.
  */
-static int storvsc_timeout = 180;
+static const int storvsc_timeout = 180;
 
 #if IS_ENABLED(CONFIG_SCSI_FC_ATTRS)
 static struct scsi_transport_template *fc_transport_template;
@@ -762,7 +762,7 @@ static void  handle_multichannel_storage(struct hv_device *device, int max_chns)
 		return;
 	}
 
-	t = wait_for_completion_timeout(&request->wait_event, 10*HZ);
+	t = wait_for_completion_timeout(&request->wait_event, storvsc_timeout * HZ);
 	if (t == 0) {
 		dev_err(dev, "Failed to create sub-channel: timed out\n");
 		return;
@@ -827,7 +827,7 @@ static int storvsc_execute_vstor_op(struct hv_device *device,
 	if (ret != 0)
 		return ret;
 
-	t = wait_for_completion_timeout(&request->wait_event, 5*HZ);
+	t = wait_for_completion_timeout(&request->wait_event, storvsc_timeout * HZ);
 	if (t == 0)
 		return -ETIMEDOUT;
 
@@ -1345,6 +1345,8 @@ static int storvsc_connect_to_vsp(struct hv_device *device, u32 ring_size,
 		return ret;
 
 	ret = storvsc_channel_init(device, is_fc);
+	if (ret)
+		vmbus_close(device->channel);
 
 	return ret;
 }
@@ -1662,7 +1664,7 @@ static int storvsc_host_reset_handler(struct scsi_cmnd *scmnd)
 	if (ret != 0)
 		return FAILED;
 
-	t = wait_for_completion_timeout(&request->wait_event, 5*HZ);
+	t = wait_for_completion_timeout(&request->wait_event, storvsc_timeout * HZ);
 	if (t == 0)
 		return TIMEOUT_ERROR;
 


### PR DESCRIPTION
jira LE-3545

```
commit-author Dexuan Cui <decui@microsoft.com>
commit b2f966568faaad326de97481096d0f3dc0971c43

Currently storvsc_timeout is only used in storvsc_sdev_configure(), and 5s and 10s are used elsewhere. It turns out that rarely the 5s is not enough on Azure, so let's use storvsc_timeout everywhere.

In case a timeout happens and storvsc_channel_init() returns an error, close the VMBus channel so that any host-to-guest messages in the channel's ringbuffer, which might come late, can be safely ignored.

Add a "const" to storvsc_timeout.

	Cc: stable@kernel.org
	Signed-off-by: Dexuan Cui <decui@microsoft.com>
Link: https://lore.kernel.org/r/1749243459-10419-1-git-send-email-decui@microsoft.com
	Reviewed-by: Long Li <longli@microsoft.com>
	Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
(cherry picked from commit b2f966568faaad326de97481096d0f3dc0971c43)
	Signed-off-by: Sultan Alsawaf <sultan@ciq.com>
```

### Build Log
```
/home/rocky/kernel-src-tree
Running make mrproper...
  CLEAN   arch/x86/boot/compressed
  CLEAN   arch/x86/boot
  CLEAN   arch/x86/crypto
  CLEAN   arch/x86/entry/vdso
  CLEAN   arch/x86/kernel/cpu
  CLEAN   arch/x86/kernel
  CLEAN   arch/x86/kvm
  CLEAN   arch/x86/purgatory
  CLEAN   arch/x86/realmode/rm
  CLEAN   arch/x86/tools
  CLEAN   arch/x86/lib
  CLEAN   certs
  CLEAN   crypto/asymmetric_keys
  CLEAN   drivers/firmware/efi/libstub
  CLEAN   drivers/gpu/drm/radeon
  CLEAN   drivers/gpu/drm/xe
  CLEAN   drivers/scsi
  CLEAN   drivers/tty/vt
  CLEAN   drivers/video/logo
  CLEAN   kernel/debug/kdb
  CLEAN   kernel
  CLEAN   lib/raid6
  CLEAN   lib
  CLEAN   net/wireless
  CLEAN   security/selinux
  CLEAN   usr/include
  CLEAN   usr
  CLEAN   vmlinux.symvers modules-only.symvers modules.builtin modules.builtin.modinfo
  CLEAN   scripts/basic
  CLEAN   scripts/genksyms
  CLEAN   scripts/kconfig
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 9s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
---
  BTF [M] sound/usb/snd-usb-audio.ko
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  BTF [M] sound/xen/snd_xen_front.ko
[TIMER]{BUILD}: 1530s
Making Modules
  INSTALL /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
---
  SIGN    /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  STRIP   /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+
[TIMER]{MODULES}: 8s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+ \
        arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 25s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+ and Index to 0
The default is /boot/loader/entries/7a95671e45f0439ca51cedd5179fb400-5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+
The default is /boot/loader/entries/7a95671e45f0439ca51cedd5179fb400-5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+.conf with index 0 and kernel /boot/vmlinuz-5.14.0-sultan_LE-3543_sig-cloud-9_5.14.0-570.30.1.el9_6-a817+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 9s
[TIMER]{BUILD}: 1530s
[TIMER]{MODULES}: 8s
[TIMER]{INSTALL}: 25s
[TIMER]{TOTAL} 1576s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/21946095/kernel-build.log)

### Testing
```
$ grep ^ok kselftest-before.log | wc -l
387
$ grep ^ok kselftest-after.log | wc -l
386
```
[kselftest-before.log](https://github.com/user-attachments/files/21946104/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21946105/kselftest-after.log)
