### PR TITLE
[SIG-CLOUD-10] Rebase custom changes to 6.12.0-55.27.1.el10_0

### DIFF
--- a/drivers/net/ethernet/microsoft/mana/mana_en.c
+++ b/drivers/net/ethernet/microsoft/mana/mana_en.c
@@ -925,7 +925,7 @@ static void mana_pf_deregister_filter(struct mana_port_context *apc)
 
 static int mana_query_device_cfg(struct mana_context *ac, u32 proto_major_ver,
 				 u32 proto_minor_ver, u32 proto_micro_ver,
-				 u16 *max_num_vports)
+				 u16 *max_num_vports, u8 *bm_hostmode)
 {
 	struct gdma_context *gc = ac->gdma_dev->gdma_context;
 	struct mana_query_device_cfg_resp resp = {};
@@ -936,7 +936,7 @@ static int mana_query_device_cfg(struct mana_context *ac, u32 proto_major_ver,
 	mana_gd_init_req_hdr(&req.hdr, MANA_QUERY_DEV_CONFIG,
 			     sizeof(req), sizeof(resp));
 
-	req.hdr.resp.msg_version = GDMA_MESSAGE_V2;
+	req.hdr.resp.msg_version = GDMA_MESSAGE_V3;
 
 	req.proto_major_ver = proto_major_ver;
 	req.proto_minor_ver = proto_minor_ver;
@@ -960,10 +960,15 @@ static int mana_query_device_cfg(struct mana_context *ac, u32 proto_major_ver,
 
 	*max_num_vports = resp.max_num_vports;
 
-	if (resp.hdr.response.msg_version == GDMA_MESSAGE_V2)
+	if (resp.hdr.response.msg_version >= GDMA_MESSAGE_V2)
 		gc->adapter_mtu = resp.adapter_mtu;
 	else
 		gc->adapter_mtu = ETH_FRAME_LEN;
+
+	if (resp.hdr.response.msg_version >= GDMA_MESSAGE_V3)
+		*bm_hostmode = resp.bm_hostmode;
+	else
+		*bm_hostmode = 0;
 
 	debugfs_create_u16("adapter-MTU", 0400, gc->mana_pci_debugfs, &gc->adapter_mtu);
 
@@ -2450,7 +2455,7 @@ static void mana_destroy_vport(struct mana_port_context *apc)
 	mana_destroy_txq(apc);
 	mana_uncfg_vport(apc);
 
-	if (gd->gdma_context->is_pf)
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode)
 		mana_pf_deregister_hw_vport(apc);
 }
 
@@ -2462,7 +2467,7 @@ static int mana_create_vport(struct mana_port_context *apc,
 
 	apc->default_rxobj = INVALID_MANA_HANDLE;
 
-	if (gd->gdma_context->is_pf) {
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode) {
 		err = mana_pf_register_hw_vport(apc);
 		if (err)
 			return err;
@@ -2686,7 +2691,7 @@ int mana_alloc_queues(struct net_device *ndev)
 	if (err)
 		goto destroy_vport;
 
-	if (gd->gdma_context->is_pf) {
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode) {
 		err = mana_pf_register_filter(apc);
 		if (err)
 			goto destroy_vport;
@@ -2748,7 +2753,7 @@ static int mana_dealloc_queues(struct net_device *ndev)
 
 	mana_chn_setxdp(apc, NULL);
 
-	if (gd->gdma_context->is_pf)
+	if (gd->gdma_context->is_pf && !apc->ac->bm_hostmode)
 		mana_pf_deregister_filter(apc);
 
 	/* No packet can be transmitted now since apc->port_is_up is false.
@@ -2989,6 +2994,7 @@ int mana_probe(struct gdma_dev *gd, bool resuming)
 	struct gdma_context *gc = gd->gdma_context;
 	struct mana_context *ac = gd->driver_data;
 	struct device *dev = gc->dev;
+	u8 bm_hostmode = 0;
 	u16 num_ports = 0;
 	int err;
 	int i;
@@ -3015,9 +3021,11 @@ int mana_probe(struct gdma_dev *gd, bool resuming)
 		goto out;
 
 	err = mana_query_device_cfg(ac, MANA_MAJOR_VERSION, MANA_MINOR_VERSION,
-				    MANA_MICRO_VERSION, &num_ports);
+				    MANA_MICRO_VERSION, &num_ports, &bm_hostmode);
 	if (err)
 		goto out;
+
+	ac->bm_hostmode = bm_hostmode;
 
 	if (!resuming) {
 		ac->num_ports = num_ports;

--- a/include/net/mana/mana.h
+++ b/include/net/mana/mana.h
@@ -408,6 +408,7 @@ struct mana_context {
 	struct gdma_dev *gdma_dev;
 
 	u16 num_ports;
+	u8 bm_hostmode;
 
 	struct mana_eq *eqs;
 	struct dentry *mana_eqs_debugfs;
@@ -557,7 +558,8 @@ struct mana_query_device_cfg_resp {
 	u64 pf_cap_flags4;
 
 	u16 max_num_vports;
-	u16 reserved;
+	u8 bm_hostmode; /* response v3: Bare Metal Host Mode */
+	u8 reserved;
 	u32 max_num_eqs;
 
 	/* response v2: */

--- a/tools/hv/hv_kvp_daemon.c
+++ b/tools/hv/hv_kvp_daemon.c
@@ -83,6 +83,7 @@ enum {
 };
 
 static int in_hand_shake;
+static int debug;
 
 static char *os_name = "";
 static char *os_major = "";
@@ -183,6 +184,20 @@ static void kvp_update_file(int pool)
 	kvp_release_lock(pool);
 }
 
+static void kvp_dump_initial_pools(int pool)
+{
+	int i;
+
+	syslog(LOG_DEBUG, "===Start dumping the contents of pool %d ===\n",
+	       pool);
+
+	for (i = 0; i < kvp_file_info[pool].num_records; i++)
+		syslog(LOG_DEBUG, "pool: %d, %d/%d key=%s val=%s\n",
+		       pool, i + 1, kvp_file_info[pool].num_records,
+		       kvp_file_info[pool].records[i].key,
+		       kvp_file_info[pool].records[i].value);
+}
+
 static void kvp_update_mem_state(int pool)
 {
 	FILE *filep;
@@ -270,6 +285,8 @@ static int kvp_file_init(void)
 			return 1;
 		kvp_file_info[i].num_records = 0;
 		kvp_update_mem_state(i);
+		if (debug)
+			kvp_dump_initial_pools(i);
 	}
 
 	return 0;
@@ -297,6 +314,9 @@ static int kvp_key_delete(int pool, const __u8 *key, int key_size)
 		 * Found a match; just move the remaining
 		 * entries up.
 		 */
+		if (debug)
+			syslog(LOG_DEBUG, "%s: deleting the KVP: pool=%d key=%s val=%s",
+			       __func__, pool, record[i].key, record[i].value);
 		if (i == (num_records - 1)) {
 			kvp_file_info[pool].num_records--;
 			kvp_update_file(pool);
@@ -315,20 +335,36 @@ static int kvp_key_delete(int pool, const __u8 *key, int key_size)
 		kvp_update_file(pool);
 		return 0;
 	}
+
+	if (debug)
+		syslog(LOG_DEBUG, "%s: could not delete KVP: pool=%d key=%s. Record not found",
+		       __func__, pool, key);
+
 	return 1;
 }
 
 static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 				 const __u8 *value, int value_size)
 {
-	int i;
-	int num_records;
 	struct kvp_record *record;
+	int num_records;
 	int num_blocks;
+	int i;
+
+	if (debug)
+		syslog(LOG_DEBUG, "%s: got a KVP: pool=%d key=%s val=%s",
+		       __func__, pool, key, value);
 
 	if ((key_size > HV_KVP_EXCHANGE_MAX_KEY_SIZE) ||
-		(value_size > HV_KVP_EXCHANGE_MAX_VALUE_SIZE))
+		(value_size > HV_KVP_EXCHANGE_MAX_VALUE_SIZE)) {
+		syslog(LOG_ERR, "%s: Too long key or value: key=%s, val=%s",
+		       __func__, key, value);
+
+		if (debug)
+			syslog(LOG_DEBUG, "%s: Too long key or value: pool=%d, key=%s, val=%s",
+			       __func__, pool, key, value);
 		return 1;
+	}
 
 	/*
 	 * First update the in-memory state.
@@ -348,6 +384,9 @@ static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 		 */
 		memcpy(record[i].value, value, value_size);
 		kvp_update_file(pool);
+		if (debug)
+			syslog(LOG_DEBUG, "%s: updated: pool=%d key=%s val=%s",
+			       __func__, pool, key, value);
 		return 0;
 	}
 
@@ -359,8 +398,10 @@ static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 		record = realloc(record, sizeof(struct kvp_record) *
 			 ENTRIES_PER_BLOCK * (num_blocks + 1));
 
-		if (record == NULL)
+		if (!record) {
+			syslog(LOG_ERR, "%s: Memory alloc failure", __func__);
 			return 1;
+		}
 		kvp_file_info[pool].num_blocks++;
 
 	}
@@ -368,6 +409,11 @@ static int kvp_key_add_or_modify(int pool, const __u8 *key, int key_size,
 	memcpy(record[i].key, key, key_size);
 	kvp_file_info[pool].records = record;
 	kvp_file_info[pool].num_records++;
+
+	if (debug)
+		syslog(LOG_DEBUG, "%s: added: pool=%d key=%s val=%s",
+		       __func__, pool, key, value);
+
 	kvp_update_file(pool);
 	return 0;
 }
@@ -1661,6 +1707,7 @@ void print_usage(char *argv[])
 	fprintf(stderr, "Usage: %s [options]\n"
 		"Options are:\n"
 		"  -n, --no-daemon        stay in foreground, don't daemonize\n"
+		"  -d, --debug            Enable debug logs(syslog debug by default)\n"
 		"  -h, --help             print this help\n", argv[0]);
 }
 
@@ -1682,10 +1729,11 @@ int main(int argc, char *argv[])
 	static struct option long_options[] = {
 		{"help",	no_argument,	   0,  'h' },
 		{"no-daemon",	no_argument,	   0,  'n' },
+		{"debug",	no_argument,	   0,  'd' },
 		{0,		0,		   0,  0   }
 	};
 
-	while ((opt = getopt_long(argc, argv, "hn", long_options,
+	while ((opt = getopt_long(argc, argv, "hnd", long_options,
 				  &long_index)) != -1) {
 		switch (opt) {
 		case 'n':
@@ -1694,6 +1742,9 @@ int main(int argc, char *argv[])
 		case 'h':
 			print_usage(argv);
 			exit(0);
+		case 'd':
+			debug = 1;
+			break;
 		default:
 			print_usage(argv);
 			exit(EXIT_FAILURE);
@@ -1715,6 +1766,9 @@ int main(int argc, char *argv[])
 	 * unpredictable amount of time to finish.
 	 */
 	kvp_get_domain_name(full_domain_name, sizeof(full_domain_name));
+
+	if (debug)
+		syslog(LOG_INFO, "Logging debug info in syslog(debug)");
 
 	if (kvp_file_init()) {
 		syslog(LOG_ERR, "Failed to initialize the pools");


### PR DESCRIPTION
## Update process (This kernel CentOS base for `6.12.0-55`)
* Kernel History Rebuild Process for all `src.rpm`s hosted by RESF
* Create `sig-cloud-10/6.12.0-55.X.1.el10_0` branch
* Check if any maintained code is included in the new `el` release.
* Cherry-pick all code from previous branch into new branch (skipping unneeded code) 
  * Fix conflicts as they arise 
* Build and Test

## Removed Commits
None

## Forward Port Process
```
[jmaple@devbox code]$ cat RR.resf_kernel-6.12.0-55.25.1.el10_0-23-g9c864bb5ae3f.log
[rolling release update] Rolling Product:  sig-cloud-10
[rolling release update] Checking out branch:  sig-cloud-10/6.12.0-55.21.1.el10_0
[rolling release update] Gathering all the RESF kernel Tags
b'fef28841a44f (tag: resf_kernel-6.12.0-55.21.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.21.1.el10_0'
b'3381775694c1 (tag: resf_kernel-6.12.0-55.20.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.20.1.el10_0'
b'072c27213755 (tag: resf_kernel-6.12.0-55.19.1.el10_0, origin/sig-cloud-10/6.12.0-55.19.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.19.1.el10_0'
b'4de01b5748c7 (tag: resf_kernel-6.12.0-55.18.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.18.1.el10_0'
b'71d4955b6748 (tag: resf_kernel-6.12.0-55.17.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.17.1.el10_0'
b'31b726f7bb14 (tag: resf_kernel-6.12.0-55.16.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.16.1.el10_0'
b'defbb7341054 (tag: resf_kernel-6.12.0-55.14.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.14.1.el10_0'
b'abf881e2d199 (tag: resf_kernel-6.12.0-55.13.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.13.1.el10_0'
b'd3c6fc1a3a45 (tag: resf_kernel-6.12.0-55.12.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.12.1.el10_0'
b'ce19035f5d30 (tag: resf_kernel-6.12.0-55.11.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.11.1.el10_0'
[rolling release update] Old Rolling Branch Tags:  [b'fef28841a44f', b'3381775694c1', b'072c27213755', b'4de01b5748c7', b'71d4955b6748', b'31b726f7bb14', b'defbb7341054', b'abf881e2d199', b'd3c6fc1a3a45', b'ce19035f5d30']
[rolling release update] Checking out branch:  rocky10_0
[rolling release update] Gathering all the RESF kernel Tags
b'9c864bb5ae3f (HEAD -> rocky10_0, tag: resf_kernel-6.12.0-55.27.1.el10_0, origin/rocky10_0) Rebuild rocky10_0 with kernel-6.12.0-55.27.1.el10_0'
b'487af0f6f40e (tag: resf_kernel-6.12.0-55.25.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.25.1.el10_0'
b'ffbe2344d41a (tag: resf_kernel-6.12.0-55.24.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.24.1.el10_0'
b'9b9ae5b20f34 (tag: resf_kernel-6.12.0-55.22.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.22.1.el10_0'
b'fef28841a44f (tag: resf_kernel-6.12.0-55.21.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.21.1.el10_0'
b'3381775694c1 (tag: resf_kernel-6.12.0-55.20.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.20.1.el10_0'
b'072c27213755 (tag: resf_kernel-6.12.0-55.19.1.el10_0, origin/sig-cloud-10/6.12.0-55.19.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.19.1.el10_0'
b'4de01b5748c7 (tag: resf_kernel-6.12.0-55.18.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.18.1.el10_0'
b'71d4955b6748 (tag: resf_kernel-6.12.0-55.17.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.17.1.el10_0'
b'31b726f7bb14 (tag: resf_kernel-6.12.0-55.16.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.16.1.el10_0'
b'defbb7341054 (tag: resf_kernel-6.12.0-55.14.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.14.1.el10_0'
b'abf881e2d199 (tag: resf_kernel-6.12.0-55.13.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.13.1.el10_0'
b'd3c6fc1a3a45 (tag: resf_kernel-6.12.0-55.12.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.12.1.el10_0'
b'ce19035f5d30 (tag: resf_kernel-6.12.0-55.11.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.11.1.el10_0'
[rolling release update] New Base Branch Tags:  [b'9c864bb5ae3f', b'487af0f6f40e', b'ffbe2344d41a', b'9b9ae5b20f34', b'fef28841a44f', b'3381775694c1', b'072c27213755', b'4de01b5748c7', b'71d4955b6748', b'31b726f7bb14', b'defbb7341054', b'abf881e2d199', b'd3c6fc1a3a45', b'ce19035f5d30']
[rolling release update] Latest RESF tag sha:  b'fef28841a44f'
"fef28841a44faed2e822b33d02681b805e3e8a37 Rebuild rocky10_0 with kernel-6.12.0-55.21.1.el10_0"
[rolling release update] Checking out old rolling branch:  sig-cloud-10/6.12.0-55.21.1.el10_0
[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD
[rolling release update] Last RESF tag sha:  b'fef28841a44f'
[rolling release update] Total Commit in old branch:  2
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
{
  "8cd774f1d1e405ff517d510ef3b61927e9cca893": "a9c0b33ef2306327dd2db02c6274107065ff9307",
  "0486695abfb5202bee64b38232f3703283bb46c7": "290e5d3c49f687c1567bde634dc33d57b0674919"
}
[rolling release update] Checking out new base branch:  rocky10_0
[rolling release update] Finding the kernel version for the new rolling release
b'9c864bb5ae3f (HEAD -> rocky10_0, tag: resf_kernel-6.12.0-55.27.1.el10_0, origin/rocky10_0) Rebuild rocky10_0 with kernel-6.12.0-55.27.1.el10_0'
<re.Match object; span=(0, 71), match=b'9c864bb5ae3f (HEAD -> rocky10_0, tag: resf_kerne>
[rolling release update} New Branch to create  sig-cloud-10/6.12.0-55.27.1.el10_0
[rolling release update] Check if branch Exists:  sig-cloud-10/6.12.0-55.27.1.el10_0
Branch sig-cloud-10/6.12.0-55.27.1.el10_0 does not exists creating
[rolling release update] Creating new branch for PR:  jmaple_sig-cloud-10/6.12.0-55.27.1.el10_0
[rolling release update] Creating Map of all new commits from last rolling release fork
[rolling release update] Total Commit in new branch:  72
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
Printing first 5 and last 5 commits
{
  "9c864bb5ae3fe2949e9b923b2c760d2def482860": "",
  "05410753622b623eb4ddf652b288311d80b5e008": "5ba8b837b522d7051ef81bacf3d95383ff8edce5",
  "93c8661c62c24e357398cf68ee315f045469db2f": "df008598b3a00be02a8051fde89ca0fbc416bd55",
  "76720f74c3c0a175ee335ccfac85314a86e4b59d": "55f9eca4bfe30a15d8656f915922e8c98b7f0728",
  "91d08dacbab68f69b5fc062a89c0dcc597666729": "342debc12183b51773b3345ba267e9263bdfaaef"
}
{
  "876b19535fec52dfff0b7635465dd2d889824d4d": "221cd51efe4565501a3dbf04cc011b537dcce7fb",
  "364baed1fb7c3825769f6b96ee22da078fb540d7": "04d3398f66d2d31c4b8caea88f051a4257b7a161",
  "5f058c080558f3efa04e1e042f8f56c233247198": "d9fecd096f67a4469536e040a8a10bbfb665918b",
  "21fd21c58af2f67378f8171d2e590afa5da48184": "c6ef3a7fa97ec823a1e1af9085cf13db9f7b3bac",
  "437d4601e0f1084b30ba67bd6f37115fedbf9807": "e0dc2c1bef722cbf16ae557690861e5f91208129"
}
[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch
[rolling release update] Removing commits from the new branch
[rolling release update] Applying the remaining commits to the new branch
Applying commit  "0486695abfb5202bee64b38232f3703283bb46c7 net: mana: Add support for Multi Vports on Bare metal"
Applying commit  "8cd774f1d1e405ff517d510ef3b61927e9cca893 tools: hv: Enable debug logs for hv_kvp_daemon"
```

## Build
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kbuild* | head -n1)
/mnt/code/kernel-src-tree-build
Running make mrproper...
[TIMER]{MRPROPER}: 6s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  GEN     arch/x86/include/generated/asm/orc_hash.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
--
  BTF [M] net/vmw_vsock/vmw_vsock_virtio_transport_common.ko
  BTF [M] net/hsr/hsr.ko
  LD [M]  net/qrtr/qrtr-mhi.ko
  BTF [M] net/qrtr/qrtr.ko
  BTF [M] net/qrtr/qrtr-mhi.ko
[TIMER]{BUILD}: 2060s
Making Modules
  SYMLINK /lib/modules/6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+/build
  INSTALL /lib/modules/6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+/modules.order
  INSTALL /lib/modules/6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+/modules.builtin
  INSTALL /lib/modules/6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+/modules.builtin.modinfo
--
  SIGN    /lib/modules/6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+/kernel/net/hsr/hsr.ko
  SIGN    /lib/modules/6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+/kernel/net/qrtr/qrtr.ko
  SIGN    /lib/modules/6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+/kernel/net/vmw_vsock/vsock_loopback.ko
  SIGN    /lib/modules/6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+/kernel/net/bluetooth/bnep/bnep.ko
  DEPMOD  /lib/modules/6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+
[TIMER]{MODULES}: 8s
Making Install
  INSTALL /boot
[TIMER]{INSTALL}: 16s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 6s
[TIMER]{BUILD}: 2060s
[TIMER]{MODULES}: 8s
[TIMER]{INSTALL}: 16s
[TIMER]{TOTAL} 2095s
Rebooting in 10 seconds
```

## KselfTests
```
[jmaple@devbox code]$ ls -rt kselftest.* | tail -n4 | while read line; do echo $line; grep '^ok ' $line | wc -l ; done
kselftest.6.12.0-rocky10_0_rebuild-fef28841a44f+.log
498
kselftest.6.12.0-jmaple_sig-cloud-10_6.12.0-55.21.1.el10_0-8cd774f1d1e4+.log
498
kselftest.6.12.0-rocky10_0_rebuild-09e336dca27b+.log
498
kselftest.6.12.0-jmaple_sig-cloud-10_6.12.0-55.27.1.el10_0-7f919518cf4+.log
498
```