### PR TITLE
[LTS 9.4] CVE-2025-22020, CVE-2022-48804, CVE-2022-49788, CVE-2023-52606, CVE-2023-52933, CVE-2024-36960, CVE-2024-38581

### DIFF
--- a/arch/powerpc/lib/sstep.c
+++ b/arch/powerpc/lib/sstep.c
@@ -591,6 +591,8 @@ static int do_fp_load(struct instruction_op *op, unsigned long ea,
 	} u;
 
 	nb = GETSIZE(op->type);
+	if (nb > sizeof(u))
+		return -EINVAL;
 	if (!address_ok(regs, ea, nb))
 		return -EFAULT;
 	rn = op->reg;
@@ -641,6 +643,8 @@ static int do_fp_store(struct instruction_op *op, unsigned long ea,
 	} u;
 
 	nb = GETSIZE(op->type);
+	if (nb > sizeof(u))
+		return -EINVAL;
 	if (!address_ok(regs, ea, nb))
 		return -EFAULT;
 	rn = op->reg;
@@ -685,6 +689,9 @@ static nokprobe_inline int do_vec_load(int rn, unsigned long ea,
 		u8 b[sizeof(__vector128)];
 	} u = {};
 
+	if (size > sizeof(u))
+		return -EINVAL;
+
 	if (!address_ok(regs, ea & ~0xfUL, 16))
 		return -EFAULT;
 	/* align to multiple of size */
@@ -711,6 +718,9 @@ static nokprobe_inline int do_vec_store(int rn, unsigned long ea,
 		__vector128 v;
 		u8 b[sizeof(__vector128)];
 	} u;
+
+	if (size > sizeof(u))
+		return -EINVAL;
 
 	if (!address_ok(regs, ea & ~0xfUL, 16))
 		return -EFAULT;

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_mes.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_mes.c
@@ -1067,6 +1067,7 @@ void amdgpu_mes_remove_ring(struct amdgpu_device *adev,
 		return;
 
 	amdgpu_mes_remove_hw_queue(adev, ring->hw_queue_id);
+	del_timer_sync(&ring->fence_drv.fallback_timer);
 	amdgpu_ring_fini(ring);
 	kfree(ring);
 }

--- a/drivers/gpu/drm/vmwgfx/vmwgfx_fence.c
+++ b/drivers/gpu/drm/vmwgfx/vmwgfx_fence.c
@@ -991,7 +991,7 @@ static int vmw_event_fence_action_create(struct drm_file *file_priv,
 	}
 
 	event->event.base.type = DRM_VMW_EVENT_FENCE_SIGNALED;
-	event->event.base.length = sizeof(*event);
+	event->event.base.length = sizeof(event->event);
 	event->event.user_data = user_data;
 
 	ret = drm_event_reserve_init(dev, file_priv, &event->base, &event->event.base);

--- a/drivers/memstick/host/rtsx_usb_ms.c
+++ b/drivers/memstick/host/rtsx_usb_ms.c
@@ -813,6 +813,7 @@ static int rtsx_usb_ms_drv_remove(struct platform_device *pdev)
 
 	host->eject = true;
 	cancel_work_sync(&host->handle_req);
+	cancel_delayed_work_sync(&host->poll_card);
 
 	mutex_lock(&host->host_mutex);
 	if (host->req) {

--- a/drivers/misc/vmw_vmci/vmci_queue_pair.c
+++ b/drivers/misc/vmw_vmci/vmci_queue_pair.c
@@ -854,6 +854,7 @@ static int qp_notify_peer_local(bool attach, struct vmci_handle handle)
 	u32 context_id = vmci_get_context_id();
 	struct vmci_event_qp ev;
 
+	memset(&ev, 0, sizeof(ev));
 	ev.msg.hdr.dst = vmci_make_handle(context_id, VMCI_EVENT_HANDLER);
 	ev.msg.hdr.src = vmci_make_handle(VMCI_HYPERVISOR_CONTEXT_ID,
 					  VMCI_CONTEXT_RESOURCE_ID);
@@ -1467,6 +1468,7 @@ static int qp_notify_peer(bool attach,
 	 * kernel.
 	 */
 
+	memset(&ev, 0, sizeof(ev));
 	ev.msg.hdr.dst = vmci_make_handle(peer_id, VMCI_EVENT_HANDLER);
 	ev.msg.hdr.src = vmci_make_handle(VMCI_HYPERVISOR_CONTEXT_ID,
 					  VMCI_CONTEXT_RESOURCE_ID);

--- a/drivers/tty/vt/vt_ioctl.c
+++ b/drivers/tty/vt/vt_ioctl.c
@@ -599,8 +599,8 @@ static int vt_setactivate(struct vt_setactivate __user *sa)
 	if (vsa.console == 0 || vsa.console > MAX_NR_CONSOLES)
 		return -ENXIO;
 
-	vsa.console = array_index_nospec(vsa.console, MAX_NR_CONSOLES + 1);
 	vsa.console--;
+	vsa.console = array_index_nospec(vsa.console, MAX_NR_CONSOLES);
 	console_lock();
 	ret = vc_allocate(vsa.console);
 	if (ret) {

--- a/fs/squashfs/squashfs_fs.h
+++ b/fs/squashfs/squashfs_fs.h
@@ -183,7 +183,7 @@ static inline int squashfs_block_size(__le32 raw)
 #define SQUASHFS_ID_BLOCK_BYTES(A)	(SQUASHFS_ID_BLOCKS(A) *\
 					sizeof(u64))
 /* xattr id lookup table defines */
-#define SQUASHFS_XATTR_BYTES(A)		((A) * sizeof(struct squashfs_xattr_id))
+#define SQUASHFS_XATTR_BYTES(A)		(((u64) (A)) * sizeof(struct squashfs_xattr_id))
 
 #define SQUASHFS_XATTR_BLOCK(A)		(SQUASHFS_XATTR_BYTES(A) / \
 					SQUASHFS_METADATA_SIZE)

--- a/fs/squashfs/squashfs_fs_sb.h
+++ b/fs/squashfs/squashfs_fs_sb.h
@@ -63,7 +63,7 @@ struct squashfs_sb_info {
 	long long				bytes_used;
 	unsigned int				inodes;
 	unsigned int				fragments;
-	int					xattr_ids;
+	unsigned int				xattr_ids;
 	unsigned int				ids;
 	bool					panic_on_errors;
 };

--- a/fs/squashfs/xattr.h
+++ b/fs/squashfs/xattr.h
@@ -10,12 +10,12 @@
 
 #ifdef CONFIG_SQUASHFS_XATTR
 extern __le64 *squashfs_read_xattr_id_table(struct super_block *, u64,
-		u64 *, int *);
+		u64 *, unsigned int *);
 extern int squashfs_xattr_lookup(struct super_block *, unsigned int, int *,
 		unsigned int *, unsigned long long *);
 #else
 static inline __le64 *squashfs_read_xattr_id_table(struct super_block *sb,
-		u64 start, u64 *xattr_table_start, int *xattr_ids)
+		u64 start, u64 *xattr_table_start, unsigned int *xattr_ids)
 {
 	struct squashfs_xattr_id_table *id_table;
 

--- a/fs/squashfs/xattr_id.c
+++ b/fs/squashfs/xattr_id.c
@@ -56,7 +56,7 @@ int squashfs_xattr_lookup(struct super_block *sb, unsigned int index,
  * Read uncompressed xattr id lookup table indexes from disk into memory
  */
 __le64 *squashfs_read_xattr_id_table(struct super_block *sb, u64 table_start,
-		u64 *xattr_table_start, int *xattr_ids)
+		u64 *xattr_table_start, unsigned int *xattr_ids)
 {
 	struct squashfs_sb_info *msblk = sb->s_fs_info;
 	unsigned int len, indexes;


### PR DESCRIPTION
[LTS 9.4]
CVE-2025-22020  VULN-64887
CVE-2022-48804  VULN-8027
CVE-2022-49788  VULN-65841
CVE-2023-52606  VULN-8150
CVE-2023-52933  VULN-55076
CVE-2024-36960  VULN-8241
CVE-2024-38581  VULN-8245


# Commits

2c7bbea35c96f130001235da05c2b613eda49118:

    memstick: rtsx_usb_ms: Fix slab-use-after-free in rtsx_usb_ms_drv_remove
    
    jira VULN-64887
    cve CVE-2025-22020
    commit-author Luo Qiu <luoqiu@kylinsec.com.cn>
    commit 4676741a3464b300b486e70585c3c9b692be1632

9499e079cafe9f72418f74f0ecc28e71f1a61607:

    vt_ioctl: fix array_index_nospec in vt_setactivate
    
    jira VULN-8027
    cve CVE-2022-48804
    commit-author Jakob Koschel <jakobkoschel@gmail.com>
    commit 61cc70d9e8ef5b042d4ed87994d20100ec8896d9

8bdcb877b9da5c4814a43ecf4fec975e862d3fa4:

    misc/vmw_vmci: fix an infoleak in vmci_host_do_receive_datagram()
    
    jira VULN-65841
    cve CVE-2022-49788
    commit-author Alexander Potapenko <glider@google.com>
    commit e5b0d06d9b10f5f43101bd6598b076c347f9295f

cd7268c95711d16922f28f60574d79e01bb1fe17:

    powerpc/lib: Validate size for vector operations
    
    jira VULN-8150
    cve CVE-2023-52606
    commit-author Naveen N Rao <naveen@kernel.org>
    commit 8f9abaa6d7de0a70fc68acaedce290c1f96e2e59

cb4b767ed84cd04781406f1c0ec019930b0a2e0f:

    Squashfs: fix handling and sanity checking of xattr_ids count
    
    jira VULN-55076
    cve CVE-2023-52933
    commit-author Phillip Lougher <phillip@squashfs.org.uk>
    commit f65c4bbbd682b0877b669828b4e033b8d5d0a2dc

6eeb3a246b301bd1e767b88f531cc9eb8a3a95a6:

    drm/vmwgfx: Fix invalid reads in fence signaled events
    
    jira VULN-8241
    cve CVE-2024-36960
    commit-author Zack Rusin <zack.rusin@broadcom.com>
    commit a37ef7613c00f2d72c8fc08bd83fb6cc76926c8c

c966c2c5188e693408fc18a77e1213908e9e4cd5:

    drm/amdgpu/mes: fix use-after-free issue
    
    jira VULN-8245
    cve CVE-2024-38581
    commit-author Jack Xiao <Jack.Xiao@amd.com>
    commit 948255282074d9367e01908b3f5dcf8c10fc9c3d


# kABI check: passed

    $ DEBUG=1 CVE=CVE-batch-0 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_4-CVE-batch-0

    [0/1] Check ABI of kernel [ciqlts9_4-CVE-batch-0]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-batch-0/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-batch-0/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/21976220/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/21976219/kselftests--ciqlts9_4--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-batch-0&#x2013;run1.log](<https://github.com/user-attachments/files/21976218/kselftests--ciqlts9_4-CVE-batch-0--run1.log>)


## Comparison

The tests results for reference and patch are the same.

    $ ktests.xsh diff  kselftests*.log

    Column    File
    --------  -------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4-CVE-batch-0--run1.log
    
    TestCase                                               Status0  Status1  Summary
    bpf:test_cgroup_storage                                pass     pass     same
    bpf:test_lpm_map                                       pass     pass     same
    bpf:test_lru_map                                       pass     pass     same
    bpf:test_sock                                          pass     pass     same
    bpf:test_sysctl                                        pass     pass     same
    bpf:test_tag                                           pass     pass     same
    bpf:test_tcpnotify_user                                pass     pass     same
    bpf:test_verifier                                      fail     fail     same
    breakpoints:breakpoint_test                            pass     pass     same
    capabilities:test_execve                               pass     pass     same
    clone3:clone3                                          pass     pass     same
    clone3:clone3_cap_checkpoint_restore                   pass     pass     same
    clone3:clone3_clear_sighand                            pass     pass     same
    clone3:clone3_set_tid                                  pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh                         pass     pass     same
    cpufreq:main.sh                                        fail     fail     same
    drivers/dma-buf:udmabuf                                pass     pass     same
    drivers/net/bonding:bond-arp-interval-causes-panic.sh  pass     pass     same
    drivers/net/bonding:bond-break-lacpdu-tx.sh            fail     fail     same
    drivers/net/bonding:bond-eth-type-change.sh            pass     pass     same
    drivers/net/bonding:bond-lladdr-target.sh              pass     pass     same
    drivers/net/bonding:bond_options.sh                    fail     fail     same
    drivers/net/bonding:dev_addr_lists.sh                  pass     pass     same
    drivers/net/bonding:mode-1-recovery-updelay.sh         pass     pass     same
    drivers/net/bonding:mode-2-recovery-updelay.sh         pass     pass     same
    drivers/net/team:dev_addr_lists.sh                     pass     pass     same
    exec:binfmt_script                                     pass     pass     same
    exec:execveat                                          pass     pass     same
    exec:load_address_16777216                             fail     fail     same
    exec:load_address_2097152                              pass     pass     same
    exec:load_address_4096                                 pass     pass     same
    exec:non-regular                                       fail     fail     same
    exec:recursion-depth                                   pass     pass     same
    filesystems/binderfs:binderfs_test                     fail     fail     same
    filesystems/epoll:epoll_wakeup_test                    pass     pass     same
    firmware:fw_run_tests.sh                               skip     skip     same
    fpu:run_test_fpu.sh                                    skip     skip     same
    fpu:test_fpu                                           pass     pass     same
    ftrace:ftracetest                                      fail     fail     same
    futex:run.sh                                           pass     pass     same
    gpio:gpio-mockup.sh                                    fail     fail     same
    intel_pstate:run.sh                                    pass     pass     same
    iommu:iommufd                                          fail     fail     same
    iommu:iommufd_fail_nth                                 pass     pass     same
    ipc:msgque                                             pass     pass     same
    ir:ir_loopback.sh                                      skip     skip     same
    kcmp:kcmp_test                                         pass     pass     same
    kexec:test_kexec_file_load.sh                          skip     skip     same
    kexec:test_kexec_load.sh                               skip     skip     same
    kvm:access_tracking_perf_test                          pass     pass     same
    kvm:amx_test                                           fail     fail     same
    kvm:cpuid_test                                         fail     fail     same
    kvm:cr4_cpuid_sync_test                                fail     fail     same
    kvm:debug_regs                                         fail     fail     same
    kvm:demand_paging_test                                 pass     pass     same
    kvm:dirty_log_page_splitting_test                      fail     fail     same
    kvm:dirty_log_perf_test                                pass     pass     same
    kvm:dirty_log_test                                     fail     fail     same
    kvm:exit_on_emulation_failure_test                     fail     fail     same
    kvm:fix_hypercall_test                                 fail     fail     same
    kvm:get_msr_index_features                             fail     fail     same
    kvm:guest_memfd_test                                   pass     pass     same
    kvm:guest_print_test                                   pass     pass     same
    kvm:hardware_disable_test                              pass     pass     same
    kvm:hyperv_clock                                       fail     fail     same
    kvm:hyperv_cpuid                                       fail     fail     same
    kvm:hyperv_evmcs                                       fail     fail     same
    kvm:hyperv_extended_hypercalls                         fail     fail     same
    kvm:hyperv_features                                    fail     fail     same
    kvm:hyperv_ipi                                         fail     fail     same
    kvm:hyperv_svm_test                                    fail     fail     same
    kvm:hyperv_tlb_flush                                   fail     fail     same
    kvm:kvm_binary_stats_test                              pass     pass     same
    kvm:kvm_clock_test                                     fail     fail     same
    kvm:kvm_create_max_vcpus                               pass     pass     same
    kvm:kvm_page_table_test                                pass     pass     same
    kvm:kvm_pv_test                                        fail     fail     same
    kvm:max_guest_memory_test                              pass     pass     same
    kvm:max_vcpuid_cap_test                                fail     fail     same
    kvm:memslot_modification_stress_test                   pass     pass     same
    kvm:memslot_perf_test                                  pass     pass     same
    kvm:mmio_warning_test                                  fail     fail     same
    kvm:monitor_mwait_test                                 fail     fail     same
    kvm:nested_exceptions_test                             fail     fail     same
    kvm:nx_huge_pages_test.sh                              fail     fail     same
    kvm:platform_info_test                                 fail     fail     same
    kvm:pmu_event_filter_test                              fail     fail     same
    kvm:private_mem_conversions_test                       fail     fail     same
    kvm:private_mem_kvm_exits_test                         fail     fail     same
    kvm:recalc_apic_map_test                               fail     fail     same
    kvm:rseq_test                                          fail     fail     same
    kvm:set_boot_cpu_id                                    fail     fail     same
    kvm:set_memory_region_test                             pass     pass     same
    kvm:set_sregs_test                                     fail     fail     same
    kvm:sev_migrate_tests                                  fail     fail     same
    kvm:smaller_maxphyaddr_emulation_test                  fail     fail     same
    kvm:smm_test                                           fail     fail     same
    kvm:state_test                                         fail     fail     same
    kvm:steal_time                                         pass     pass     same
    kvm:svm_int_ctl_test                                   fail     fail     same
    kvm:svm_nested_shutdown_test                           fail     fail     same
    kvm:svm_nested_soft_inject_test                        fail     fail     same
    kvm:svm_vmcall_test                                    fail     fail     same
    kvm:sync_regs_test                                     fail     fail     same
    kvm:system_counter_offset_test                         pass     pass     same
    kvm:triple_fault_event_test                            fail     fail     same
    kvm:tsc_msrs_test                                      fail     fail     same
    kvm:tsc_scaling_sync                                   fail     fail     same
    kvm:ucna_injection_test                                fail     fail     same
    kvm:userspace_io_test                                  fail     fail     same
    kvm:userspace_msr_exit_test                            fail     fail     same
    kvm:vmx_apic_access_test                               fail     fail     same
    kvm:vmx_close_while_nested_test                        fail     fail     same
    kvm:vmx_dirty_log_test                                 fail     fail     same
    kvm:vmx_exception_with_invalid_guest_state             fail     fail     same
    kvm:vmx_invalid_nested_guest_state                     fail     fail     same
    kvm:vmx_msrs_test                                      fail     fail     same
    kvm:vmx_nested_tsc_scaling_test                        fail     fail     same
    kvm:vmx_pmu_caps_test                                  fail     fail     same
    kvm:vmx_preemption_timer_test                          fail     fail     same
    kvm:vmx_set_nested_state_test                          fail     fail     same
    kvm:vmx_tsc_adjust_test                                fail     fail     same
    kvm:xapic_ipi_test                                     fail     fail     same
    kvm:xapic_state_test                                   fail     fail     same
    kvm:xcr0_cpuid_test                                    fail     fail     same
    kvm:xen_shinfo_test                                    fail     fail     same
    kvm:xen_vmcall_test                                    fail     fail     same
    kvm:xss_msr_test                                       fail     fail     same
    landlock:base_test                                     fail     fail     same
    landlock:fs_test                                       fail     fail     same
    landlock:ptrace_test                                   fail     fail     same
    lib:bitmap.sh                                          skip     skip     same
    lib:prime_numbers.sh                                   pass     pass     same
    lib:printf.sh                                          skip     skip     same
    lib:scanf.sh                                           skip     skip     same
    lib:strscpy.sh                                         skip     skip     same
    livepatch:test-callbacks.sh                            pass     pass     same
    livepatch:test-ftrace.sh                               pass     pass     same
    livepatch:test-livepatch.sh                            pass     pass     same
    livepatch:test-shadow-vars.sh                          pass     pass     same
    livepatch:test-state.sh                                pass     pass     same
    livepatch:test-sysfs.sh                                pass     pass     same
    membarrier:membarrier_test_multi_thread                pass     pass     same
    membarrier:membarrier_test_single_thread               pass     pass     same
    memfd:memfd_test                                       pass     pass     same
    memfd:run_fuse_test.sh                                 pass     pass     same
    memfd:run_hugetlbfs_test.sh                            pass     pass     same
    memory-hotplug:mem-on-off-test.sh                      pass     pass     same
    mincore:mincore_selftest                               fail     fail     same
    mount:run_nosymfollow.sh                               pass     pass     same
    mount:run_unprivileged_remount.sh                      pass     pass     same
    mqueue:mq_open_tests                                   pass     pass     same
    mqueue:mq_perf_tests                                   pass     pass     same
    nci:nci_dev                                            fail     fail     same
    net/forwarding:bridge_locked_port.sh                   pass     pass     same
    net/forwarding:bridge_mdb.sh                           skip     skip     same
    net/forwarding:bridge_mdb_host.sh                      pass     pass     same
    net/forwarding:bridge_mdb_max.sh                       skip     skip     same
    net/forwarding:bridge_mdb_port_down.sh                 pass     pass     same
    net/forwarding:bridge_mld.sh                           pass     pass     same
    net/forwarding:bridge_port_isolation.sh                pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh                    pass     pass     same
    net/forwarding:bridge_vlan_aware.sh                    pass     pass     same
    net/forwarding:bridge_vlan_mcast.sh                    pass     pass     same
    net/forwarding:bridge_vlan_unaware.sh                  pass     pass     same
    net/forwarding:custom_multipath_hash.sh                fail     fail     same
    net/forwarding:ethtool.sh                              skip     skip     same
    net/forwarding:ethtool_extended_state.sh               skip     skip     same
    net/forwarding:gre_custom_multipath_hash.sh            fail     fail     same
    net/forwarding:gre_inner_v4_multipath.sh               pass     pass     same
    net/forwarding:gre_multipath.sh                        pass     pass     same
    net/forwarding:gre_multipath_nh.sh                     fail     fail     same
    net/forwarding:gre_multipath_nh_res.sh                 fail     fail     same
    net/forwarding:hw_stats_l3.sh                          skip     skip     same
    net/forwarding:hw_stats_l3_gre.sh                      skip     skip     same
    net/forwarding:ip6_forward_instats_vrf.sh              skip     skip     same
    net/forwarding:ip6gre_custom_multipath_hash.sh         fail     fail     same
    net/forwarding:ip6gre_flat.sh                          pass     pass     same
    net/forwarding:ip6gre_flat_key.sh                      pass     pass     same
    net/forwarding:ip6gre_flat_keys.sh                     pass     pass     same
    net/forwarding:ip6gre_hier.sh                          pass     pass     same
    net/forwarding:ip6gre_hier_key.sh                      pass     pass     same
    net/forwarding:ip6gre_hier_keys.sh                     pass     pass     same
    net/forwarding:ip6gre_inner_v4_multipath.sh            pass     pass     same
    net/forwarding:ipip_flat_gre.sh                        pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh                    pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh                   pass     pass     same
    net/forwarding:ipip_hier_gre.sh                        pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh                    pass     pass     same
    net/forwarding:local_termination.sh                    skip     skip     same
    net/forwarding:loopback.sh                             skip     skip     same
    net/forwarding:mirror_gre.sh                           pass     pass     same
    net/forwarding:mirror_gre_bound.sh                     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh                 pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh                 pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh             pass     pass     same
    net/forwarding:mirror_gre_changes.sh                   pass     pass     same
    net/forwarding:mirror_gre_flower.sh                    pass     pass     same
    net/forwarding:mirror_gre_lag_lacp.sh                  pass     pass     same
    net/forwarding:mirror_gre_neigh.sh                     pass     pass     same
    net/forwarding:mirror_gre_nh.sh                        pass     pass     same
    net/forwarding:mirror_gre_vlan.sh                      pass     pass     same
    net/forwarding:mirror_vlan.sh                          pass     pass     same
    net/forwarding:no_forwarding.sh                        pass     pass     same
    net/forwarding:pedit_dsfield.sh                        pass     pass     same
    net/forwarding:pedit_ip.sh                             pass     pass     same
    net/forwarding:pedit_l4port.sh                         pass     pass     same
    net/forwarding:q_in_vni_ipv6.sh                        pass     pass     same
    net/forwarding:router.sh                               skip     skip     same
    net/forwarding:router_bridge.sh                        pass     pass     same
    net/forwarding:router_bridge_1d.sh                     pass     pass     same
    net/forwarding:router_bridge_pvid_vlan_upper.sh        pass     pass     same
    net/forwarding:router_bridge_vlan.sh                   pass     pass     same
    net/forwarding:router_bridge_vlan_upper.sh             pass     pass     same
    net/forwarding:router_bridge_vlan_upper_pvid.sh        pass     pass     same
    net/forwarding:router_broadcast.sh                     pass     pass     same
    net/forwarding:router_mpath_nh.sh                      fail     fail     same
    net/forwarding:router_mpath_nh_res.sh                  pass     pass     same
    net/forwarding:router_multicast.sh                     skip     skip     same
    net/forwarding:router_multipath.sh                     fail     fail     same
    net/forwarding:router_nh.sh                            pass     pass     same
    net/forwarding:router_vid_1.sh                         pass     pass     same
    net/forwarding:skbedit_priority.sh                     pass     pass     same
    net/forwarding:tc_chains.sh                            pass     pass     same
    net/forwarding:tc_flower.sh                            pass     pass     same
    net/forwarding:tc_flower_cfm.sh                        fail     fail     same
    net/forwarding:tc_flower_l2_miss.sh                    fail     fail     same
    net/forwarding:tc_flower_router.sh                     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh                        pass     pass     same
    net/forwarding:tc_shblocks.sh                          pass     pass     same
    net/forwarding:tc_tunnel_key.sh                        skip     skip     same
    net/forwarding:tc_vlan_modify.sh                       pass     pass     same
    net/forwarding:vxlan_asymmetric.sh                     pass     pass     same
    net/forwarding:vxlan_asymmetric_ipv6.sh                pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh                      pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh            pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472_ipv6.sh       pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh                      pass     pass     same
    net/forwarding:vxlan_bridge_1q_ipv6.sh                 pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh            pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472_ipv6.sh       pass     pass     same
    net/forwarding:vxlan_symmetric.sh                      pass     pass     same
    net/forwarding:vxlan_symmetric_ipv6.sh                 pass     pass     same
    net/hsr:hsr_ping.sh                                    fail     fail     same
    net/mptcp:diag.sh                                      pass     pass     same
    net/mptcp:mptcp_connect.sh                             pass     pass     same
    net/mptcp:mptcp_sockopt.sh                             pass     pass     same
    net/mptcp:pm_netlink.sh                                pass     pass     same
    net:altnames.sh                                        pass     pass     same
    net:bareudp.sh                                         pass     pass     same
    net:big_tcp.sh                                         skip     skip     same
    net:cmsg_so_mark.sh                                    pass     pass     same
    net:devlink_port_split.py                              skip     skip     same
    net:drop_monitor_tests.sh                              skip     skip     same
    net:fcnal-test.sh                                      skip     skip     same
    net:fib-onlink-tests.sh                                pass     pass     same
    net:fib_nexthop_multiprefix.sh                         pass     pass     same
    net:fib_nexthop_nongw.sh                               pass     pass     same
    net:fib_rule_tests.sh                                  pass     pass     same
    net:fib_tests.sh                                       fail     fail     same
    net:fin_ack_lat.sh                                     pass     pass     same
    net:gre_gso.sh                                         skip     skip     same
    net:icmp.sh                                            fail     fail     same
    net:icmp_redirect.sh                                   pass     pass     same
    net:io_uring_zerocopy_tx.sh                            fail     fail     same
    net:ip6_gre_headroom.sh                                pass     pass     same
    net:ipv6_flowlabel.sh                                  pass     pass     same
    net:l2_tos_ttl_inherit.sh                              skip     skip     same
    net:l2tp.sh                                            pass     pass     same
    net:msg_zerocopy.sh                                    pass     pass     same
    net:netdevice.sh                                       pass     pass     same
    net:pmtu.sh                                            fail     fail     same
    net:psock_snd.sh                                       pass     pass     same
    net:reuseaddr_ports_exhausted.sh                       pass     pass     same
    net:reuseport_bpf                                      pass     pass     same
    net:reuseport_bpf_cpu                                  pass     pass     same
    net:reuseport_bpf_numa                                 pass     pass     same
    net:reuseport_dualstack                                pass     pass     same
    net:route_localnet.sh                                  pass     pass     same
    net:rps_default_mask.sh                                pass     pass     same
    net:rtnetlink.sh                                       skip     skip     same
    net:run_afpackettests                                  pass     pass     same
    net:run_netsocktests                                   pass     pass     same
    net:rxtimestamp.sh                                     pass     pass     same
    net:so_txtime.sh                                       pass     pass     same
    net:srv6_end_next_csid_l3vpn_test.sh                   pass     pass     same
    net:srv6_hencap_red_l3vpn_test.sh                      pass     pass     same
    net:srv6_hl2encap_red_l2vpn_test.sh                    pass     pass     same
    net:stress_reuseport_listen.sh                         pass     pass     same
    net:tcp_fastopen_backup_key.sh                         pass     pass     same
    net:test_blackhole_dev.sh                              fail     fail     same
    net:test_bpf.sh                                        pass     pass     same
    net:test_bridge_neigh_suppress.sh                      skip     skip     same
    net:test_vxlan_fdb_changelink.sh                       pass     pass     same
    net:test_vxlan_under_vrf.sh                            pass     pass     same
    net:tls                                                pass     pass     same
    net:traceroute.sh                                      pass     pass     same
    net:udpgro.sh                                          fail     fail     same
    net:udpgro_bench.sh                                    fail     fail     same
    net:udpgso.sh                                          pass     pass     same
    net:unicast_extensions.sh                              pass     pass     same
    net:veth.sh                                            fail     fail     same
    net:vrf-xfrm-tests.sh                                  pass     pass     same
    net:vrf_route_leaking.sh                               pass     pass     same
    net:vrf_strict_mode_test.sh                            pass     pass     same
    netfilter:bridge_brouter.sh                            skip     skip     same
    netfilter:conntrack_icmp_related.sh                    fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh                   fail     fail     same
    netfilter:conntrack_vrf.sh                             skip     skip     same
    netfilter:ipip-conntrack-mtu.sh                        skip     skip     same
    netfilter:ipvs.sh                                      skip     skip     same
    netfilter:nf_nat_edemux.sh                             skip     skip     same
    netfilter:nft_audit.sh                                 fail     fail     same
    netfilter:nft_concat_range.sh                          fail     fail     same
    netfilter:nft_conntrack_helper.sh                      skip     skip     same
    netfilter:nft_fib.sh                                   skip     skip     same
    netfilter:nft_flowtable.sh                             fail     fail     same
    netfilter:nft_meta.sh                                  pass     pass     same
    netfilter:nft_nat.sh                                   skip     skip     same
    netfilter:nft_queue.sh                                 skip     skip     same
    netfilter:rpath.sh                                     pass     pass     same
    nsfs:owner                                             pass     pass     same
    nsfs:pidns                                             pass     pass     same
    pid_namespace:regression_enomem                        pass     pass     same
    pidfd:pidfd_fdinfo_test                                pass     pass     same
    pidfd:pidfd_getfd_test                                 pass     pass     same
    pidfd:pidfd_open_test                                  pass     pass     same
    pidfd:pidfd_poll_test                                  pass     pass     same
    pidfd:pidfd_setns_test                                 pass     pass     same
    pidfd:pidfd_test                                       pass     pass     same
    pidfd:pidfd_wait                                       pass     pass     same
    proc:fd-001-lookup                                     pass     pass     same
    proc:fd-002-posix-eq                                   pass     pass     same
    proc:fd-003-kthread                                    pass     pass     same
    proc:proc-fsconfig-hidepid                             pass     pass     same
    proc:proc-loadavg-001                                  pass     pass     same
    proc:proc-multiple-procfs                              pass     pass     same
    proc:proc-self-map-files-001                           pass     pass     same
    proc:proc-self-map-files-002                           pass     pass     same
    proc:proc-self-syscall                                 pass     pass     same
    proc:proc-self-wchan                                   pass     pass     same
    proc:proc-subset-pid                                   pass     pass     same
    proc:proc-uptime-002                                   pass     pass     same
    proc:read                                              pass     pass     same
    proc:self                                              pass     pass     same
    proc:setns-dcache                                      pass     pass     same
    proc:setns-sysvipc                                     pass     pass     same
    proc:thread-self                                       pass     pass     same
    pstore:pstore_post_reboot_tests                        skip     skip     same
    pstore:pstore_tests                                    fail     fail     same
    ptrace:get_syscall_info                                pass     pass     same
    ptrace:peeksiginfo                                     pass     pass     same
    ptrace:vmaccess                                        fail     fail     same
    rlimits:rlimits-per-userns                             pass     pass     same
    rseq:basic_percpu_ops_test                             pass     pass     same
    rseq:basic_test                                        pass     pass     same
    rseq:param_test                                        pass     pass     same
    rseq:param_test_benchmark                              pass     pass     same
    rseq:param_test_compare_twice                          pass     pass     same
    rseq:run_param_test.sh                                 pass     pass     same
    seccomp:seccomp_benchmark                              pass     pass     same
    seccomp:seccomp_bpf                                    pass     pass     same
    sgx:test_sgx                                           fail     fail     same
    sigaltstack:sas                                        pass     pass     same
    size:get_size                                          pass     pass     same
    splice:default_file_splice_read.sh                     pass     pass     same
    splice:short_splice_read.sh                            fail     fail     same
    static_keys:test_static_keys.sh                        skip     skip     same
    syscall_user_dispatch:sud_benchmark                    pass     pass     same
    syscall_user_dispatch:sud_test                         pass     pass     same
    tc-testing:tdc.sh                                      fail     fail     same
    tdx:tdx_guest_test                                     fail     fail     same
    timens:clock_nanosleep                                 pass     pass     same
    timens:exec                                            pass     pass     same
    timens:futex                                           pass     pass     same
    timens:procfs                                          pass     pass     same
    timens:timens                                          pass     pass     same
    timens:timer                                           pass     pass     same
    timens:timerfd                                         pass     pass     same
    timens:vfork_exec                                      pass     pass     same
    timers:inconsistency-check                             pass     pass     same
    timers:mqueue-lat                                      pass     pass     same
    timers:nanosleep                                       pass     pass     same
    timers:nsleep-lat                                      pass     pass     same
    timers:posix_timers                                    pass     pass     same
    timers:raw_skew                                        pass     pass     same
    timers:rtcpie                                          pass     pass     same
    timers:set-timer-lat                                   pass     pass     same
    timers:threadtest                                      pass     pass     same
    tmpfs:bug-link-o-tmpfile                               pass     pass     same
    tpm2:test_smoke.sh                                     skip     skip     same
    tpm2:test_space.sh                                     skip     skip     same
    tty:tty_tstamp_update                                  skip     skip     same
    vDSO:vdso_standalone_test_x86                          pass     pass     same
    vDSO:vdso_test_abi                                     pass     pass     same
    vDSO:vdso_test_clock_getres                            pass     pass     same
    vDSO:vdso_test_correctness                             pass     pass     same
    vDSO:vdso_test_getcpu                                  pass     pass     same
    vDSO:vdso_test_gettimeofday                            pass     pass     same
    x86:amx_64                                             fail     fail     same
    x86:check_initial_reg_state_64                         pass     pass     same
    x86:corrupt_xstate_header_64                           fail     fail     same
    x86:fsgsbase_64                                        fail     fail     same
    x86:fsgsbase_restore_64                                fail     fail     same
    x86:ioperm_64                                          pass     pass     same
    x86:iopl_64                                            pass     pass     same
    x86:lam_64                                             fail     fail     same
    x86:mov_ss_trap_64                                     fail     fail     same
    x86:sigaltstack_64                                     fail     fail     same
    x86:sigreturn_64                                       fail     fail     same
    x86:single_step_syscall_64                             fail     fail     same
    x86:syscall_arg_fault_64                               fail     fail     same
    x86:syscall_nt_64                                      pass     pass     same
    x86:syscall_numbering_64                               fail     fail     same
    x86:sysret_rip_64                                      fail     fail     same
    x86:sysret_ss_attrs_64                                 pass     pass     same
    x86:test_mremap_vdso_64                                pass     pass     same
    x86:test_vsyscall_64                                   pass     pass     same
    zram:zram.sh                                           pass     pass     same

