### PR TITLE
[LE-3546] scsi: storvsc: Increase the timeouts to storvsc_timeout

### DIFF
--- a/drivers/scsi/storvsc_drv.c
+++ b/drivers/scsi/storvsc_drv.c
@@ -356,7 +356,7 @@ MODULE_PARM_DESC(ring_avail_percent_lowater,
 /*
  * Timeout in seconds for all devices managed by this driver.
  */
-static int storvsc_timeout = 180;
+static const int storvsc_timeout = 180;
 
 #if IS_ENABLED(CONFIG_SCSI_FC_ATTRS)
 static struct scsi_transport_template *fc_transport_template;
@@ -762,7 +762,7 @@ static void  handle_multichannel_storage(struct hv_device *device, int max_chns)
 		return;
 	}
 
-	t = wait_for_completion_timeout(&request->wait_event, 10*HZ);
+	t = wait_for_completion_timeout(&request->wait_event, storvsc_timeout * HZ);
 	if (t == 0) {
 		dev_err(dev, "Failed to create sub-channel: timed out\n");
 		return;
@@ -827,7 +827,7 @@ static int storvsc_execute_vstor_op(struct hv_device *device,
 	if (ret != 0)
 		return ret;
 
-	t = wait_for_completion_timeout(&request->wait_event, 5*HZ);
+	t = wait_for_completion_timeout(&request->wait_event, storvsc_timeout * HZ);
 	if (t == 0)
 		return -ETIMEDOUT;
 
@@ -1345,6 +1345,8 @@ static int storvsc_connect_to_vsp(struct hv_device *device, u32 ring_size,
 		return ret;
 
 	ret = storvsc_channel_init(device, is_fc);
+	if (ret)
+		vmbus_close(device->channel);
 
 	return ret;
 }
@@ -1662,7 +1664,7 @@ static int storvsc_host_reset_handler(struct scsi_cmnd *scmnd)
 	if (ret != 0)
 		return FAILED;
 
-	t = wait_for_completion_timeout(&request->wait_event, 5*HZ);
+	t = wait_for_completion_timeout(&request->wait_event, storvsc_timeout * HZ);
 	if (t == 0)
 		return TIMEOUT_ERROR;
 


### PR DESCRIPTION
jira LE-3546
```
commit-author Dexuan Cui <decui@microsoft.com>
commit b2f966568faaad326de97481096d0f3dc0971c43

Currently storvsc_timeout is only used in storvsc_sdev_configure(), and 5s and 10s are used elsewhere. It turns out that rarely the 5s is not enough on Azure, so let's use storvsc_timeout everywhere.

In case a timeout happens and storvsc_channel_init() returns an error, close the VMBus channel so that any host-to-guest messages in the channel's ringbuffer, which might come late, can be safely ignored.

Add a "const" to storvsc_timeout.

	Cc: stable@kernel.org
	Signed-off-by: Dexuan Cui <decui@microsoft.com>
Link: https://lore.kernel.org/r/1749243459-10419-1-git-send-email-decui@microsoft.com
	Reviewed-by: Long Li <longli@microsoft.com>
	Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
(cherry picked from commit b2f966568faaad326de97481096d0f3dc0971c43)
	Signed-off-by: Sultan Alsawaf <sultan@ciq.com>
```

### Build log
```
/home/rocky/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 3s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  GEN     arch/x86/include/generated/asm/orc_hash.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctls.h
  WRAP    arch/x86/include/generated/uapi/asm/ipcbuf.h
  WRAP    arch/x86/include/generated/uapi/asm/param.h
  WRAP    arch/x86/include/generated/uapi/asm/poll.h
  WRAP    arch/x86/include/generated/uapi/asm/socket.h
  WRAP    arch/x86/include/generated/uapi/asm/resource.h
  WRAP    arch/x86/include/generated/uapi/asm/sockios.h
  WRAP    arch/x86/include/generated/uapi/asm/termbits.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
---
  BTF [M] net/vmw_vsock/vsock_loopback.ko
  BTF [M] net/qrtr/qrtr-mhi.ko
  BTF [M] net/qrtr/qrtr.ko
  BTF [M] net/hsr/hsr.ko
[TIMER]{BUILD}: 1656s
Making Modules
  SYMLINK /lib/modules/6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+/build
  INSTALL /lib/modules/6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+/modules.order
  INSTALL /lib/modules/6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+/modules.builtin
  INSTALL /lib/modules/6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+/modules.builtin.modinfo
  INSTALL /lib/modules/6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+/kernel/arch/x86/events/amd/power.ko
---
  SIGN    /lib/modules/6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+/kernel/net/qrtr/qrtr-mhi.ko
  SIGN    /lib/modules/6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+/kernel/net/qrtr/qrtr.ko
  SIGN    /lib/modules/6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+/kernel/net/hsr/hsr.ko
  DEPMOD  /lib/modules/6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+
[TIMER]{MODULES}: 9s
Making Install
  INSTALL /boot
[TIMER]{INSTALL}: 35s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-6.12.0-sultan_LE-3543_sig-cloud-10_6.12.0-55.27.1.el10_0-31d+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 3s
[TIMER]{BUILD}: 1656s
[TIMER]{MODULES}: 9s
[TIMER]{INSTALL}: 35s
[TIMER]{TOTAL} 1707s
Rebooting in 10 seconds
```

[kernel-build.log](https://github.com/user-attachments/files/21997620/kernel-build.log)


### Testing
```
$ grep ok <(diff -adU0 <(grep ^ok kselftest-before.log | sort) <(grep ^ok kselftest-after.log | sort))
+ok 15 selftests: net: bind_wildcard
+ok 1 selftests: filesystems: devpts_pts # SKIP
+ok 1 selftests: livepatch: test-livepatch.sh # SKIP
-ok 1 selftests: tty: tty_tstamp_update
+ok 2 selftests: livepatch: test-callbacks.sh # SKIP
+ok 3 selftests: livepatch: test-shadow-vars.sh # SKIP
+ok 4 selftests: livepatch: test-state.sh # SKIP
+ok 5 selftests: livepatch: test-ftrace.sh # SKIP
+ok 6 selftests: livepatch: test-sysfs.sh # SKIP
+ok 6 selftests: timers: inconsistency-check
-ok 79 selftests: kvm: rseq_test
+ok 7 selftests: livepatch: test-syscall.sh # SKIP
```

[kselftest-before.log](https://github.com/user-attachments/files/21997622/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/21997624/kselftest-after.log)
