### PR TITLE
[SIG-CLOUD-9] [LE-3554] Drivers: hv: vmbus: Remove vmbus_sendpacket_pagebuffer()

### DIFF
--- a/drivers/hv/channel.c
+++ b/drivers/hv/channel.c
@@ -1077,65 +1077,6 @@ int vmbus_sendpacket(struct vmbus_channel *channel, void *buffer,
 EXPORT_SYMBOL(vmbus_sendpacket);
 
 /*
- * vmbus_sendpacket_pagebuffer - Send a range of single-page buffer
- * packets using a GPADL Direct packet type. This interface allows you
- * to control notifying the host. This will be useful for sending
- * batched data. Also the sender can control the send flags
- * explicitly.
- */
-int vmbus_sendpacket_pagebuffer(struct vmbus_channel *channel,
-				struct hv_page_buffer pagebuffers[],
-				u32 pagecount, void *buffer, u32 bufferlen,
-				u64 requestid)
-{
-	int i;
-	struct vmbus_channel_packet_page_buffer desc;
-	u32 descsize;
-	u32 packetlen;
-	u32 packetlen_aligned;
-	struct kvec bufferlist[3];
-	u64 aligned_data = 0;
-
-	if (pagecount > MAX_PAGE_BUFFER_COUNT)
-		return -EINVAL;
-
-	/*
-	 * Adjust the size down since vmbus_channel_packet_page_buffer is the
-	 * largest size we support
-	 */
-	descsize = sizeof(struct vmbus_channel_packet_page_buffer) -
-			  ((MAX_PAGE_BUFFER_COUNT - pagecount) *
-			  sizeof(struct hv_page_buffer));
-	packetlen = descsize + bufferlen;
-	packetlen_aligned = ALIGN(packetlen, sizeof(u64));
-
-	/* Setup the descriptor */
-	desc.type = VM_PKT_DATA_USING_GPA_DIRECT;
-	desc.flags = VMBUS_DATA_PACKET_FLAG_COMPLETION_REQUESTED;
-	desc.dataoffset8 = descsize >> 3; /* in 8-bytes granularity */
-	desc.length8 = (u16)(packetlen_aligned >> 3);
-	desc.transactionid = VMBUS_RQST_ERROR; /* will be updated in hv_ringbuffer_write() */
-	desc.reserved = 0;
-	desc.rangecount = pagecount;
-
-	for (i = 0; i < pagecount; i++) {
-		desc.range[i].len = pagebuffers[i].len;
-		desc.range[i].offset = pagebuffers[i].offset;
-		desc.range[i].pfn	 = pagebuffers[i].pfn;
-	}
-
-	bufferlist[0].iov_base = &desc;
-	bufferlist[0].iov_len = descsize;
-	bufferlist[1].iov_base = buffer;
-	bufferlist[1].iov_len = bufferlen;
-	bufferlist[2].iov_base = &aligned_data;
-	bufferlist[2].iov_len = (packetlen_aligned - packetlen);
-
-	return hv_ringbuffer_write(channel, bufferlist, 3, requestid, NULL);
-}
-EXPORT_SYMBOL_GPL(vmbus_sendpacket_pagebuffer);
-
-/*
  * vmbus_sendpacket_mpb_desc - Send one or more multi-page buffer packets
  * using a GPADL Direct packet type.
  * The desc argument must include space for the VMBus descriptor. The

--- a/drivers/hv/channel.c
+++ b/drivers/hv/channel.c
@@ -1136,9 +1136,10 @@ int vmbus_sendpacket_pagebuffer(struct vmbus_channel *channel,
 EXPORT_SYMBOL_GPL(vmbus_sendpacket_pagebuffer);
 
 /*
- * vmbus_sendpacket_multipagebuffer - Send a multi-page buffer packet
+ * vmbus_sendpacket_mpb_desc - Send one or more multi-page buffer packets
  * using a GPADL Direct packet type.
- * The buffer includes the vmbus descriptor.
+ * The desc argument must include space for the VMBus descriptor. The
+ * rangecount field must already be set.
  */
 int vmbus_sendpacket_mpb_desc(struct vmbus_channel *channel,
 			      struct vmbus_packet_mpb_array *desc,
@@ -1160,7 +1161,6 @@ int vmbus_sendpacket_mpb_desc(struct vmbus_channel *channel,
 	desc->length8 = (u16)(packetlen_aligned >> 3);
 	desc->transactionid = VMBUS_RQST_ERROR; /* will be updated in hv_ringbuffer_write() */
 	desc->reserved = 0;
-	desc->rangecount = 1;
 
 	bufferlist[0].iov_base = desc;
 	bufferlist[0].iov_len = desc_size;

--- a/drivers/net/hyperv/hyperv_net.h
+++ b/drivers/net/hyperv/hyperv_net.h
@@ -157,7 +157,6 @@ struct hv_netvsc_packet {
 	u8 cp_partial; /* partial copy into send buffer */
 
 	u8 rmsg_size; /* RNDIS header and PPI size */
-	u8 rmsg_pgcnt; /* page count of RNDIS header and PPI */
 	u8 page_buf_cnt;
 
 	u16 q_idx;

--- a/drivers/net/hyperv/hyperv_net.h
+++ b/drivers/net/hyperv/hyperv_net.h
@@ -892,6 +892,18 @@ struct nvsp_message {
 				 sizeof(struct nvsp_message))
 #define NETVSC_MIN_IN_MSG_SIZE sizeof(struct vmpacket_descriptor)
 
+/* Maximum # of contiguous data ranges that can make up a trasmitted packet.
+ * Typically it's the max SKB fragments plus 2 for the rndis packet and the
+ * linear portion of the SKB. But if MAX_SKB_FRAGS is large, the value may
+ * need to be limited to MAX_PAGE_BUFFER_COUNT, which is the max # of entries
+ * in a GPA direct packet sent to netvsp over VMBus.
+ */
+#if MAX_SKB_FRAGS + 2 < MAX_PAGE_BUFFER_COUNT
+#define MAX_DATA_RANGES (MAX_SKB_FRAGS + 2)
+#else
+#define MAX_DATA_RANGES MAX_PAGE_BUFFER_COUNT
+#endif
+
 /* Estimated requestor size:
  * out_ring_size/min_out_msg_size + in_ring_size/min_in_msg_size
  */

--- a/drivers/net/hyperv/netvsc.c
+++ b/drivers/net/hyperv/netvsc.c
@@ -1049,6 +1049,42 @@ static int netvsc_dma_map(struct hv_device *hv_dev,
 	return 0;
 }
 
+/* Build an "array" of mpb entries describing the data to be transferred
+ * over VMBus. After the desc header fields, each "array" entry is variable
+ * size, and each entry starts after the end of the previous entry. The
+ * "offset" and "len" fields for each entry imply the size of the entry.
+ *
+ * The pfns are in HV_HYP_PAGE_SIZE, because all communication with Hyper-V
+ * uses that granularity, even if the system page size of the guest is larger.
+ * Each entry in the input "pb" array must describe a contiguous range of
+ * guest physical memory so that the pfns are sequential if the range crosses
+ * a page boundary. The offset field must be < HV_HYP_PAGE_SIZE.
+ */
+static inline void netvsc_build_mpb_array(struct hv_page_buffer *pb,
+				u32 page_buffer_count,
+				struct vmbus_packet_mpb_array *desc,
+				u32 *desc_size)
+{
+	struct hv_mpb_array *mpb_entry = &desc->range;
+	int i, j;
+
+	for (i = 0; i < page_buffer_count; i++) {
+		u32 offset = pb[i].offset;
+		u32 len = pb[i].len;
+
+		mpb_entry->offset = offset;
+		mpb_entry->len = len;
+
+		for (j = 0; j < HVPFN_UP(offset + len); j++)
+			mpb_entry->pfn_array[j] = pb[i].pfn + j;
+
+		mpb_entry = (struct hv_mpb_array *)&mpb_entry->pfn_array[j];
+	}
+
+	desc->rangecount = page_buffer_count;
+	*desc_size = (char *)mpb_entry - (char *)desc;
+}
+
 static inline int netvsc_send_pkt(
 	struct hv_device *device,
 	struct hv_netvsc_packet *packet,
@@ -1091,6 +1127,9 @@ static inline int netvsc_send_pkt(
 
 	packet->dma_range = NULL;
 	if (packet->page_buf_cnt) {
+		struct vmbus_channel_packet_page_buffer desc;
+		u32 desc_size;
+
 		if (packet->cp_partial)
 			pb += packet->rmsg_pgcnt;
 
@@ -1100,11 +1139,12 @@ static inline int netvsc_send_pkt(
 			goto exit;
 		}
 
-		ret = vmbus_sendpacket_pagebuffer(out_channel,
-						  pb, packet->page_buf_cnt,
-						  &nvmsg, sizeof(nvmsg),
-						  req_id);
-
+		netvsc_build_mpb_array(pb, packet->page_buf_cnt,
+				(struct vmbus_packet_mpb_array *)&desc,
+				 &desc_size);
+		ret = vmbus_sendpacket_mpb_desc(out_channel,
+				(struct vmbus_packet_mpb_array *)&desc,
+				desc_size, &nvmsg, sizeof(nvmsg), req_id);
 		if (ret)
 			netvsc_dma_unmap(ndev_ctx->device_ctx, packet);
 	} else {

--- a/drivers/net/hyperv/netvsc.c
+++ b/drivers/net/hyperv/netvsc.c
@@ -947,8 +947,7 @@ static void netvsc_copy_to_send_buf(struct netvsc_device *net_device,
 		     + pend_size;
 	int i;
 	u32 padding = 0;
-	u32 page_count = packet->cp_partial ? packet->rmsg_pgcnt :
-		packet->page_buf_cnt;
+	u32 page_count = packet->cp_partial ? 1 : packet->page_buf_cnt;
 	u32 remain;
 
 	/* Add padding */
@@ -1131,7 +1130,7 @@ static inline int netvsc_send_pkt(
 		u32 desc_size;
 
 		if (packet->cp_partial)
-			pb += packet->rmsg_pgcnt;
+			pb++;
 
 		ret = netvsc_dma_map(ndev_ctx->device_ctx, packet, pb);
 		if (ret) {
@@ -1293,7 +1292,7 @@ int netvsc_send(struct net_device *ndev,
 		packet->send_buf_index = section_index;
 
 		if (packet->cp_partial) {
-			packet->page_buf_cnt -= packet->rmsg_pgcnt;
+			packet->page_buf_cnt--;
 			packet->total_data_buflen = msd_len + packet->rmsg_size;
 		} else {
 			packet->page_buf_cnt = 0;

--- a/drivers/net/hyperv/netvsc_drv.c
+++ b/drivers/net/hyperv/netvsc_drv.c
@@ -342,7 +342,6 @@ static u32 init_page_array(void *hdr, u32 len, struct sk_buff *skb,
 	pb[0].len = len;
 	pb[0].pfn = virt_to_hvpfn(hdr);
 	packet->rmsg_size = len;
-	packet->rmsg_pgcnt = 1;
 
 	pb[1].offset = offset_in_hvpage(skb->data);
 	pb[1].len = skb_headlen(skb);

--- a/drivers/net/hyperv/netvsc_drv.c
+++ b/drivers/net/hyperv/netvsc_drv.c
@@ -325,43 +325,10 @@ static u16 netvsc_select_queue(struct net_device *ndev, struct sk_buff *skb,
 	return txq;
 }
 
-static u32 fill_pg_buf(unsigned long hvpfn, u32 offset, u32 len,
-		       struct hv_page_buffer *pb)
-{
-	int j = 0;
-
-	hvpfn += offset >> HV_HYP_PAGE_SHIFT;
-	offset = offset & ~HV_HYP_PAGE_MASK;
-
-	while (len > 0) {
-		unsigned long bytes;
-
-		bytes = HV_HYP_PAGE_SIZE - offset;
-		if (bytes > len)
-			bytes = len;
-		pb[j].pfn = hvpfn;
-		pb[j].offset = offset;
-		pb[j].len = bytes;
-
-		offset += bytes;
-		len -= bytes;
-
-		if (offset == HV_HYP_PAGE_SIZE && len) {
-			hvpfn++;
-			offset = 0;
-			j++;
-		}
-	}
-
-	return j + 1;
-}
-
 static u32 init_page_array(void *hdr, u32 len, struct sk_buff *skb,
 			   struct hv_netvsc_packet *packet,
 			   struct hv_page_buffer *pb)
 {
-	u32 slots_used = 0;
-	char *data = skb->data;
 	int frags = skb_shinfo(skb)->nr_frags;
 	int i;
 
@@ -370,28 +337,28 @@ static u32 init_page_array(void *hdr, u32 len, struct sk_buff *skb,
 	 * 2. skb linear data
 	 * 3. skb fragment data
 	 */
-	slots_used += fill_pg_buf(virt_to_hvpfn(hdr),
-				  offset_in_hvpage(hdr),
-				  len,
-				  &pb[slots_used]);
 
+	pb[0].offset = offset_in_hvpage(hdr);
+	pb[0].len = len;
+	pb[0].pfn = virt_to_hvpfn(hdr);
 	packet->rmsg_size = len;
-	packet->rmsg_pgcnt = slots_used;
+	packet->rmsg_pgcnt = 1;
 
-	slots_used += fill_pg_buf(virt_to_hvpfn(data),
-				  offset_in_hvpage(data),
-				  skb_headlen(skb),
-				  &pb[slots_used]);
+	pb[1].offset = offset_in_hvpage(skb->data);
+	pb[1].len = skb_headlen(skb);
+	pb[1].pfn = virt_to_hvpfn(skb->data);
 
 	for (i = 0; i < frags; i++) {
 		skb_frag_t *frag = skb_shinfo(skb)->frags + i;
+		struct hv_page_buffer *cur_pb = &pb[i + 2];
+		u64 pfn = page_to_hvpfn(skb_frag_page(frag));
+		u32 offset = skb_frag_off(frag);
 
-		slots_used += fill_pg_buf(page_to_hvpfn(skb_frag_page(frag)),
-					  skb_frag_off(frag),
-					  skb_frag_size(frag),
-					  &pb[slots_used]);
+		cur_pb->offset = offset_in_hvpage(offset);
+		cur_pb->len = skb_frag_size(frag);
+		cur_pb->pfn = pfn + (offset >> HV_HYP_PAGE_SHIFT);
 	}
-	return slots_used;
+	return frags + 2;
 }
 
 static int count_skb_frag_slots(struct sk_buff *skb)
@@ -482,7 +449,7 @@ static int netvsc_xmit(struct sk_buff *skb, struct net_device *net, bool xdp_tx)
 	struct net_device *vf_netdev;
 	u32 rndis_msg_size;
 	u32 hash;
-	struct hv_page_buffer pb[MAX_PAGE_BUFFER_COUNT];
+	struct hv_page_buffer pb[MAX_DATA_RANGES];
 
 	/* If VF is present and up then redirect packets to it.
 	 * Skip the VF if it is marked down or has no carrier.

--- a/drivers/net/hyperv/rndis_filter.c
+++ b/drivers/net/hyperv/rndis_filter.c
@@ -225,8 +225,7 @@ static int rndis_filter_send_request(struct rndis_device *dev,
 				  struct rndis_request *req)
 {
 	struct hv_netvsc_packet *packet;
-	struct hv_page_buffer page_buf[2];
-	struct hv_page_buffer *pb = page_buf;
+	struct hv_page_buffer pb;
 	int ret;
 
 	/* Setup the packet to send it */
@@ -235,27 +234,14 @@ static int rndis_filter_send_request(struct rndis_device *dev,
 	packet->total_data_buflen = req->request_msg.msg_len;
 	packet->page_buf_cnt = 1;
 
-	pb[0].pfn = virt_to_phys(&req->request_msg) >>
-					HV_HYP_PAGE_SHIFT;
-	pb[0].len = req->request_msg.msg_len;
-	pb[0].offset = offset_in_hvpage(&req->request_msg);
-
-	/* Add one page_buf when request_msg crossing page boundary */
-	if (pb[0].offset + pb[0].len > HV_HYP_PAGE_SIZE) {
-		packet->page_buf_cnt++;
-		pb[0].len = HV_HYP_PAGE_SIZE -
-			pb[0].offset;
-		pb[1].pfn = virt_to_phys((void *)&req->request_msg
-			+ pb[0].len) >> HV_HYP_PAGE_SHIFT;
-		pb[1].offset = 0;
-		pb[1].len = req->request_msg.msg_len -
-			pb[0].len;
-	}
+	pb.pfn = virt_to_phys(&req->request_msg) >> HV_HYP_PAGE_SHIFT;
+	pb.len = req->request_msg.msg_len;
+	pb.offset = offset_in_hvpage(&req->request_msg);
 
 	trace_rndis_send(dev->ndev, 0, &req->request_msg);
 
 	rcu_read_lock_bh();
-	ret = netvsc_send(dev->ndev, packet, NULL, pb, NULL, false);
+	ret = netvsc_send(dev->ndev, packet, NULL, &pb, NULL, false);
 	rcu_read_unlock_bh();
 
 	return ret;

--- a/drivers/scsi/storvsc_drv.c
+++ b/drivers/scsi/storvsc_drv.c
@@ -1815,6 +1815,7 @@ static int storvsc_queuecommand(struct Scsi_Host *host, struct scsi_cmnd *scmnd)
 				return SCSI_MLQUEUE_DEVICE_BUSY;
 		}
 
+		payload->rangecount = 1;
 		payload->range.len = length;
 		payload->range.offset = offset_in_hvpg;
 

--- a/include/linux/hyperv.h
+++ b/include/linux/hyperv.h
@@ -1226,13 +1226,6 @@ extern int vmbus_sendpacket(struct vmbus_channel *channel,
 				  enum vmbus_packet_type type,
 				  u32 flags);
 
-extern int vmbus_sendpacket_pagebuffer(struct vmbus_channel *channel,
-					    struct hv_page_buffer pagebuffers[],
-					    u32 pagecount,
-					    void *buffer,
-					    u32 bufferlen,
-					    u64 requestid);
-
 extern int vmbus_sendpacket_mpb_desc(struct vmbus_channel *channel,
 				     struct vmbus_packet_mpb_array *mpb,
 				     u32 desc_size,


### PR DESCRIPTION

### Commit message

```
    Drivers: hv: vmbus: Remove vmbus_sendpacket_pagebuffer()
    
    jira LE-3554
    commit-author Michael Kelley <mhklinux@outlook.com>
    commit 45a442fe369e6c4e0b4aa9f63b31c3f2f9e2090e
    
    With the netvsc driver changed to use vmbus_sendpacket_mpb_desc()
    instead of vmbus_sendpacket_pagebuffer(), the latter has no remaining
    callers. Remove it.

--------------------------------------------------------------------------------------------

    hv_netvsc: Remove rmsg_pgcnt
    
    jira LE-3554
    commit-author Michael Kelley <mhklinux@outlook.com>
    commit 5bbc644bbf4e97a05bc0cb052189004588ff8a09
    
    init_page_array() now always creates a single page buffer array entry
    for the rndis message, even if the rndis message crosses a page
    boundary. As such, the number of page buffer array entries used for
    the rndis message must no longer be tracked -- it is always just 1.
    Remove the rmsg_pgcnt field and use "1" where the value is needed.

--------------------------------------------------------------------------------------------


    hv_netvsc: Preserve contiguous PFN grouping in the page buffer array
    
    jira LE-3554
    commit-author Michael Kelley <mhklinux@outlook.com>
    commit 41a6328b2c55276f89ea3812069fd7521e348bbf
    
    Starting with commit dca5161f9bd0 ("hv_netvsc: Check status in
    SEND_RNDIS_PKT completion message") in the 6.3 kernel, the Linux
    driver for Hyper-V synthetic networking (netvsc) occasionally reports
    "nvsp_rndis_pkt_complete error status: 2".[1] This error indicates
    that Hyper-V has rejected a network packet transmit request from the
    guest, and the outgoing network packet is dropped. Higher level
    network protocols presumably recover and resend the packet so there is
    no functional error, but performance is slightly impacted. Commit
    dca5161f9bd0 is not the cause of the error -- it only added reporting
    of an error that was already happening without any notice. The error
    has presumably been present since the netvsc driver was originally
    introduced into Linux.
    
    The root cause of the problem is that the netvsc driver in Linux may
    send an incorrectly formatted VMBus message to Hyper-V when
    transmitting the network packet. The incorrect formatting occurs when
    the rndis header of the VMBus message crosses a page boundary due to
    how the Linux skb head memory is aligned. In such a case, two PFNs are
    required to describe the location of the rndis header, even though
    they are contiguous in guest physical address (GPA) space. Hyper-V
    requires that two rndis header PFNs be in a single "GPA range" data
    struture, but current netvsc code puts each PFN in its own GPA range,
    which Hyper-V rejects as an error.
    
    The incorrect formatting occurs only for larger packets that netvsc
    must transmit via a VMBus "GPA Direct" message. There's no problem
    when netvsc transmits a smaller packet by copying it into a pre-
    allocated send buffer slot because the pre-allocated slots don't have
    page crossing issues.
    
    After commit 14ad6ed30a10 ("net: allow small head cache usage with
    large MAX_SKB_FRAGS values") in the 6.14-rc4 kernel, the error occurs
    much more frequently in VMs with 16 or more vCPUs. It may occur every
    few seconds, or even more frequently, in an ssh session that outputs a
    lot of text. Commit 14ad6ed30a10 subtly changes how skb head memory is
    allocated, making it much more likely that the rndis header will cross
    a page boundary when the vCPU count is 16 or more. The changes in
    commit 14ad6ed30a10 are perfectly valid -- they just had the side
    effect of making the netvsc bug more prominent.
    
    Current code in init_page_array() creates a separate page buffer array
    entry for each PFN required to identify the data to be transmitted.
    Contiguous PFNs get separate entries in the page buffer array, and any
    information about contiguity is lost.
    
    Fix the core issue by having init_page_array() construct the page
    buffer array to represent contiguous ranges rather than individual
    pages. When these ranges are subsequently passed to
    netvsc_build_mpb_array(), it can build GPA ranges that contain
    multiple PFNs, as required to avoid the error "nvsp_rndis_pkt_complete
    error status: 2". If instead the network packet is sent by copying
    into a pre-allocated send buffer slot, the copy proceeds using the
    contiguous ranges rather than individual pages, but the result of the
    copying is the same. Also fix rndis_filter_send_request() to construct
    a contiguous range, since it has its own page buffer array.
    
    This change has a side benefit in CoCo VMs in that netvsc_dma_map()
    calls dma_map_single() on each contiguous range instead of on each
    page. This results in fewer calls to dma_map_single() but on larger
    chunks of memory, which should reduce contention on the swiotlb.
    
    Since the page buffer array now contains one entry for each contiguous
    range instead of for each individual page, the number of entries in
    the array can be reduced, saving 208 bytes of stack space in
    netvsc_xmit() when MAX_SKG_FRAGS has the default value of 17.
    
    [1] https://bugzilla.kernel.org/show_bug.cgi?id=217503
    
--------------------------------------------------------------------------------------------

    hv_netvsc: Use vmbus_sendpacket_mpb_desc() to send VMBus messages
    
    jira LE-3554
    commit-author Michael Kelley <mhklinux@outlook.com>
    commit 4f98616b855cb0e3b5917918bb07b44728eb96ea
    
    netvsc currently uses vmbus_sendpacket_pagebuffer() to send VMBus
    messages. This function creates a series of GPA ranges, each of which
    contains a single PFN. However, if the rndis header in the VMBus
    message crosses a page boundary, the netvsc protocol with the host
    requires that both PFNs for the rndis header must be in a single "GPA
    range" data structure, which isn't possible with
    vmbus_sendpacket_pagebuffer(). As the first step in fixing this, add a
    new function netvsc_build_mpb_array() to build a VMBus message with
    multiple GPA ranges, each of which may contain multiple PFNs. Use
    vmbus_sendpacket_mpb_desc() to send this VMBus message to the host.
    
    There's no functional change since higher levels of netvsc don't
    maintain or propagate knowledge of contiguous PFNs. Based on its
    input, netvsc_build_mpb_array() still produces a separate GPA range
    for each PFN and the behavior is the same as with
    vmbus_sendpacket_pagebuffer(). But the groundwork is laid for a
    subsequent patch to provide the necessary grouping.
    
--------------------------------------------------------------------------------------------

    Drivers: hv: Allow vmbus_sendpacket_mpb_desc() to create multiple ranges
    
    jira LE-3554
    commit-author Michael Kelley <mhklinux@outlook.com>
    commit 380b75d3078626aadd0817de61f3143f5db6e393
    
    vmbus_sendpacket_mpb_desc() is currently used only by the storvsc driver
    and is hardcoded to create a single GPA range. To allow it to also be
    used by the netvsc driver to create multiple GPA ranges, no longer
    hardcode as having a single GPA range. Allow the calling driver to
    specify the rangecount in the supplied descriptor.
    
    Update the storvsc driver to reflect this new approach.
    
```

### Kernel Build

```
/home/rocky/workspace/kernel-src-tree
Skipping make mrproper
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-HEAD-901c28ff4d62"
Making olddefconfig
#
# configuration written to .config
#
Starting Build
  SYNC    include/config/auto.conf.cmd
mkdir -p /home/rocky/workspace/kernel-src-tree/tools/objtool && make O=/home/rocky/workspace/kernel-src-tree subdir=tools/objtool --no-print-directory -C objtool 
mkdir -p /home/rocky/workspace/kernel-src-tree/tools/bpf/resolve_btfids && make O=/home/rocky/workspace/kernel-src-tree subdir=tools/bpf/resolve_btfids --no-print-directory -C bpf/resolve_btfids 
  INSTALL libsubcmd_headers
  CALL    scripts/atomic/check-atomics.sh
warning: generated include/linux/atomic/atomic-instrumented.h has been modified.
  CALL    scripts/checksyscalls.sh
  CHK     include/generated/compile.h
  CHK     kernel/kheaders_data.tar.xz
  TEST    posttest
arch/x86/tools/insn_decoder_test: success: Decoded and checked 6993310 instructions
  TEST    posttest
arch/x86/tools/insn_sanity: Success: decoded and checked 1000000 random instructions with 0 errors (seed:0xc8873efd)
Kernel: arch/x86/boot/bzImage is ready  (#1)
[TIMER]{BUILD}: 34s
Making Modules
  INSTALL /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/
  <--snip-->  STRIP   /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  STRIP   /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-HEAD-901c28ff4d62+/kernel/sound/xen/snd_xen_front.ko
  DEPMOD  /lib/modules/5.14.0-HEAD-901c28ff4d62+
[TIMER]{MODULES}: 8s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-HEAD-901c28ff4d62+ \
	arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 25s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-HEAD-c771763a2b69+ and Index to 3
The default is /boot/loader/entries/ae477367830943118aa3354df0e829b2-5.14.0-HEAD-c771763a2b69+.conf with index 3 and kernel /boot/vmlinuz-5.14.0-HEAD-c771763a2b69+
The default is /boot/loader/entries/ae477367830943118aa3354df0e829b2-5.14.0-HEAD-c771763a2b69+.conf with index 3 and kernel /boot/vmlinuz-5.14.0-HEAD-c771763a2b69+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 0s
[TIMER]{BUILD}: 34s
[TIMER]{MODULES}: 8s
[TIMER]{INSTALL}: 25s
[TIMER]{TOTAL} 69s
Rebooting in 10 seconds
```
[kernel-build.log](https://github.com/user-attachments/files/22034459/kernel-build.log)

### Kselftest

```
[rocky@shreeya-scn9 workspace]$ grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
345
347
[rocky@shreeya-scn9 workspace]$ grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
82
80
```
[kselftest-after.log](https://github.com/user-attachments/files/22034487/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/22034488/kselftest-before.log)


### Testing

```
[rocky@shreeya-scn9 kernel-src-tree]$ lsmod | grep hv_netvsc
hv_netvsc             122880  0
hv_vmbus              188416  8 hv_balloon,hv_utils,hv_netvsc,hid_hyperv,hv_storvsc,hyperv_keyboard,hyperv_drm,pci_hyperv

[rocky@shreeya-scn9 kernel-src-tree]$ ip addr show dev eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 60:45:bd:ef:7a:84 brd ff:ff:ff:ff:ff:ff
    inet 10.3.0.10/24 brd 10.3.0.255 scope global noprefixroute eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::6245:bdff:feef:7a84/64 scope link 
       valid_lft forever preferred_lft forever

[rocky@shreeya-scn9 kernel-src-tree]$ ip route show default
default via 10.3.0.1 dev eth0 proto dhcp src 10.3.0.10 metric 100 
default via 10.3.0.1 dev eth1 proto dhcp src 10.3.0.10 metric 100 
[rocky@shreeya-scn9 kernel-src-tree]$ ping -c 4 10.3.0.10
PING 10.3.0.10 (10.3.0.10) 56(84) bytes of data.
64 bytes from 10.3.0.10: icmp_seq=1 ttl=64 time=0.028 ms
64 bytes from 10.3.0.10: icmp_seq=2 ttl=64 time=0.038 ms
64 bytes from 10.3.0.10: icmp_seq=3 ttl=64 time=0.047 ms
64 bytes from 10.3.0.10: icmp_seq=4 ttl=64 time=0.036 ms

--- 10.3.0.10 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3073ms
rtt min/avg/max/mdev = 0.028/0.037/0.047/0.006 ms

[rocky@shreeya-scn9 kernel-src-tree]$ ping -c 20 -s 1472 10.3.0.10
PING 10.3.0.10 (10.3.0.10) 1472(1500) bytes of data.
1480 bytes from 10.3.0.10: icmp_seq=1 ttl=64 time=0.029 ms
1480 bytes from 10.3.0.10: icmp_seq=2 ttl=64 time=0.038 ms
1480 bytes from 10.3.0.10: icmp_seq=3 ttl=64 time=0.042 ms
1480 bytes from 10.3.0.10: icmp_seq=4 ttl=64 time=0.035 ms
1480 bytes from 10.3.0.10: icmp_seq=5 ttl=64 time=0.035 ms
1480 bytes from 10.3.0.10: icmp_seq=6 ttl=64 time=0.022 ms
1480 bytes from 10.3.0.10: icmp_seq=7 ttl=64 time=0.037 ms
1480 bytes from 10.3.0.10: icmp_seq=8 ttl=64 time=0.038 ms
1480 bytes from 10.3.0.10: icmp_seq=9 ttl=64 time=0.040 ms
1480 bytes from 10.3.0.10: icmp_seq=10 ttl=64 time=0.043 ms
1480 bytes from 10.3.0.10: icmp_seq=11 ttl=64 time=0.032 ms
1480 bytes from 10.3.0.10: icmp_seq=12 ttl=64 time=0.036 ms
1480 bytes from 10.3.0.10: icmp_seq=13 ttl=64 time=0.039 ms
1480 bytes from 10.3.0.10: icmp_seq=14 ttl=64 time=0.039 ms
1480 bytes from 10.3.0.10: icmp_seq=15 ttl=64 time=0.048 ms
1480 bytes from 10.3.0.10: icmp_seq=16 ttl=64 time=0.047 ms
1480 bytes from 10.3.0.10: icmp_seq=17 ttl=64 time=0.041 ms
1480 bytes from 10.3.0.10: icmp_seq=18 ttl=64 time=0.039 ms
1480 bytes from 10.3.0.10: icmp_seq=19 ttl=64 time=0.046 ms
1480 bytes from 10.3.0.10: icmp_seq=20 ttl=64 time=0.047 ms

--- 10.3.0.10 ping statistics ---
20 packets transmitted, 20 received, 0% packet loss, time 19469ms
rtt min/avg/max/mdev = 0.022/0.038/0.048/0.006 ms

[rocky@shreeya-scn9 kernel-src-tree]$ sudo dmesg | grep hv_netvsc
[    2.851798] hv_vmbus: registering driver hv_netvsc
[    2.860647] hv_netvsc f8615163-0000-1000-2000-6045bdef7a84 (unnamed net_device) (uninitialized): VF slot 1 added
[    4.918476] hv_netvsc f8615163-0000-1000-2000-6045bdef7a84 eth0: VF registering: eth1
[    5.606771] hv_netvsc f8615163-0000-1000-2000-6045bdef7a84 eth0: Data path switched to VF: eth1
[    5.682826] hv_netvsc f8615163-0000-1000-2000-6045bdef7a84 eth0: Data path switched from VF: eth1
[    5.887417] hv_netvsc f8615163-0000-1000-2000-6045bdef7a84 eth0: Data path switched to VF: eth1
[rocky@shreeya-scn9 kernel-src-tree]$ 
```

  