### PR TITLE
Revert "Revert: crypto: DRBG - switch to HMAC SHA512 DRBG as default …

### DIFF
--- a/crypto/drbg.c
+++ b/crypto/drbg.c
@@ -178,16 +178,16 @@ static const struct drbg_core drbg_cores[] = {
 		.backend_cra_name = "hmac(sha384)",
 	}, {
 		.flags = DRBG_HMAC | DRBG_STRENGTH256,
-		.statelen = 64, /* block length of cipher */
-		.blocklen_bytes = 64,
-		.cra_name = "hmac_sha512",
-		.backend_cra_name = "hmac(sha512)",
-	}, {
-		.flags = DRBG_HMAC | DRBG_STRENGTH256,
 		.statelen = 32, /* block length of cipher */
 		.blocklen_bytes = 32,
 		.cra_name = "hmac_sha256",
 		.backend_cra_name = "hmac(sha256)",
+	}, {
+		.flags = DRBG_HMAC | DRBG_STRENGTH256,
+		.statelen = 64, /* block length of cipher */
+		.blocklen_bytes = 64,
+		.cra_name = "hmac_sha512",
+		.backend_cra_name = "hmac(sha512)",
 	},
 #endif /* CONFIG_CRYPTO_DRBG_HMAC */
 };


### PR DESCRIPTION
…DRBG"

    JIRA: INTERNAL
    Revert Author <jallison@ciq.com>
    Revert Commit fd8a0deb716f6f4dde224de4a6e1caa08cef801d.
    Revert Reason: This changes the default DRBG back to HMAC SHA512 to
    keep entropy certifications for all Rocky9.6 FIPS modules.
    Approved by the lab.

Keeping hmac(sha512) allows the entropy certificates used for Rocky 9.2 FIPS to be re-used in 9.6, preventing re-certification of all the kernel and userspace modules.

NB. We still get the scalability speedup from the per-CPU DRBG changes.