### PR TITLE
[LTS 9.4] ndisc: use RCU protection in ndisc_alloc_skb()

### DIFF
--- a/include/linux/netdevice.h
+++ b/include/linux/netdevice.h
@@ -2684,6 +2684,12 @@ struct net *dev_net(const struct net_device *dev)
 }
 
 static inline
+struct net *dev_net_rcu(const struct net_device *dev)
+{
+	return read_pnet_rcu(&dev->nd_net);
+}
+
+static inline
 void dev_net_set(struct net_device *dev, struct net *net)
 {
 	write_pnet(&dev->nd_net, net);

--- a/include/net/net_namespace.h
+++ b/include/net/net_namespace.h
@@ -350,21 +350,30 @@ static inline void put_net_track(struct net *net, netns_tracker *tracker)
 
 typedef struct {
 #ifdef CONFIG_NET_NS
-	struct net *net;
+	struct net __rcu *net;
 #endif
 } possible_net_t;
 
 static inline void write_pnet(possible_net_t *pnet, struct net *net)
 {
 #ifdef CONFIG_NET_NS
-	pnet->net = net;
+	rcu_assign_pointer(pnet->net, net);
 #endif
 }
 
 static inline struct net *read_pnet(const possible_net_t *pnet)
 {
 #ifdef CONFIG_NET_NS
-	return pnet->net;
+	return rcu_dereference_protected(pnet->net, true);
+#else
+	return &init_net;
+#endif
+}
+
+static inline struct net *read_pnet_rcu(possible_net_t *pnet)
+{
+#ifdef CONFIG_NET_NS
+	return rcu_dereference(pnet->net);
 #else
 	return &init_net;
 #endif

--- a/include/net/net_namespace.h
+++ b/include/net/net_namespace.h
@@ -370,7 +370,7 @@ static inline struct net *read_pnet(const possible_net_t *pnet)
 #endif
 }
 
-static inline struct net *read_pnet_rcu(possible_net_t *pnet)
+static inline struct net *read_pnet_rcu(const possible_net_t *pnet)
 {
 #ifdef CONFIG_NET_NS
 	return rcu_dereference(pnet->net);

--- a/net/ipv6/ndisc.c
+++ b/net/ipv6/ndisc.c
@@ -414,15 +414,11 @@ static struct sk_buff *ndisc_alloc_skb(struct net_device *dev,
 {
 	int hlen = LL_RESERVED_SPACE(dev);
 	int tlen = dev->needed_tailroom;
-	struct sock *sk = dev_net(dev)->ipv6.ndisc_sk;
 	struct sk_buff *skb;
 
 	skb = alloc_skb(hlen + sizeof(struct ipv6hdr) + len + tlen, GFP_ATOMIC);
-	if (!skb) {
-		ND_PRINTK(0, err, "ndisc: %s failed to allocate an skb\n",
-			  __func__);
+	if (!skb)
 		return NULL;
-	}
 
 	skb->protocol = htons(ETH_P_IPV6);
 	skb->dev = dev;
@@ -433,7 +429,9 @@ static struct sk_buff *ndisc_alloc_skb(struct net_device *dev,
 	/* Manually assign socket ownership as we avoid calling
 	 * sock_alloc_send_pskb() to bypass wmem buffer limits
 	 */
-	skb_set_owner_w(skb, sk);
+	rcu_read_lock();
+	skb_set_owner_w(skb, dev_net_rcu(dev)->ipv6.ndisc_sk);
+	rcu_read_unlock();
 
 	return skb;
 }


### PR DESCRIPTION
[LTS 9.4]
CVE-2025-21764
VULN-54027


# Problem

<https://access.redhat.com/security/cve/CVE-2025-21764>
> A vulnerability was found in the Linux kernel's IPv6 Neighbor Discovery (NDISC) subsystem, which manages network neighbor information. The issue arises from improper synchronization mechanisms when allocating socket buffers (sk\_buff) in the ndisc\_alloc\_skb() function. Specifically, the function can be called without holding the necessary Read-Copy-Update (RCU) or Routing Netlink (RTNL) locks, leading to a potential use-after-free (UAF) condition. This flaw allows an attacker with local access and low privileges to exploit the race condition, potentially causing system instability or crashes.


# Solution

The mainline fix 628e6d18930bbd21f2d4562228afe27694f66da9 uses `dev_net_rcu(…)` function defined in 482ad2a4ace2740ca0ff1cbc8f3c7f862f3ab507, which in turn uses `read_pnet_rcu(…)` defined in 2034d90ae41ae93e30d492ebcf1f06f97a9cfba6, none of which were backported to `ciqlts9_4`, so they were included in this PR.

Consider the comparative timeline of `net/ipv6/ndisc.c` and `include/net/net_namespace.h` files changes in the mainline kernel, stable linux 5.15 and LTS 9.4 - all of the commits mentioned were backported to 5.15 along with CVE-2025-21764 patch:

[timeline.log](<https://github.com/user-attachments/files/22124093/timeline.log>)

       kernel-mainline                                                                                   linux-5.15.y            ciqlts9_4
       ------------------------------------------------------------------------------------------------  ----------------------  ----------------------
       c57a9c503 2025-04-14 net: Remove ->exit_batch_rtnl().
       7a60d91c6 2025-04-14 net: Add ->exit_rtnl() hook to struct pernet_operations.
       c353e8983 2025-03-24 net: introduce per netns packet chains
       e57a63202 2025-02-18 net: Add net_passive_inc() and net_passive_dec().
       0784d83df 2025-02-15 ndisc: ndisc_send_redirect() cleanup
       ed6ae1f32 2025-02-10 ndisc: extend RCU protection in ndisc_send_skb()                             ~ e24d225e4 2025-03-13
    1> 628e6d189 2025-02-10 ndisc: use RCU protection in ndisc_alloc_skb()                               ~ b870256dd 2025-03-13
       48145a57d 2025-02-10 ndisc: ndisc_send_redirect() must use dev_get_by_index_rcu()                 ~ 80f706868 2025-03-13
    2> 482ad2a4a 2025-02-06 net: add dev_net_rcu() helper                                                ~ 6e0d21491 2025-03-13
       0734d7c3d 2025-01-15 net: expedite synchronize_net() for cleanup_net()
       a853c6095 2024-12-17 inetpeer: do not get a refcount in inet_getpeer()
       …
       ffabe98cb 2024-02-04 net: make dev_unreg_count global
       b4a11b203 2023-10-20 net: fix IPSTATS_MIB_OUTPKGS increment in OutForwDatagrams.                                          ~ 791e96333 2023-12-11
    3> 2034d90ae 2023-10-18 net: treat possible_net_t net pointer as an RCU one and add read_pnet_rcu()  ~ c22b8d778 2025-03-13
       d986f5212 2023-09-15 ipv6: lockless IPV6_MULTICAST_LOOP implementation
       b0adfba7e 2023-09-15 ipv6: lockless IPV6_UNICAST_HOPS implementation
       …
       c8d6c380d 2013-01-21 ndisc: Simplify arguments for ip6_nd_hdr().                                  = c8d6c380d 2013-01-21  = c8d6c380d 2013-01-21
       2576f17df 2013-01-21 ipv6: Unshare ip6_nd_hdr() and change return type to void.                   = 2576f17df 2013-01-21  = 2576f17df 2013-01-21
    0> de09334b9 2013-01-21 ndisc: Introduce ndisc_alloc_skb() helper.                                   = de09334b9 2013-01-21  = de09334b9 2013-01-21
       9c86dafe9 2013-01-21 ndisc: Introduce ndisc_fill_redirect_hdr_option().                           = 9c86dafe9 2013-01-21  = 9c86dafe9 2013-01-21
       6bce6b4e1 2013-01-21 ndisc: Use skb_linearize() instead of pskb_may_pull(skb, skb->len).          = 6bce6b4e1 2013-01-21  = 6bce6b4e1 2013-01-21
       …

Legend:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-right" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-right">0</td>
<td class="org-left">de09334b9326632bbf1a74bfd8b01866cbbf2f61</td>
<td class="org-left">Commit marked as introducing the bug</td>
</tr>


<tr>
<td class="org-right">1</td>
<td class="org-left">628e6d18930bbd21f2d4562228afe27694f66da9</td>
<td class="org-left">The mainline fix of CVE-2025-21764</td>
</tr>


<tr>
<td class="org-right">2</td>
<td class="org-left">482ad2a4ace2740ca0ff1cbc8f3c7f862f3ab507</td>
<td class="org-left">Defines `dev_net_rcu(…)`</td>
</tr>


<tr>
<td class="org-right">3</td>
<td class="org-left">2034d90ae41ae93e30d492ebcf1f06f97a9cfba6</td>
<td class="org-left">Defines `read_pnet_rcu(…)`</td>
</tr>
</tbody>
</table>

The `dev_net_rcu(…)` function defined in 482ad2a4ace2740ca0ff1cbc8f3c7f862f3ab507 was specifically put as a groundwork for the patch series (<https://lore.kernel.org/all/20250207135841.1948589-3-edumazet@google.com/>) to which 628e6d18930bbd21f2d4562228afe27694f66da9 belongs:

<https://lore.kernel.org/all/173888823503.1713650.11309572430849516645.git-patchwork-notify@kernel.org/>
> Instead, add dev\_net\_rcu() for rcu\_read\_lock() contexts
> and start to use it to fix bugs and clearly document the
> safety requirements.

Apart from adding the `read_pnet_rcu(…)` function the 2034d90ae41ae93e30d492ebcf1f06f97a9cfba6 commit modifies also the existing `read_pnet(…)` and `write_pnet(…)` functions used in other places of kernel code (it affects LTS 9.4 as `CONFIG_NET_NS` is enabled in all `ciqlts9_4` configs). However, the semantics remain unchanged and only the additional RCU-related protections are introduced. See the documentation for the `rcu_assign_pointer(…)` macro <https://github.com/ctrliq/kernel-src-tree/blob/72caef5909197071573183338db0b5e94224311c/include/linux/rcupdate.h#L489-L501>

and the definition of `__rcu_dereference_protected(…)`
<https://github.com/ctrliq/kernel-src-tree/blob/72caef5909197071573183338db0b5e94224311c/include/linux/rcupdate.h#L468-L473>

by which `rcu_dereference_protected(…)` is expressed:
<https://github.com/ctrliq/kernel-src-tree/blob/72caef5909197071573183338db0b5e94224311c/include/linux/rcupdate.h#L673-L674>


# kABI check: passed

    $ DESCR_TARGET=1 DEBUG=1 RELAXED_DEPS=1 CVE=CVE-2025-21764 ./ninja.sh -d explain _kabi_checked__x86_64--test--ciqlts9_4-CVE-2025-21764

    ninja: Entering directory `/data/build/rocky-patching'
    ninja explain: output state/kernels/ciqlts9_4-CVE-2025-21764/x86_64/kabi_checked doesn't exist
    ninja explain: state/kernels/ciqlts9_4-CVE-2025-21764/x86_64/kabi_checked is dirty
    [0/1] 	Check ABI of kernel [ciqlts9_4-CVE-2025-21764]	_kabi_checked__x86_64--test--ciqlts9_4-CVE-2025-21764
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-2025-21764/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-2025-21764/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/22124101/boot-test.log>)


# Kselftests: passed relative


## Coverage

Only the net-related tests were run (at least for the patch, the reference test run contains full scope).


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/22124099/kselftests--ciqlts9_4--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-2025-21764&#x2013;run1.log](<https://github.com/user-attachments/files/22124098/kselftests--ciqlts9_4-CVE-2025-21764--run1.log>)
[kselftests&#x2013;ciqlts9\_4-CVE-2025-21764&#x2013;run2.log](<https://github.com/user-attachments/files/22124095/kselftests--ciqlts9_4-CVE-2025-21764--run2.log>)


## Comparison

The tests results for the reference and patched kernel are the same

    $ ktests.xsh diff --where 'tests.TestCase LIKE "net%"' kselftests--*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4-CVE-2025-21764--run1.log
    Status2   kselftests--ciqlts9_4-CVE-2025-21764--run2.log
    
    TestCase                                          Status0  Status1  Status2  Summary
    net/forwarding:bridge_locked_port.sh              pass     pass     pass     same
    net/forwarding:bridge_mdb.sh                      skip     skip     skip     same
    net/forwarding:bridge_mdb_host.sh                 pass     pass     pass     same
    net/forwarding:bridge_mdb_max.sh                  skip     skip     skip     same
    net/forwarding:bridge_mdb_port_down.sh            pass     pass     pass     same
    net/forwarding:bridge_mld.sh                      pass     pass     pass     same
    net/forwarding:bridge_port_isolation.sh           pass     pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh               pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh               pass     pass     pass     same
    net/forwarding:bridge_vlan_mcast.sh               pass     pass     pass     same
    net/forwarding:bridge_vlan_unaware.sh             pass     pass     pass     same
    net/forwarding:custom_multipath_hash.sh           fail     fail     fail     same
    net/forwarding:ethtool.sh                         skip     skip     skip     same
    net/forwarding:ethtool_extended_state.sh          skip     skip     skip     same
    net/forwarding:gre_custom_multipath_hash.sh       fail     fail     fail     same
    net/forwarding:gre_inner_v4_multipath.sh          pass     pass     pass     same
    net/forwarding:gre_multipath.sh                   pass     pass     pass     same
    net/forwarding:gre_multipath_nh.sh                fail     fail     fail     same
    net/forwarding:gre_multipath_nh_res.sh            fail     fail     fail     same
    net/forwarding:hw_stats_l3.sh                     skip     skip     skip     same
    net/forwarding:hw_stats_l3_gre.sh                 skip     skip     skip     same
    net/forwarding:ip6_forward_instats_vrf.sh         skip     skip     skip     same
    net/forwarding:ip6gre_custom_multipath_hash.sh    fail     fail     fail     same
    net/forwarding:ip6gre_flat.sh                     pass     pass     pass     same
    net/forwarding:ip6gre_flat_key.sh                 pass     pass     pass     same
    net/forwarding:ip6gre_flat_keys.sh                pass     pass     pass     same
    net/forwarding:ip6gre_hier.sh                     pass     pass     pass     same
    net/forwarding:ip6gre_hier_key.sh                 pass     pass     pass     same
    net/forwarding:ip6gre_hier_keys.sh                pass     pass     pass     same
    net/forwarding:ip6gre_inner_v4_multipath.sh       pass     pass     pass     same
    net/forwarding:ipip_flat_gre.sh                   pass     pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh               pass     pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh              pass     pass     pass     same
    net/forwarding:ipip_hier_gre.sh                   pass     pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh               pass     pass     pass     same
    net/forwarding:local_termination.sh               skip     skip     skip     same
    net/forwarding:loopback.sh                        skip     skip     skip     same
    net/forwarding:mirror_gre.sh                      pass     pass     pass     same
    net/forwarding:mirror_gre_bound.sh                pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh            pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh            pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh        pass     pass     pass     same
    net/forwarding:mirror_gre_changes.sh              pass     pass     pass     same
    net/forwarding:mirror_gre_flower.sh               pass     pass     pass     same
    net/forwarding:mirror_gre_lag_lacp.sh             pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh                pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh                   pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh                 pass     pass     pass     same
    net/forwarding:mirror_vlan.sh                     pass     pass     pass     same
    net/forwarding:no_forwarding.sh                   pass     pass     pass     same
    net/forwarding:pedit_dsfield.sh                   pass     pass     pass     same
    net/forwarding:pedit_ip.sh                        pass     pass     pass     same
    net/forwarding:pedit_l4port.sh                    pass     pass     pass     same
    net/forwarding:q_in_vni_ipv6.sh                   pass     pass     pass     same
    net/forwarding:router.sh                          skip     skip     skip     same
    net/forwarding:router_bridge.sh                   pass     pass     pass     same
    net/forwarding:router_bridge_1d.sh                pass     pass     pass     same
    net/forwarding:router_bridge_pvid_vlan_upper.sh   pass     pass     pass     same
    net/forwarding:router_bridge_vlan.sh              pass     pass     pass     same
    net/forwarding:router_bridge_vlan_upper.sh        pass     pass     pass     same
    net/forwarding:router_bridge_vlan_upper_pvid.sh   pass     pass     pass     same
    net/forwarding:router_broadcast.sh                pass     pass     pass     same
    net/forwarding:router_mpath_nh.sh                 fail     fail     fail     same
    net/forwarding:router_mpath_nh_res.sh             pass     pass     pass     same
    net/forwarding:router_multicast.sh                skip     skip     skip     same
    net/forwarding:router_multipath.sh                fail     fail     fail     same
    net/forwarding:router_nh.sh                       pass     pass     pass     same
    net/forwarding:router_vid_1.sh                    pass     pass     pass     same
    net/forwarding:skbedit_priority.sh                pass     pass     pass     same
    net/forwarding:tc_chains.sh                       pass     pass     pass     same
    net/forwarding:tc_flower.sh                       pass     pass     pass     same
    net/forwarding:tc_flower_cfm.sh                   fail     fail     fail     same
    net/forwarding:tc_flower_l2_miss.sh               fail     fail     fail     same
    net/forwarding:tc_flower_router.sh                pass     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh                   pass     pass     pass     same
    net/forwarding:tc_shblocks.sh                     pass     pass     pass     same
    net/forwarding:tc_tunnel_key.sh                   skip     skip     skip     same
    net/forwarding:tc_vlan_modify.sh                  pass     pass     pass     same
    net/forwarding:vxlan_asymmetric.sh                pass     pass     pass     same
    net/forwarding:vxlan_asymmetric_ipv6.sh           pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh                 pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh       pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472_ipv6.sh  pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh                 pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q_ipv6.sh            pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh       pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472_ipv6.sh  pass     pass     pass     same
    net/forwarding:vxlan_symmetric.sh                 pass     pass     pass     same
    net/forwarding:vxlan_symmetric_ipv6.sh            pass     pass     pass     same
    net/hsr:hsr_ping.sh                               fail     fail     fail     same
    net/mptcp:diag.sh                                 pass     pass     pass     same
    net/mptcp:mptcp_connect.sh                        pass     pass     pass     same
    net/mptcp:mptcp_sockopt.sh                        pass     pass     pass     same
    net/mptcp:pm_netlink.sh                           pass     pass     pass     same
    net:altnames.sh                                   pass     pass     pass     same
    net:bareudp.sh                                    pass     pass     pass     same
    net:big_tcp.sh                                    skip     skip     skip     same
    net:cmsg_so_mark.sh                               pass     pass     pass     same
    net:devlink_port_split.py                         skip     skip     skip     same
    net:drop_monitor_tests.sh                         skip     skip     skip     same
    net:fcnal-test.sh                                 skip     skip     skip     same
    net:fib-onlink-tests.sh                           pass     pass     pass     same
    net:fib_nexthop_multiprefix.sh                    pass     pass     pass     same
    net:fib_nexthop_nongw.sh                          pass     pass     pass     same
    net:fib_rule_tests.sh                             pass     pass     pass     same
    net:fib_tests.sh                                  fail     fail     fail     same
    net:fin_ack_lat.sh                                pass     pass     pass     same
    net:gre_gso.sh                                    skip     skip     skip     same
    net:icmp.sh                                       fail     fail     fail     same
    net:icmp_redirect.sh                              pass     pass     pass     same
    net:io_uring_zerocopy_tx.sh                       fail     fail     fail     same
    net:ip6_gre_headroom.sh                           pass     pass     pass     same
    net:ipv6_flowlabel.sh                             pass     pass     pass     same
    net:l2_tos_ttl_inherit.sh                         skip     skip     skip     same
    net:l2tp.sh                                       pass     pass     pass     same
    net:msg_zerocopy.sh                               pass     pass     pass     same
    net:netdevice.sh                                  pass     pass     pass     same
    net:pmtu.sh                                       fail     fail     fail     same
    net:psock_snd.sh                                  pass     pass     pass     same
    net:reuseaddr_ports_exhausted.sh                  pass     pass     pass     same
    net:reuseport_bpf                                 pass     pass     pass     same
    net:reuseport_bpf_cpu                             pass     pass     pass     same
    net:reuseport_bpf_numa                            pass     pass     pass     same
    net:reuseport_dualstack                           pass     pass     pass     same
    net:route_localnet.sh                             pass     pass     pass     same
    net:rps_default_mask.sh                           pass     pass     pass     same
    net:rtnetlink.sh                                  skip     skip     skip     same
    net:run_afpackettests                             pass     pass     pass     same
    net:run_netsocktests                              pass     pass     pass     same
    net:rxtimestamp.sh                                pass     pass     pass     same
    net:so_txtime.sh                                  pass     pass     pass     same
    net:srv6_end_next_csid_l3vpn_test.sh              pass     pass     pass     same
    net:srv6_hencap_red_l3vpn_test.sh                 pass     pass     pass     same
    net:srv6_hl2encap_red_l2vpn_test.sh               pass     pass     pass     same
    net:stress_reuseport_listen.sh                    pass     pass     pass     same
    net:tcp_fastopen_backup_key.sh                    pass     pass     pass     same
    net:test_blackhole_dev.sh                         fail     fail     fail     same
    net:test_bpf.sh                                   pass     pass     pass     same
    net:test_bridge_neigh_suppress.sh                 skip     skip     skip     same
    net:test_vxlan_fdb_changelink.sh                  pass     pass     pass     same
    net:test_vxlan_under_vrf.sh                       pass     pass     pass     same
    net:tls                                           pass     pass     pass     same
    net:traceroute.sh                                 pass     pass     pass     same
    net:udpgro.sh                                     fail     fail     fail     same
    net:udpgro_bench.sh                               fail     fail     fail     same
    net:udpgso.sh                                     pass     pass     pass     same
    net:unicast_extensions.sh                         pass     pass     pass     same
    net:veth.sh                                       fail     fail     fail     same
    net:vrf-xfrm-tests.sh                             pass     pass     pass     same
    net:vrf_route_leaking.sh                          pass     pass     pass     same
    net:vrf_strict_mode_test.sh                       pass     pass     pass     same
    netfilter:bridge_brouter.sh                       skip     skip     skip     same
    netfilter:conntrack_icmp_related.sh               fail     fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh              fail     fail     fail     same
    netfilter:conntrack_vrf.sh                        skip     skip     skip     same
    netfilter:ipip-conntrack-mtu.sh                   skip     skip     skip     same
    netfilter:ipvs.sh                                 skip     skip     skip     same
    netfilter:nf_nat_edemux.sh                        skip     skip     skip     same
    netfilter:nft_audit.sh                            fail     fail     fail     same
    netfilter:nft_concat_range.sh                     fail     fail     fail     same
    netfilter:nft_conntrack_helper.sh                 skip     skip     skip     same
    netfilter:nft_fib.sh                              skip     skip     skip     same
    netfilter:nft_flowtable.sh                        fail     fail     fail     same
    netfilter:nft_meta.sh                             pass     pass     pass     same
    netfilter:nft_nat.sh                              skip     skip     skip     same
    netfilter:nft_queue.sh                            skip     skip     skip     same
    netfilter:rpath.sh                                pass     pass     pass     same


# Specific tests: skipped

