### PR TITLE
[LTS 9.4] media: uvcvideo: Remove dangling pointers

### DIFF
--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1761,7 +1761,10 @@ int uvc_ctrl_begin(struct uvc_video_chain *chain)
 }
 
 static int uvc_ctrl_commit_entity(struct uvc_device *dev,
-	struct uvc_entity *entity, int rollback, struct uvc_control **err_ctrl)
+				  struct uvc_fh *handle,
+				  struct uvc_entity *entity,
+				  int rollback,
+				  struct uvc_control **err_ctrl)
 {
 	struct uvc_control *ctrl;
 	unsigned int i;
@@ -1809,6 +1812,10 @@ static int uvc_ctrl_commit_entity(struct uvc_device *dev,
 				*err_ctrl = ctrl;
 			return ret;
 		}
+
+		if (!rollback && handle &&
+		    ctrl->info.flags & UVC_CTRL_FLAG_ASYNCHRONOUS)
+			ctrl->handle = handle;
 	}
 
 	return 0;
@@ -1845,8 +1852,8 @@ int __uvc_ctrl_commit(struct uvc_fh *handle, int rollback,
 
 	/* Find the control. */
 	list_for_each_entry(entity, &chain->entities, chain) {
-		ret = uvc_ctrl_commit_entity(chain->dev, entity, rollback,
-					     &err_ctrl);
+		ret = uvc_ctrl_commit_entity(chain->dev, handle, entity,
+					     rollback, &err_ctrl);
 		if (ret < 0) {
 			if (ctrls)
 				ctrls->error_idx =
@@ -1995,9 +2002,6 @@ int uvc_ctrl_set(struct uvc_fh *handle,
 
 	mapping->set(mapping, value,
 		uvc_ctrl_data(ctrl, UVC_CTRL_DATA_CURRENT));
-
-	if (ctrl->info.flags & UVC_CTRL_FLAG_ASYNCHRONOUS)
-		ctrl->handle = handle;
 
 	ctrl->dirty = 1;
 	ctrl->modified = 1;
@@ -2320,7 +2324,7 @@ int uvc_ctrl_restore_values(struct uvc_device *dev)
 			ctrl->dirty = 1;
 		}
 
-		ret = uvc_ctrl_commit_entity(dev, entity, 0, NULL);
+		ret = uvc_ctrl_commit_entity(dev, NULL, entity, 0, NULL);
 		if (ret < 0)
 			return ret;
 	}

--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1847,16 +1847,18 @@ int __uvc_ctrl_commit(struct uvc_fh *handle, int rollback,
 	list_for_each_entry(entity, &chain->entities, chain) {
 		ret = uvc_ctrl_commit_entity(chain->dev, entity, rollback,
 					     &err_ctrl);
-		if (ret < 0)
+		if (ret < 0) {
+			if (ctrls)
+				ctrls->error_idx =
+					uvc_ctrl_find_ctrl_idx(entity, ctrls,
+							       err_ctrl);
 			goto done;
+		}
 	}
 
 	if (!rollback)
 		uvc_ctrl_send_events(handle, ctrls->controls, ctrls->count);
 done:
-	if (ret < 0 && ctrls)
-		ctrls->error_idx = uvc_ctrl_find_ctrl_idx(entity, ctrls,
-							  err_ctrl);
 	mutex_unlock(&chain->ctrl_mutex);
 	return ret;
 }
@@ -2162,7 +2164,7 @@ static int uvc_ctrl_init_xu_ctrl(struct uvc_device *dev,
 int uvc_xu_ctrl_query(struct uvc_video_chain *chain,
 	struct uvc_xu_control_query *xqry)
 {
-	struct uvc_entity *entity;
+	struct uvc_entity *entity, *iter;
 	struct uvc_control *ctrl;
 	unsigned int i;
 	bool found;
@@ -2172,16 +2174,16 @@ int uvc_xu_ctrl_query(struct uvc_video_chain *chain,
 	int ret;
 
 	/* Find the extension unit. */
-	found = false;
-	list_for_each_entry(entity, &chain->entities, chain) {
-		if (UVC_ENTITY_TYPE(entity) == UVC_VC_EXTENSION_UNIT &&
-		    entity->id == xqry->unit) {
-			found = true;
+	entity = NULL;
+	list_for_each_entry(iter, &chain->entities, chain) {
+		if (UVC_ENTITY_TYPE(iter) == UVC_VC_EXTENSION_UNIT &&
+		    iter->id == xqry->unit) {
+			entity = iter;
 			break;
 		}
 	}
 
-	if (!found) {
+	if (!entity) {
 		uvc_dbg(chain->dev, CONTROL, "Extension unit %u not found\n",
 			xqry->unit);
 		return -ENOENT;

--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1529,6 +1529,40 @@ static void uvc_ctrl_send_slave_event(struct uvc_video_chain *chain,
 	uvc_ctrl_send_event(chain, handle, ctrl, mapping, val, changes);
 }
 
+static void uvc_ctrl_set_handle(struct uvc_fh *handle, struct uvc_control *ctrl,
+				struct uvc_fh *new_handle)
+{
+	lockdep_assert_held(&handle->chain->ctrl_mutex);
+
+	if (new_handle) {
+		if (ctrl->handle)
+			dev_warn_ratelimited(&handle->stream->dev->udev->dev,
+					     "UVC non compliance: Setting an async control with a pending operation.");
+
+		if (new_handle == ctrl->handle)
+			return;
+
+		if (ctrl->handle) {
+			WARN_ON(!ctrl->handle->pending_async_ctrls);
+			if (ctrl->handle->pending_async_ctrls)
+				ctrl->handle->pending_async_ctrls--;
+		}
+
+		ctrl->handle = new_handle;
+		handle->pending_async_ctrls++;
+		return;
+	}
+
+	/* Cannot clear the handle for a control not owned by us.*/
+	if (WARN_ON(ctrl->handle != handle))
+		return;
+
+	ctrl->handle = NULL;
+	if (WARN_ON(!handle->pending_async_ctrls))
+		return;
+	handle->pending_async_ctrls--;
+}
+
 void uvc_ctrl_status_event(struct uvc_video_chain *chain,
 			   struct uvc_control *ctrl, const u8 *data)
 {
@@ -1539,7 +1573,8 @@ void uvc_ctrl_status_event(struct uvc_video_chain *chain,
 	mutex_lock(&chain->ctrl_mutex);
 
 	handle = ctrl->handle;
-	ctrl->handle = NULL;
+	if (handle)
+		uvc_ctrl_set_handle(handle, ctrl, NULL);
 
 	list_for_each_entry(mapping, &ctrl->info.mappings, list) {
 		s32 value = __uvc_ctrl_get_value(mapping, data);
@@ -1815,7 +1850,7 @@ static int uvc_ctrl_commit_entity(struct uvc_device *dev,
 
 		if (!rollback && handle &&
 		    ctrl->info.flags & UVC_CTRL_FLAG_ASYNCHRONOUS)
-			ctrl->handle = handle;
+			uvc_ctrl_set_handle(handle, ctrl, handle);
 	}
 
 	return 0;
@@ -2744,6 +2779,26 @@ int uvc_ctrl_init_device(struct uvc_device *dev)
 	}
 
 	return 0;
+}
+
+void uvc_ctrl_cleanup_fh(struct uvc_fh *handle)
+{
+	struct uvc_entity *entity;
+
+	guard(mutex)(&handle->chain->ctrl_mutex);
+
+	if (!handle->pending_async_ctrls)
+		return;
+
+	list_for_each_entry(entity, &handle->chain->dev->entities, list) {
+		for (unsigned int i = 0; i < entity->ncontrols; ++i) {
+			if (entity->controls[i].handle != handle)
+				continue;
+			uvc_ctrl_set_handle(handle, &entity->controls[i], NULL);
+		}
+	}
+
+	WARN_ON(handle->pending_async_ctrls);
 }
 
 /*

--- a/drivers/media/usb/uvc/uvc_v4l2.c
+++ b/drivers/media/usb/uvc/uvc_v4l2.c
@@ -659,6 +659,8 @@ static int uvc_v4l2_release(struct file *file)
 
 	uvc_dbg(stream->dev, CALLS, "%s\n", __func__);
 
+	uvc_ctrl_cleanup_fh(handle);
+
 	/* Only free resources if this is a privileged handle. */
 	if (uvc_has_privileges(handle))
 		uvc_queue_release(&stream->queue);

--- a/drivers/media/usb/uvc/uvcvideo.h
+++ b/drivers/media/usb/uvc/uvcvideo.h
@@ -329,7 +329,11 @@ struct uvc_video_chain {
 	struct uvc_entity *processing;		/* Processing unit */
 	struct uvc_entity *selector;		/* Selector unit */
 
-	struct mutex ctrl_mutex;		/* Protects ctrl.info */
+	struct mutex ctrl_mutex;		/*
+						 * Protects ctrl.info,
+						 * ctrl.handle and
+						 * uvc_fh.pending_async_ctrls
+						 */
 
 	struct v4l2_prio_state prio;		/* V4L2 priority state */
 	u32 caps;				/* V4L2 chain-wide caps */
@@ -604,6 +608,7 @@ struct uvc_fh {
 	struct uvc_video_chain *chain;
 	struct uvc_streaming *stream;
 	enum uvc_handle_state state;
+	unsigned int pending_async_ctrls;
 };
 
 struct uvc_driver {
@@ -788,6 +793,8 @@ int uvc_ctrl_is_accessible(struct uvc_video_chain *chain, u32 v4l2_id,
 
 int uvc_xu_ctrl_query(struct uvc_video_chain *chain,
 		      struct uvc_xu_control_query *xqry);
+
+void uvc_ctrl_cleanup_fh(struct uvc_fh *handle);
 
 /* Utility functions */
 struct usb_host_endpoint *uvc_find_endpoint(struct usb_host_interface *alts,


### PR DESCRIPTION
[LTS 9.4]
CVE-2024-58002
VULN-53465


# Problem

<https://access.redhat.com/security/cve/CVE-2024-58002>
> A dangling pointer vulnerability was found in the Linux kernel. When an async control is written, a copy of a pointer is made in the file handle that started the operation. If the user closes that file descriptor, its structure will be freed and there will be one dangling pointer per pending async control that the driver will try to use, leading to denial of service of the system.


# Applicability: yes

The affected module is "USB Video Class", `uvcvideo.ko`. Enabled by `CONFIG_USB_VIDEO_CLASS`, set to `m` in all config files of `ciqlts9_4`:

    $ grep 'USB_VIDEO_CLASS\b' configs/*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-aarch64-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-aarch64-rt-debug-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-aarch64-rt-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-ppc64le-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-s390x-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-x86_64-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-x86_64-rt-debug-rhel.config:CONFIG_USB_VIDEO_CLASS=m
    configs/kernel-x86_64-rt-rhel.config:CONFIG_USB_VIDEO_CLASS=m

The fixing commit 221cd51efe4565501a3dbf04cc011b537dcce7fb is not backported, the "Fixes" commit e5225c820c057537dc780244760e2e24c7d27366 can be found natively in `ciqlts9_4`'s history.


# Solution

The fixing commit 221cd51efe4565501a3dbf04cc011b537dcce7fb could not have been cherry picked without conflicts. It's useful to compare the timeline of the modified files `drivers/media/usb/uvc/{uvc_ctrl.c,uvc_v4l2.c,uvcvideo.h}`, for LTS 9.4 and Linux stable 5.15 as  this fix was backported to 5.15 and the 5.15 version is only a few commits ahead of LTS 9.4:

       kernel-mainline                                                                                                   linux-5.15.y            ciqlts9_4
       ----------------------------------------------------------------------------------------------------------------  ----------------------  ----------------------
       …
       8869eb654 2024-12-19 media: uvcvideo: Allow changing noparam on the fly
       d6b874ff9 2024-12-19 media: uvcvideo: Flush the control cache when we get an event
       02baaa09d 2024-12-19 media: uvcvideo: Annotate lock requirements for uvc_ctrl_set
    1> 221cd51ef 2024-12-19 media: uvcvideo: Remove dangling pointers                                                    ~ 117f7a297 2025-03-13
       04d3398f6 2024-12-19 media: uvcvideo: Remove redundant NULL assignment                                            ~ 14810fb99 2025-03-13
    2> d9fecd096 2024-12-19 media: uvcvideo: Only save async fh if success                                               ~ d775f9e9ek 2025-03-13
       840fb2c33 2024-12-19 media: uvcvideo: Remove duplicated cap/out code
       c31cffd5a 2024-12-19 media: uvcvideo: Fix event flags in uvc_ctrl_send_events                                     ~ 74512c021 2025-03-13
       a9ea1a3d8 2024-12-19 media: uvcvideo: Fix crash during unbind if gpio unit is in use                              ~ 0fdd7cc59 2025-03-13
       44f703386 2024-10-08 media: uvcvideo: Refactor the status irq API
       66558537c 2024-07-22 media: uvcvideo: Fix custom control mapping probing
       8c40efeda 2024-06-17 media: uvcvideo: Remove mappings form uvc_device_info
       e5cbddd09 2024-06-17 media: uvcvideo: Remove PLF device quirking
       6c7f1f756 2024-06-17 media: uvcvideo: Cleanup version-specific mapping
       b2b5fcb1c 2024-06-17 media: uvcvideo: Probe the PLF characteristics
       a8505ad3b 2024-06-17 media: uvcvideo: Refactor Power Line Frequency limit selection
       8f4362a8d 2024-06-17 media: uvcvideo: Allow custom control mapping
       86419686e 2024-06-17 media: uvcvideo: Override default flags                                                      ~ 3a1e47f47 2024-08-19
       53d799538 2024-06-17 media: uvcvideo: Fix hw timestamp handling for slow FPS
       9183c6f1a 2024-06-17 media: uvcvideo: Quirk for invalid dev_sof in Logitech C922
    3> 64627daf0 2024-05-04 media: uvcvideo: Refactor iterators                                                          ~ e0360e009 2025-03-13
       9a6f13261 2024-05-03 media: uvcvideo: Use max() macro
       3de6df64f 2024-04-19 media: uvcvideo: Disable autosuspend for Insta360 Link
       07731053d 2024-04-19 media: uvcvideo: Add quirk for Logitech Rally Bar
       41ebaa5e0 2023-09-14 media: uvcvideo: Fix OOB read
       6d00f4ec1 2023-07-28 media: uvcvideo: Fix menu count handling for userspace XU mappings                                                   ~ d90d3f3ce 2023-11-21
       af621ba2e 2023-06-09 media: uvcvideo: Constify formats, frames and intervals                                                              ~ ba54197fe 2023-11-21
       aa8db3adc 2023-06-09 media: uvcvideo: Rename uvc_format 'frame' field to 'frames'                                                         ~ eb571a6b4 2023-11-21
       ccfad4e85 2023-06-09 media: uvcvideo: Rename uvc_streaming 'format' field to 'formats'                                                    ~ 86ce1a698 2023-11-21
       …
       8643d237a 2018-09-11 media: uvcvideo: Make some structs const                                                     = 8643d237a 2018-09-11  = 8643d237a 2018-09-11
       394dc5888 2018-08-31 media: videobuf2-v4l2: integrate with media requests                                         = 394dc5888 2018-08-31  = 394dc5888 2018-08-31
    0> e5225c820 2018-07-27 media: uvcvideo: Send a control event when a Control Change interrupt arrives                = e5225c820 2018-07-27  = e5225c820 2018-07-27
       222964eaf 2018-07-27 media: uvcvideo: Remove a redundant check                                                    = 222964eaf 2018-07-27  = 222964eaf 2018-07-27
       557a5c7fe 2018-07-27 media: uvcvideo: Add KSMedia 8-bit IR format support                                         = 557a5c7fe 2018-07-27  = 557a5c7fe 2018-07-27
       …

(Full [timeline.log](<https://github.com/user-attachments/files/22127349/timeline.log>))

Legend:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-right" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-right">0</td>
<td class="org-left">e5225c820c057537dc780244760e2e24c7d27366</td>
<td class="org-left">The commit introducing the bug</td>
</tr>


<tr>
<td class="org-right">1</td>
<td class="org-left">221cd51efe4565501a3dbf04cc011b537dcce7fb</td>
<td class="org-left">The commit fixing the bug</td>
</tr>
</tbody>
</table>

Since the latest version 6d00f4ec1205a01a6aac1fe3ce04d53a6b2ede59 for `ciqlts9_4` there was a set of 6 commits to consider as the domain of possible prerequisites: 04d3398f66d2d31c4b8caea88f051a4257b7a161, d9fecd096f67a4469536e040a8a10bbfb665918b, c31cffd5ae2c3d7ef21d9008977a9d117ce7a64e, a9ea1a3d88b7947ce8cadb2afceee7a54872bbc5, 86419686e66da5b90a07fb8a40ab138fe97189b5, e0360e0099047898eca2dab42ca404919df045db (actually could have been more, but the solution was found within this heuristic starting point). The subset 64627daf0c5f7838111f52bbbd1a597cb5d6871a, d9fecd096f67a4469536e040a8a10bbfb665918b was found to secure the clean cherry pick of the mainline fix 221cd51efe4565501a3dbf04cc011b537dcce7fb while also being the smallest. Thus, the legend continued:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-right" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-right">2</td>
<td class="org-left">d9fecd096f67a4469536e040a8a10bbfb665918b</td>
<td class="org-left">First prerequisite for the fix</td>
</tr>


<tr>
<td class="org-right">3</td>
<td class="org-left">64627daf0c5f7838111f52bbbd1a597cb5d6871a</td>
<td class="org-left">Second prerequisite for the fix</td>
</tr>
</tbody>
</table>

It can be noticed that the 5.15 backport actually differs slightly from the mainline version in how mutex is locked in the `uvc_ctrl_cleanup_fh(…)` function.

Mainline:
<https://github.com/ctrliq/kernel-src-tree/blob/221cd51efe4565501a3dbf04cc011b537dcce7fb/drivers/media/usb/uvc/uvc_ctrl.c#L2810-L2828>

Stable 5.15:
<https://github.com/ctrliq/kernel-src-tree/blob/117f7a2975baa4b7d702d3f4830d5a4ebd0c6d50/drivers/media/usb/uvc/uvc_ctrl.c#L2590-L2612>

This is because the the [include/linux/cleanup.h](https://github.com/ctrliq/kernel-src-tree/blob/221cd51efe4565501a3dbf04cc011b537dcce7fb/include/linux/cleanup.h) file, where the `guard(…)` macro is defined, is missing from the 5.15 version. It was backported to `ciqlts9_4`, however, in the 880fe866b72e880f78da6c9496b05100c14c68bb commit, therefore the mainline version of the patch was used in this backport.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-2024-58002 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_4-CVE-2024-58002

    [0/1] Check ABI of kernel [ciqlts9_4-CVE-2024-58002]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-2024-58002/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-2024-58002/x86_64/kabi_checked


# Boot test: passed

Including the "boot test" of the `uvcvideo.ko` module, that is its loading:

[boot-test.log](<https://github.com/user-attachments/files/22127354/boot-test.log>)


# Kselftests: passed relative


## Coverage

`bpf` (only `test_cgroup_storage`, `test_tag`, `test_sysctl`, `test_verifier`, `test_tcpnotify_user`, `test_sock`, `test_lpm_map`, `test_lru_map`), `breakpoints` (only `breakpoint_test`), `capabilities`, `clone3`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding` (all except `bond_macvlan.sh`), `drivers/net/team`, `exec`, `filesystems/binderfs`, `filesystems/epoll`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `iommu`, `ipc`, `ir`, `kcmp`, `kexec`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net/forwarding` (all except `sch_tbf_prio.sh`, `ipip_hier_gre_keys.sh`, `sch_tbf_root.sh`, `tc_actions.sh`, `gre_inner_v6_multipath.sh`, `q_in_vni.sh`, `tc_police.sh`, `sch_ets.sh`, `mirror_gre_vlan_bridge_1q.sh`, `mirror_gre_bridge_1d_vlan.sh`, `router_bridge_1d_lag.sh`, `sch_red.sh`, `bridge_igmp.sh`, `ip6gre_inner_v6_multipath.sh`, `dual_vxlan_bridge.sh`, `vxlan_bridge_1d_ipv6.sh`, `router_bridge_lag.sh`, `sch_tbf_ets.sh`), `net/hsr`, `net/mptcp` (all except `simult_flows.sh`, `userspace_pm.sh`, `mptcp_join.sh`), `net` (all except `reuseport_addr_any.sh`, `srv6_end_flavors_test.sh`, `fib_nexthops.sh`, `gro.sh`, `reuseaddr_conflict`, `srv6_end_dt4_l3vpn_test.sh`, `srv6_end_dt6_l3vpn_test.sh`, `txtimestamp.sh`, `udpgso_bench.sh`, `srv6_end_dt46_l3vpn_test.sh`, `xfrm_policy.sh`, `ip_defrag.sh`, `udpgro_fwd.sh`), `netfilter` (all except `nft_trans_stress.sh`), `nsfs`, `pid_namespace`, `pidfd`, `proc` (all except `proc-uptime-001`, `proc-pid-vm`), `pstore`, `ptrace`, `rlimits`, `rseq`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `syscall_user_dispatch`, `tc-testing`, `tdx`, `timens`, `timers`, `tmpfs`, `tpm2`, `tty`, `vDSO`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/22127353/kselftests--ciqlts9_4--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-2024-58002&#x2013;run1.log](<https://github.com/user-attachments/files/22127352/kselftests--ciqlts9_4-CVE-2024-58002--run1.log>)
[kselftests&#x2013;ciqlts9\_4-CVE-2024-58002&#x2013;run2.log](<https://github.com/user-attachments/files/22127350/kselftests--ciqlts9_4-CVE-2024-58002--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4-CVE-2024-58002--run1.log
    Status2   kselftests--ciqlts9_4-CVE-2024-58002--run2.log


# Specific tests: skipped

