### PR TITLE
[LTS 9.4] net/sched: flower: Fix chain template offload

### DIFF
--- a/include/net/sch_generic.h
+++ b/include/net/sch_generic.h
@@ -16,6 +16,7 @@
 #include <linux/rwsem.h>
 #include <linux/atomic.h>
 #include <linux/hashtable.h>
+#include <linux/rh_kabi.h>
 #include <net/gen_stats.h>
 #include <net/rtnetlink.h>
 #include <net/flow_offload.h>
@@ -376,6 +377,10 @@ struct tcf_proto_ops {
 						struct nlattr **tca,
 						struct netlink_ext_ack *extack);
 	void			(*tmplt_destroy)(void *tmplt_priv);
+	RH_KABI_BROKEN_INSERT(void	(*tmplt_reoffload)(struct tcf_chain *chain,
+						   bool add,
+						   flow_setup_cb_t *cb,
+						   void *cb_priv))
 	struct tcf_exts *	(*get_exts)(const struct tcf_proto *tp,
 					    u32 handle);
 

--- a/net/sched/cls_api.c
+++ b/net/sched/cls_api.c
@@ -1536,6 +1536,9 @@ tcf_block_playback_offloads(struct tcf_block *block, flow_setup_cb_t *cb,
 	     chain_prev = chain,
 		     chain = __tcf_get_next_chain(block, chain),
 		     tcf_chain_put(chain_prev)) {
+		if (chain->tmplt_ops && add)
+			chain->tmplt_ops->tmplt_reoffload(chain, true, cb,
+							  cb_priv);
 		for (tp = __tcf_get_next_proto(chain, NULL); tp;
 		     tp_prev = tp,
 			     tp = __tcf_get_next_proto(chain, tp),
@@ -1551,6 +1554,9 @@ tcf_block_playback_offloads(struct tcf_block *block, flow_setup_cb_t *cb,
 				goto err_playback_remove;
 			}
 		}
+		if (chain->tmplt_ops && !add)
+			chain->tmplt_ops->tmplt_reoffload(chain, false, cb,
+							  cb_priv);
 	}
 
 	return 0;
@@ -2950,7 +2956,8 @@ static int tc_chain_tmplt_add(struct tcf_chain *chain, struct net *net,
 	ops = tcf_proto_lookup_ops(name, true, extack);
 	if (IS_ERR(ops))
 		return PTR_ERR(ops);
-	if (!ops->tmplt_create || !ops->tmplt_destroy || !ops->tmplt_dump) {
+	if (!ops->tmplt_create || !ops->tmplt_destroy || !ops->tmplt_dump ||
+	    !ops->tmplt_reoffload) {
 		NL_SET_ERR_MSG(extack, "Chain templates are not supported with specified classifier");
 		module_put(ops->owner);
 		return -EOPNOTSUPP;

--- a/net/sched/cls_flower.c
+++ b/net/sched/cls_flower.c
@@ -2695,6 +2695,28 @@ static void fl_tmplt_destroy(void *tmplt_priv)
 	kfree(tmplt);
 }
 
+static void fl_tmplt_reoffload(struct tcf_chain *chain, bool add,
+			       flow_setup_cb_t *cb, void *cb_priv)
+{
+	struct fl_flow_tmplt *tmplt = chain->tmplt_priv;
+	struct flow_cls_offload cls_flower = {};
+
+	cls_flower.rule = flow_rule_alloc(0);
+	if (!cls_flower.rule)
+		return;
+
+	cls_flower.common.chain_index = chain->index;
+	cls_flower.command = add ? FLOW_CLS_TMPLT_CREATE :
+				   FLOW_CLS_TMPLT_DESTROY;
+	cls_flower.cookie = (unsigned long) tmplt;
+	cls_flower.rule->match.dissector = &tmplt->dissector;
+	cls_flower.rule->match.mask = &tmplt->mask;
+	cls_flower.rule->match.key = &tmplt->dummy_key;
+
+	cb(TC_SETUP_CLSFLOWER, &cls_flower, cb_priv);
+	kfree(cls_flower.rule);
+}
+
 static int fl_dump_key_val(struct sk_buff *skb,
 			   void *val, int val_type,
 			   void *mask, int mask_type, int len)
@@ -3596,6 +3618,7 @@ static struct tcf_proto_ops cls_fl_ops __read_mostly = {
 	.bind_class	= fl_bind_class,
 	.tmplt_create	= fl_tmplt_create,
 	.tmplt_destroy	= fl_tmplt_destroy,
+	.tmplt_reoffload = fl_tmplt_reoffload,
 	.tmplt_dump	= fl_tmplt_dump,
 	.get_exts	= fl_get_exts,
 	.owner		= THIS_MODULE,


### PR DESCRIPTION
[LTS 9.4]
CVE-2024-26669
VULN-8198


# Problem

<https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=32f2a0afa95fae0d1ceec2ff06e0e816939964b8>

> net/sched: flower: Fix chain template offload
> 
> When a qdisc is deleted from a net device the stack instructs the
> underlying driver to remove its flow offload callback from the
> associated filter block using the 'FLOW\_BLOCK\_UNBIND' command. The stack
> then continues to replay the removal of the filters in the block for
> this driver by iterating over the chains in the block and invoking the
> 'reoffload' operation of the classifier being used. In turn, the
> classifier in its 'reoffload' operation prepares and emits a
> 'FLOW\_CLS\_DESTROY' command for each filter.
> 
> However, the stack does not do the same for chain templates and the
> underlying driver never receives a 'FLOW\_CLS\_TMPLT\_DESTROY' command when
> a qdisc is deleted. This results in a memory leak [1] which can be
> reproduced using [2].


# Affected: yes

The bug-affected (or rather fix-modified) files are:

-   `net/sched/cls_flower.c`
-   `net/sched/cls_api.c`
-   `include/net/sch_generic.h`

The "flower" traffic class implemented by `net/sched/cls_flower.c` is inabled with `CONFIG_NET_CLS_FLOWER` option, set to `m` in all LTS 9.4 configs:

    $ grep 'CONFIG_NET_CLS_FLOWER\b' configs/*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-aarch64-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-aarch64-rt-debug-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-aarch64-rt-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-ppc64le-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-s390x-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-x86_64-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-x86_64-rt-debug-rhel.config:CONFIG_NET_CLS_FLOWER=m
    configs/kernel-x86_64-rt-rhel.config:CONFIG_NET_CLS_FLOWER=m

Naturally, the `CONFIG_NET_CLS` option guarding the `net/sched/cls_api.c` file is enabled as well.

The mainline fix 32f2a0afa95fae0d1ceec2ff06e0e816939964b8 identifies bbf73830cd48cff1599811d4f69c7cfd49c7b869 as the culprit - it's present in `ciqlts9_4` history natively.


# Solution

The mainline fix cherry-picks cleanly but breaks the kABI. From the `check-kabi`'s message:

    *** ERROR - ABI BREAKAGE WAS DETECTED ***
    
    The following symbols have been changed (this will cause an ABI breakage):
    
    flow_block_cb_alloc
    flow_block_cb_free
    flow_block_cb_lookup
    flow_block_cb_setup_simple
    flow_indr_block_cb_alloc
    flow_indr_dev_register
    flow_indr_dev_unregister
    qdisc_reset

The breakage is caused by the introduction of `tmplt_reoffload` field to the `tcf_proto_ops` struct:
<https://github.com/ctrliq/kernel-src-tree/commit/32f2a0afa95fae0d1ceec2ff06e0e816939964b8#diff-acd1ebb1376db4fecebf48e5007639bb90d4ae3e36fe459c2d8bb282fcd218f2R378-R381>

The field was added nonetheless, although moved to the end of the struct and wrapped in the `RH_KABI_EXTEND` macro, which is the sole diff from the mainline fix. The rest of this section argues that it was safe to do so.


## Modified-whitelisted symbols relation

Using the same method as in <https://github.com/ctrliq/kernel-src-tree/pull/475> the relation between the affected whitelisted symbols and the modified one can be established: [kabi-break-chain.log](<https://github.com/user-attachments/files/22216549/kabi-break-chain.log>). It can be summarized in a hierarchical list as:

-   `[struct] tcf_proto_ops` → `[struct] tcf_chain` → `[struct] tcf_block` → `[struct] Qdisc_class_ops` → `[struct] Qdisc_ops` → `[struct] Qdisc`
    -   `[func] qdisc_reset`
    -   `[func] flow_indr_block_cb_alloc`
    -   `[typedef] flow_indr_block_bind_cb_t`
        -   `[func] flow_indr_dev_unregister`
        -   `[func] flow_indr_dev_register`
    -   `[struct] flow_block_offload` → `[func] flow_block_cb_setup_simple`
    -   `[struct] flow_block_indr` → `[struct] flow_block_cb`
        -   `[func] flow_block_cb_lookup`
        -   `[func] flow_block_cb_free`
        -   `[func] flow_block_cb_alloc`

How to read this summary:

-   Notation "`X` → `Y`" means "`X` is used in the definition of `Y`".
-   The same meaning has the child-parent relation, that is
    
    -   `X`
        -   `Y`
    
    is the same as "`X` → `Y`".
-   At the root of the hierarchy is the modified symbol `tcf_proto_ops`.
-   The leaves are the whitelisted symbols.

For example, the `tcf_proto_ops` influences the definition of `flow_block_cb_lookup` by the chain of `[struct] tcf_proto_ops` → `[struct] tcf_chain` → `[struct] tcf_block` → `[struct] Qdisc_class_ops` → `[struct] Qdisc_ops` → `[struct] Qdisc` → `[struct] flow_block_indr` → `[struct] flow_block_cb` → `[func] flow_block_cb_lookup`.

Here's an initial chain between `[struct] tcf_proto_ops` and `[struct] Qdisc` common for all whitelisted symbols:

`[struct] tcf_proto_ops`:
<https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/sch_generic.h#L341>

`[struct] tcf_chain`:
<https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/sch_generic.h#L455>

`[struct] tcf_block`:
<https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/sch_generic.h#L479>

`[struct] Qdisc_class_ops`:
<https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/sch_generic.h#L268-L270>

`[struct] Qdisc_ops`:
<https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/sch_generic.h#L291>

`[struct] Qdisc`:
<https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/sch_generic.h#L98>


## Usage of the `tcf_proto_ops` struct

Although analyzing the symbol's usage within the patched kernel itself doesn't make sense kABI-preservation-wise (kABI will always be preserved by the virtue of a single cohesive build process) it paints the picture of how this symbol can be expected to be used in some downstream custom kernel branch.

Below is the complete list of `tcf_proto_ops` usages in `ciqlts9_4`, based on [gtags](https://en.wikipedia.org/wiki/GNU_GLOBAL), divided by the category of use

-   As a function argument
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/pkt_cls.h#L25>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/pkt_cls.h#L26>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L280>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L300>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L648>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L650>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L2822>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L2908>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L2969>

-   As a local variable
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L232>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L252>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L282>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L302>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L354>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L659>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L2830>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L2937>

-   As a struct field
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/sch_generic.h#L420>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/include/net/sch_generic.h#L455>

-   As a return value
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L230>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_api.c#L248>

-   As a file-scope static variable
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_basic.c#L318>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_bpf.c#L682>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_cgroup.c#L200>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_flow.c#L693>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_flower.c#L3580>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_fw.c#L423>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_matchall.c#L387>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_route.c#L656>
    <https://github.com/ctrliq/kernel-src-tree/blob/32c89d9fdf6cec63997c5317db1a44a088a3b53c/net/sched/cls_u32.c#L1442>


### Observations and conclusion

-   **Whenever `tcf_proto_ops` is passed as a function argument it's always through a pointer**. This ensures preservation of stack addresses.
-   **Whenever `tcf_proto_ops` is used as a local variable it's always by a pointer**. This ensures preservation of stack addresses.
-   **Whenever `tcf_proto_ops` is used as a struct field it's always through a pointer**. This allows the containing struct to be used without any kABI-related restraints.
-   **Whenever `tcf_proto_ops` is returned from a function it's always through a pointer**. In fact this use case showcases how a `tcf_proto_ops` object can be obtained in general - through the use of `tcf_proto_lookup_ops(…)` function exclusively. This defines `tcf_proto_ops` "creation" API excluding automatic allocation on the stack. However, it does internally depend on static allocation, which is addressed in the last point.
-   The `tcf_proto_ops` struct is used as a static variable in each and every one of the traffic classes modules. This usage defines all allocations of `tcf_proto_ops` struct. Theoretically it's possible that a user defined his own custom network traffic class `myprecious` in a way analogous to those defined in the mainline kernel `u32`, `route`, etc., like
    
        static struct tcf_proto_ops cls_myprecious_ops __read_mostly = {
    
    This binary module could then be incompatible with the patched kernel. However, this scenario is highly unlikely, and if `tcf_proto_ops` was ever used in such way then the user would request to put the `tcf_proto_ops` symbol on the whitelist directly, yet it's missing.

Considering that the `tcf_proto_ops` struct is allocated statically, but in a highly controlled and limited fashion, closely related to the definitions of kernel-native traffic classes and unlikely to ever be replicated by an out-of-tree code, and that it's deeply buried, exclusively through pointers, in the substructure of the `Qdisc` struct that the users actually come to contact with in the whitelisted functions, it was determined that modifying it won't cause binary compatibility problems.


# kABI check: passed

    $ DESCR_TARGET=1 DEBUG=1 RELAXED_DEPS=1 CVE=CVE-2024-26669 ./ninja.sh -d explain _kabi_checked__x86_64--test--ciqlts9_4-CVE-2024-26669

    ninja explain: output state/kernels/ciqlts9_4-CVE-2024-26669/x86_64/kabi_checked doesn't exist
    ninja explain: state/kernels/ciqlts9_4-CVE-2024-26669/x86_64/kabi_checked is dirty
    [0/1] 	Check ABI of kernel [ciqlts9_4-CVE-2024-26669]	_kabi_checked__x86_64--test--ciqlts9_4-CVE-2024-26669
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-2024-26669/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-2024-26669/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/22217910/boot-test.log>)


# Kselftests: passed relative


## Coverage

Only the net-specific tests were run (collections `net`, `net/forwarding`, `net/mptcp`, `netfilter`)


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/22217909/kselftests--ciqlts9_4--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-2024-26669&#x2013;run1.log](<https://github.com/user-attachments/files/22217908/kselftests--ciqlts9_4-CVE-2024-26669--run1.log>)
[kselftests&#x2013;ciqlts9\_4-CVE-2024-26669&#x2013;run2.log](<https://github.com/user-attachments/files/22217907/kselftests--ciqlts9_4-CVE-2024-26669--run2.log>)


## Comparison

The tests results for the reference and patched kernel are the same.

    $ ktests.xsh diff  kselftests*.log --where 'tests.TestCase LIKE "net%"'

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4-CVE-2024-26669--run1.log
    Status2   kselftests--ciqlts9_4-CVE-2024-26669--run2.log
    
    TestCase                                          Status0  Status1  Status2  Summary
    net/forwarding:bridge_locked_port.sh              pass     pass     pass     same
    net/forwarding:bridge_mdb.sh                      skip     skip     skip     same
    net/forwarding:bridge_mdb_host.sh                 pass     pass     pass     same
    net/forwarding:bridge_mdb_max.sh                  skip     skip     skip     same
    net/forwarding:bridge_mdb_port_down.sh            pass     pass     pass     same
    net/forwarding:bridge_mld.sh                      pass     pass     pass     same
    net/forwarding:bridge_port_isolation.sh           pass     pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh               pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh               pass     pass     pass     same
    net/forwarding:bridge_vlan_mcast.sh               pass     pass     pass     same
    net/forwarding:bridge_vlan_unaware.sh             pass     pass     pass     same
    net/forwarding:custom_multipath_hash.sh           fail     fail     fail     same
    net/forwarding:ethtool.sh                         skip     skip     skip     same
    net/forwarding:ethtool_extended_state.sh          skip     skip     skip     same
    net/forwarding:gre_custom_multipath_hash.sh       fail     fail     fail     same
    net/forwarding:gre_inner_v4_multipath.sh          pass     pass     pass     same
    net/forwarding:gre_multipath.sh                   pass     pass     pass     same
    net/forwarding:gre_multipath_nh.sh                fail     fail     fail     same
    net/forwarding:gre_multipath_nh_res.sh            fail     fail     fail     same
    net/forwarding:hw_stats_l3.sh                     skip     skip     skip     same
    net/forwarding:hw_stats_l3_gre.sh                 skip     skip     skip     same
    net/forwarding:ip6_forward_instats_vrf.sh         skip     skip     skip     same
    net/forwarding:ip6gre_custom_multipath_hash.sh    fail     fail     fail     same
    net/forwarding:ip6gre_flat.sh                     pass     pass     pass     same
    net/forwarding:ip6gre_flat_key.sh                 pass     pass     pass     same
    net/forwarding:ip6gre_flat_keys.sh                pass     pass     pass     same
    net/forwarding:ip6gre_hier.sh                     pass     pass     pass     same
    net/forwarding:ip6gre_hier_key.sh                 pass     pass     pass     same
    net/forwarding:ip6gre_hier_keys.sh                pass     pass     pass     same
    net/forwarding:ip6gre_inner_v4_multipath.sh       pass     pass     pass     same
    net/forwarding:ipip_flat_gre.sh                   pass     pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh               pass     pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh              pass     pass     pass     same
    net/forwarding:ipip_hier_gre.sh                   pass     pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh               pass     pass     pass     same
    net/forwarding:local_termination.sh               skip     skip     skip     same
    net/forwarding:loopback.sh                        skip     skip     skip     same
    net/forwarding:mirror_gre.sh                      pass     pass     pass     same
    net/forwarding:mirror_gre_bound.sh                pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh            pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh            pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh        pass     pass     pass     same
    net/forwarding:mirror_gre_changes.sh              pass     pass     pass     same
    net/forwarding:mirror_gre_flower.sh               pass     pass     pass     same
    net/forwarding:mirror_gre_lag_lacp.sh             pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh                pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh                   pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh                 pass     pass     pass     same
    net/forwarding:mirror_vlan.sh                     pass     pass     pass     same
    net/forwarding:no_forwarding.sh                   pass     pass     pass     same
    net/forwarding:pedit_dsfield.sh                   pass     pass     pass     same
    net/forwarding:pedit_ip.sh                        pass     pass     pass     same
    net/forwarding:pedit_l4port.sh                    pass     pass     pass     same
    net/forwarding:q_in_vni_ipv6.sh                   pass     pass     pass     same
    net/forwarding:router.sh                          skip     skip     skip     same
    net/forwarding:router_bridge.sh                   pass     pass     pass     same
    net/forwarding:router_bridge_1d.sh                pass     pass     pass     same
    net/forwarding:router_bridge_pvid_vlan_upper.sh   pass     pass     pass     same
    net/forwarding:router_bridge_vlan.sh              pass     pass     pass     same
    net/forwarding:router_bridge_vlan_upper.sh        pass     pass     pass     same
    net/forwarding:router_bridge_vlan_upper_pvid.sh   pass     pass     pass     same
    net/forwarding:router_broadcast.sh                pass     pass     pass     same
    net/forwarding:router_mpath_nh.sh                 fail     fail     fail     same
    net/forwarding:router_mpath_nh_res.sh             pass     pass     pass     same
    net/forwarding:router_multicast.sh                skip     skip     skip     same
    net/forwarding:router_multipath.sh                fail     fail     fail     same
    net/forwarding:router_nh.sh                       pass     pass     pass     same
    net/forwarding:router_vid_1.sh                    pass     pass     pass     same
    net/forwarding:skbedit_priority.sh                pass     pass     pass     same
    net/forwarding:tc_chains.sh                       pass     pass     pass     same
    net/forwarding:tc_flower.sh                       pass     pass     pass     same
    net/forwarding:tc_flower_cfm.sh                   fail     fail     fail     same
    net/forwarding:tc_flower_l2_miss.sh               fail     fail     fail     same
    net/forwarding:tc_flower_router.sh                pass     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh                   pass     pass     pass     same
    net/forwarding:tc_shblocks.sh                     pass     pass     pass     same
    net/forwarding:tc_tunnel_key.sh                   skip     skip     skip     same
    net/forwarding:tc_vlan_modify.sh                  pass     pass     pass     same
    net/forwarding:vxlan_asymmetric.sh                pass     pass     pass     same
    net/forwarding:vxlan_asymmetric_ipv6.sh           pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh                 pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh       pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472_ipv6.sh  pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh                 pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q_ipv6.sh            pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh       pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472_ipv6.sh  pass     pass     pass     same
    net/forwarding:vxlan_symmetric.sh                 pass     pass     pass     same
    net/forwarding:vxlan_symmetric_ipv6.sh            pass     pass     pass     same
    net/hsr:hsr_ping.sh                               fail     fail     fail     same
    net/mptcp:diag.sh                                 pass     pass     pass     same
    net/mptcp:mptcp_connect.sh                        pass     pass     pass     same
    net/mptcp:mptcp_sockopt.sh                        pass     pass     pass     same
    net/mptcp:pm_netlink.sh                           pass     pass     pass     same
    net:altnames.sh                                   pass     pass     pass     same
    net:bareudp.sh                                    pass     pass     pass     same
    net:big_tcp.sh                                    skip     skip     skip     same
    net:cmsg_so_mark.sh                               pass     pass     pass     same
    net:devlink_port_split.py                         skip     skip     skip     same
    net:drop_monitor_tests.sh                         skip     skip     skip     same
    net:fcnal-test.sh                                 skip     skip     skip     same
    net:fib-onlink-tests.sh                           pass     pass     pass     same
    net:fib_nexthop_multiprefix.sh                    pass     pass     pass     same
    net:fib_nexthop_nongw.sh                          pass     pass     pass     same
    net:fib_rule_tests.sh                             pass     pass     pass     same
    net:fib_tests.sh                                  fail     fail     fail     same
    net:fin_ack_lat.sh                                pass     pass     pass     same
    net:gre_gso.sh                                    skip     skip     skip     same
    net:icmp.sh                                       fail     fail     fail     same
    net:icmp_redirect.sh                              pass     pass     pass     same
    net:io_uring_zerocopy_tx.sh                       fail     fail     fail     same
    net:ip6_gre_headroom.sh                           pass     pass     pass     same
    net:ipv6_flowlabel.sh                             pass     pass     pass     same
    net:l2_tos_ttl_inherit.sh                         skip     skip     skip     same
    net:l2tp.sh                                       pass     pass     pass     same
    net:msg_zerocopy.sh                               pass     pass     pass     same
    net:netdevice.sh                                  pass     pass     pass     same
    net:pmtu.sh                                       fail     fail     fail     same
    net:psock_snd.sh                                  pass     pass     pass     same
    net:reuseaddr_ports_exhausted.sh                  pass     pass     pass     same
    net:reuseport_bpf                                 pass     pass     pass     same
    net:reuseport_bpf_cpu                             pass     pass     pass     same
    net:reuseport_bpf_numa                            pass     pass     pass     same
    net:reuseport_dualstack                           pass     pass     pass     same
    net:route_localnet.sh                             pass     pass     pass     same
    net:rps_default_mask.sh                           pass     pass     pass     same
    net:rtnetlink.sh                                  skip     skip     skip     same
    net:run_afpackettests                             pass     pass     pass     same
    net:run_netsocktests                              pass     pass     pass     same
    net:rxtimestamp.sh                                pass     pass     pass     same
    net:so_txtime.sh                                  pass     pass     pass     same
    net:srv6_end_next_csid_l3vpn_test.sh              pass     pass     pass     same
    net:srv6_hencap_red_l3vpn_test.sh                 pass     pass     pass     same
    net:srv6_hl2encap_red_l2vpn_test.sh               pass     pass     pass     same
    net:stress_reuseport_listen.sh                    pass     pass     pass     same
    net:tcp_fastopen_backup_key.sh                    pass     pass     pass     same
    net:test_blackhole_dev.sh                         fail     fail     fail     same
    net:test_bpf.sh                                   pass     pass     pass     same
    net:test_bridge_neigh_suppress.sh                 skip     skip     skip     same
    net:test_vxlan_fdb_changelink.sh                  pass     pass     pass     same
    net:test_vxlan_under_vrf.sh                       pass     pass     pass     same
    net:tls                                           pass     pass     pass     same
    net:traceroute.sh                                 pass     pass     pass     same
    net:udpgro.sh                                     fail     fail     fail     same
    net:udpgro_bench.sh                               fail     fail     fail     same
    net:udpgso.sh                                     pass     pass     pass     same
    net:unicast_extensions.sh                         pass     pass     pass     same
    net:veth.sh                                       fail     fail     fail     same
    net:vrf-xfrm-tests.sh                             pass     pass     pass     same
    net:vrf_route_leaking.sh                          pass     pass     pass     same
    net:vrf_strict_mode_test.sh                       pass     pass     pass     same
    netfilter:bridge_brouter.sh                       skip     skip     skip     same
    netfilter:conntrack_icmp_related.sh               fail     fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh              fail     fail     fail     same
    netfilter:conntrack_vrf.sh                        skip     skip     skip     same
    netfilter:ipip-conntrack-mtu.sh                   skip     skip     skip     same
    netfilter:ipvs.sh                                 skip     skip     skip     same
    netfilter:nf_nat_edemux.sh                        skip     skip     skip     same
    netfilter:nft_audit.sh                            fail     fail     fail     same
    netfilter:nft_concat_range.sh                     fail     fail     fail     same
    netfilter:nft_conntrack_helper.sh                 skip     skip     skip     same
    netfilter:nft_fib.sh                              skip     skip     skip     same
    netfilter:nft_flowtable.sh                        fail     fail     fail     same
    netfilter:nft_meta.sh                             pass     pass     pass     same
    netfilter:nft_nat.sh                              skip     skip     skip     same
    netfilter:nft_queue.sh                            skip     skip     skip     same
    netfilter:rpath.sh                                pass     pass     pass     same


# Specific tests: skipped

