### PR TITLE
[lts86] Many VULNs 9-9-25

### DIFF
--- a/arch/x86/include/asm/kvm_host.h
+++ b/arch/x86/include/asm/kvm_host.h
@@ -639,6 +639,7 @@ struct kvm_vcpu_arch {
 	u64 ia32_misc_enable_msr;
 	u64 smbase;
 	u64 smi_count;
+	bool at_instruction_boundary;
 	bool tpr_access_reporting;
 	bool xsaves_enabled;
 	bool xfd_no_write_intercept;
@@ -1256,6 +1257,8 @@ struct kvm_vcpu_stat {
 	u64 nested_run;
 	u64 directed_yield_attempted;
 	u64 directed_yield_successful;
+	u64 preemption_reported;
+	u64 preemption_other;
 	u64 guest_mode;
 };
 

--- a/arch/x86/kvm/svm/svm.c
+++ b/arch/x86/kvm/svm/svm.c
@@ -4255,6 +4255,8 @@ out:
 
 static void svm_handle_exit_irqoff(struct kvm_vcpu *vcpu)
 {
+	if (to_svm(vcpu)->vmcb->control.exit_code == SVM_EXIT_INTR)
+		vcpu->arch.at_instruction_boundary = true;
 }
 
 static void svm_sched_in(struct kvm_vcpu *vcpu, int cpu)

--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -6521,6 +6521,7 @@ static void handle_external_interrupt_irqoff(struct kvm_vcpu *vcpu)
 		return;
 
 	handle_interrupt_nmi_irqoff(vcpu, gate_offset(desc));
+	vcpu->arch.at_instruction_boundary = true;
 }
 
 static void vmx_handle_exit_irqoff(struct kvm_vcpu *vcpu)

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -278,6 +278,8 @@ const struct _kvm_stats_desc kvm_vcpu_stats_desc[] = {
 	STATS_DESC_COUNTER(VCPU, nested_run),
 	STATS_DESC_COUNTER(VCPU, directed_yield_attempted),
 	STATS_DESC_COUNTER(VCPU, directed_yield_successful),
+	STATS_DESC_COUNTER(VCPU, preemption_reported),
+	STATS_DESC_COUNTER(VCPU, preemption_other),
 	STATS_DESC_ICOUNTER(VCPU, guest_mode)
 };
 
@@ -4462,6 +4464,19 @@ static void kvm_steal_time_set_preempted(struct kvm_vcpu *vcpu)
 	struct kvm_host_map map;
 	struct kvm_steal_time *st;
 
+	/*
+	 * The vCPU can be marked preempted if and only if the VM-Exit was on
+	 * an instruction boundary and will not trigger guest emulation of any
+	 * kind (see vcpu_run).  Vendor specific code controls (conservatively)
+	 * when this is true, for example allowing the vCPU to be marked
+	 * preempted if and only if the VM-Exit was due to a host interrupt.
+	 */
+	if (!vcpu->arch.at_instruction_boundary) {
+		vcpu->stat.preemption_other++;
+		return;
+	}
+
+	vcpu->stat.preemption_reported++;
 	if (!(vcpu->arch.st.msr_val & KVM_MSR_ENABLED))
 		return;
 
@@ -10040,6 +10055,13 @@ static int vcpu_run(struct kvm_vcpu *vcpu)
 	vcpu->arch.l1tf_flush_l1d = true;
 
 	for (;;) {
+		/*
+		 * If another guest vCPU requests a PV TLB flush in the middle
+		 * of instruction emulation, the rest of the emulation could
+		 * use a stale page translation. Assume that any code after
+		 * this point can start executing an instruction.
+		 */
+		vcpu->arch.at_instruction_boundary = false;
 		if (kvm_vcpu_running(vcpu)) {
 			r = vcpu_enter_guest(vcpu);
 		} else {

--- a/kernel/time/posix-cpu-timers.c
+++ b/kernel/time/posix-cpu-timers.c
@@ -1123,6 +1123,15 @@ void run_posix_cpu_timers(void)
 	lockdep_assert_irqs_disabled();
 
 	/*
+	 * Ensure that release_task(tsk) can't happen while
+	 * handle_posix_cpu_timers() is running. Otherwise, a concurrent
+	 * posix_cpu_timer_del() may fail to lock_task_sighand(tsk) and
+	 * miss timer->it.cpu.firing != 0.
+	 */
+	if (tsk->exit_state)
+		return;
+
+	/*
 	 * The fast path checks that there are no expired thread or thread
 	 * group timers.  If that's so, just return.
 	 */

--- a/net/core/devlink.c
+++ b/net/core/devlink.c
@@ -4353,7 +4353,7 @@ static int devlink_param_get(struct devlink *devlink,
 			     const struct devlink_param *param,
 			     struct devlink_param_gset_ctx *ctx)
 {
-	if (!param->get)
+	if (!param->get || devlink->reload_failed)
 		return -EOPNOTSUPP;
 	return param->get(devlink, param->id, ctx);
 }
@@ -4362,7 +4362,7 @@ static int devlink_param_set(struct devlink *devlink,
 			     const struct devlink_param *param,
 			     struct devlink_param_gset_ctx *ctx)
 {
-	if (!param->set)
+	if (!param->set || devlink->reload_failed)
 		return -EOPNOTSUPP;
 	return param->set(devlink, param->id, ctx);
 }

--- a/net/wireless/scan.c
+++ b/net/wireless/scan.c
@@ -2240,7 +2240,7 @@ cfg80211_update_notlisted_nontrans(struct wiphy *wiphy,
 	size_t new_ie_len;
 	struct cfg80211_bss_ies *new_ies;
 	const struct cfg80211_bss_ies *old;
-	u8 cpy_len;
+	size_t cpy_len;
 
 	lockdep_assert_held(&wiphy_to_rdev(wiphy)->bss_lock);
 


### PR DESCRIPTION
### Commits

```
    wifi: cfg80211: fix u8 overflow in cfg80211_update_notlisted_nontrans()

    jira VULN-3805
    cve CVE-2022-41674
    commit-author Johannes Berg <johannes.berg@intel.com>
    commit aebe9f4639b13a1f4e9a6b42cdd2e38c617b442d
```

```
    KVM: x86: do not report a vCPU as preempted outside instruction boundaries

    jira VULN-3802
    cve CVE-2022-39189
    commit-author Paolo Bonzini <pbonzini@redhat.com>
    commit 6cd88243c7e03845a450795e134b488fc2afb736
```

```
    devlink: Fix use-after-free after a failed reload

    jira VULN-3798
    cve CVE-2022-3625
    commit-author Ido Schimmel <idosch@nvidia.com>
    commit 6b4db2e528f650c7fb712961aac36455468d5902
```

```
    posix-cpu-timers: fix race between handle_posix_cpu_timers() and posix_cpu_timer_del()

    jira VULN-136688
    cve CVE-2025-38352
    commit-author Oleg Nesterov <oleg@redhat.com>
    commit f90fff1e152dedf52b932240ebbd670d83330eca
    upstream-diff Used 5.4 LT 78a4b8e3795b31dae58762bc091bb0f4f74a2200 version
```

### Build Log

```
/home/brett/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 8s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqlts8_6_many-vulns-9-9-25-5ebf8c3e84e5"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1234s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL virt/lib/irqbypass.ko
  INSTALL sound/xen/snd_xen_front.ko
  DEPMOD  4.18.0-bmastbergen_ciqlts8_6_many-vulns-9-9-25-5ebf8c3e84e5+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-bmastbergen_ciqlts8_6_many-vulns-9-9-25-5ebf8c3e84e5+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 101s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-bmastbergen_ciqlts8_6_many-vulns-9-9-25-5ebf8c3e84e5+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 8s
[TIMER]{BUILD}: 1234s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 101s
[TIMER]{TOTAL} 1372s
Rebooting in 10 seconds

```

### Testing

[selftest-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.x86_64.log](https://github.com/user-attachments/files/22241586/selftest-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.x86_64.log)

[selftest-4.18.0-bmastbergen_ciqlts8_6_many-vulns-9-9-25-5ebf8c3e84e5+.log](https://github.com/user-attachments/files/22241592/selftest-4.18.0-bmastbergen_ciqlts8_6_many-vulns-9-9-25-5ebf8c3e84e5%2B.log)

```
brett@lycia ~/ciq/many-86-vulns-9-9-25
 % grep ^ok selftest-4.18.0-372.32.1.el8_6.86ciq_lts.14.1.x86_64.log | wc -l
215
brett@lycia ~/ciq/many-86-vulns-9-9-25
 % grep ^ok selftest-4.18.0-bmastbergen_ciqlts8_6_many-vulns-9-9-25-5ebf8c3e84e5+.log | wc -l
215
```