### PR TITLE
[SIG-CLOUD-8] posix-cpu-timers: fix race between handle_posix_cpu_timers() and posix_cpu_timer_del()

### DIFF
--- a/kernel/time/posix-cpu-timers.c
+++ b/kernel/time/posix-cpu-timers.c
@@ -1123,6 +1123,15 @@ void run_posix_cpu_timers(void)
 	lockdep_assert_irqs_disabled();
 
 	/*
+	 * Ensure that release_task(tsk) can't happen while
+	 * handle_posix_cpu_timers() is running. Otherwise, a concurrent
+	 * posix_cpu_timer_del() may fail to lock_task_sighand(tsk) and
+	 * miss timer->it.cpu.firing != 0.
+	 */
+	if (tsk->exit_state)
+		return;
+
+	/*
 	 * The fast path checks that there are no expired thread or thread
 	 * group timers.  If that's so, just return.
 	 */


### PR DESCRIPTION
```
cve CVE-2025-38352
commit-author Oleg Nesterov <oleg@redhat.com>
commit f90fff1e152dedf52b932240ebbd670d83330eca
upstream-diff There where massive merge conflicts due several commits
	      missing from upstream.  Had to manually place and correct
	      do to cherry-pick being extremely greedy with trying to
	      pull changes from this LKML change set:
	      https://lore.kernel.org/all/20200730101404.956367860@linutronix.de/

If an exiting non-autoreaping task has already passed exit_notify() and calls handle_posix_cpu_timers() from IRQ, it can be reaped by its parent or debugger right after unlock_task_sighand().

If a concurrent posix_cpu_timer_del() runs at that moment, it won't be able to detect timer->it.cpu.firing != 0: cpu_timer_task_rcu() and/or lock_task_sighand() will fail.

Add the tsk->exit_state check into run_posix_cpu_timers() to fix this.

This fix is not needed if CONFIG_POSIX_CPU_TIMERS_TASK_WORK=y, because exit_task_work() is called before exit_notify(). But the check still makes sense, task_work_add(&tsk->posix_cputimers_work.work) will fail anyway in this case.

        Cc: stable@vger.kernel.org
        Reported-by: Benoît Sevens <bsevens@google.com>
Fixes: 0bdd2ed4138e ("sched: run_posix_cpu_timers: Don't check ->exit_state, use lock_task_sighand()")
        Signed-off-by: Oleg Nesterov <oleg@redhat.com>
        Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
(cherry picked from commit f90fff1e152dedf52b932240ebbd670d83330eca)
        Signed-off-by: Jonathan Maple <jmaple@ciq.com>
```

## BUILD
```
[jmaple@devbox kernel-src-tree]$ git push origin {jmaple}_sig-cloud-8/4.18.0-553.72.1.el8_10
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 20 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (5/5), 1.41 KiB | 1.41 MiB/s, done.
Total 5 (delta 4), reused 2 (delta 2), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote:
remote: Create a pull request for '{jmaple}_sig-cloud-8/4.18.0-553.72.1.el8_10' on GitHub by visiting:
remote:      https://github.com/ctrliq/kernel-src-tree/pull/new/%7Bjmaple%7D_sig-cloud-8/4.18.0-553.72.1.el8_10
remote:
To github.com:ctrliq/kernel-src-tree.git
 * [new branch]                {jmaple}_sig-cloud-8/4.18.0-553.72.1.el8_10 -> {jmaple}_sig-cloud-8/4.18.0-553.72.1.el8_10
[jmaple@devbox kernel-src-tree]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kbuild* | head -n1)
ls: cannot access 'kbuild*': No such file or directory
^C
[jmaple@devbox kernel-src-tree]$ cd ../
[jmaple@devbox code]$ ^C
[jmaple@devbox code]$ ^C
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kbuild* | head -n1)
/mnt/code/kernel-src-tree-build
Running make mrproper...
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   .config .config.old
[TIMER]{MRPROPER}: 5s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_sig-cloud-8_4.18.0-553.72.1.el8_10-7c700caae90"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1934s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-jmaple_sig-cloud-8_4.18.0-553.72.1.el8_10-7c700caae90+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-jmaple_sig-cloud-8_4.18.0-553.72.1.el8_10-7c700caae90+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 19s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-jmaple_sig-cloud-8_4.18.0-553.72.1.el8_10-5a1cae8e021+ and Index to 1
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 1934s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 19s
[TIMER]{TOTAL} 1976s
Rebooting in 10 seconds
```

## KselfTest
```
[jmaple@devbox code]$ ls -rt kselftest.* | tail -n4 | while read line; do echo $line; grep '^ok ' $line | wc -l ; done
kselftest.4.18.0-jmaple_sig-cloud-8_4.18.0-553.62.1.el8_10-2e23f271b6bd+.log
206
kselftest.4.18.0-jmaple_sig-cloud-8_4.18.0-553.66.1.el8_10-0c35fa329ed+.log
206
kselftest.4.18.0-jmaple_sig-cloud-8_4.18.0-553.72.1.el8_10-5a1cae8e021+.log
206
kselftest.4.18.0-jmaple_sig-cloud-8_4.18.0-553.72.1.el8_10-7c700caae90+.log
206
```