### PR TITLE
[LTS 9.4] nfsd: don't ignore the return code of svc_proc_register()

### DIFF
--- a/fs/nfsd/stats.c
+++ b/fs/nfsd/stats.c
@@ -126,7 +126,10 @@ int nfsd_stat_init(void)
 	if (err)
 		return err;
 
-	svc_proc_register(&init_net, &nfsd_svcstats, &nfsd_proc_ops);
+	if (!svc_proc_register(&init_net, &nfsd_svcstats, &nfsd_proc_ops)) {
+		nfsd_stat_counters_destroy();
+		return -ENOMEM;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
[LTS 9.4]
CVE-2025-22026
VULN-64896


# Problem

<https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=930b64ca0c511521f0abdd1d57ce52b2a6e3476b>

> nfsd: don't ignore the return code of svc\_proc\_register()
> 
> Currently, nfsd\_proc\_stat\_init() ignores the return value of
> svc\_proc\_register(). If the procfile creation fails, then the kernel
> will WARN when it tries to remove the entry later.
> 
> Fix nfsd\_proc\_stat\_init() to return the same type of pointer as
> svc\_proc\_register(), and fix up nfsd\_net\_init() to check that and fail
> the nfsd\_net construction if it occurs.
> 
> svc\_proc\_register() can fail if the dentry can't be allocated, or if an
> identical dentry already exists. The second case is pretty unlikely in
> the nfsd\_net construction codepath, so if this happens, return -ENOMEM.


# Affected: yes

The affected `nfsd` module is enabled with `CONFIG_NFSD` which is `m` for all config variants

    $ grep 'CONFIG_NFSD\b' configs/*.config

    configs/kernel-aarch64-64k-debug-rhel.config:CONFIG_NFSD=m
    configs/kernel-aarch64-64k-rhel.config:CONFIG_NFSD=m
    configs/kernel-aarch64-debug-rhel.config:CONFIG_NFSD=m
    configs/kernel-aarch64-rhel.config:CONFIG_NFSD=m
    configs/kernel-aarch64-rt-debug-rhel.config:CONFIG_NFSD=m
    configs/kernel-aarch64-rt-rhel.config:CONFIG_NFSD=m
    configs/kernel-ppc64le-debug-rhel.config:CONFIG_NFSD=m
    configs/kernel-ppc64le-rhel.config:CONFIG_NFSD=m
    configs/kernel-s390x-debug-rhel.config:CONFIG_NFSD=m
    configs/kernel-s390x-rhel.config:CONFIG_NFSD=m
    configs/kernel-s390x-zfcpdump-rhel.config:CONFIG_NFSD=m
    configs/kernel-x86_64-debug-rhel.config:CONFIG_NFSD=m
    configs/kernel-x86_64-rhel.config:CONFIG_NFSD=m
    configs/kernel-x86_64-rt-debug-rhel.config:CONFIG_NFSD=m
    configs/kernel-x86_64-rt-rhel.config:CONFIG_NFSD=m

The return value of `svc_proc_register(…)` function is clearly not being checked:

<https://github.com/ctrliq/kernel-src-tree/blob/3713f881bfcad9c120fc1e097d9f5e5605a6bd2d/fs/nfsd/stats.c#L129>


# Solution

Cherry-picking the mainline fix 930b64ca0c511521f0abdd1d57ce52b2a6e3476b is meaningless, as the code underwent considerable architectural changes related to the exposition of network stats in the user space since `ciqlts9_4` branched off. Picking them as "cve-pre" would be impractical and risky, could also affect the `/proc` interface. It was chosen instead to apply a change equivalent to 930b64ca0c511521f0abdd1d57ce52b2a6e3476b in meaning but fitting `ciqlts9_4` codebase. As a result it differs completely from the upstream.

1.  The modified function was `nfsd_stat_init(…)` instead of `nfsd_proc_stat_init(…)`. It's logically the same function, but was renamed in 93483ac5fec62cc1de166051b219d953bb5e4ef4. Observe the evolution of `nfsd_stat_init(…)` between `ciqlts9_4` and `kernel-mainline` for the full context, with the last change coming from the upstream CVE-2025-22026 fix:
    <https://github.com/ctrliq/kernel-src-tree/blob/3713f881bfcad9c120fc1e097d9f5e5605a6bd2d/fs/nfsd/stats.c#L121-L132>
    <https://github.com/ctrliq/kernel-src-tree/blob/93483ac5fec62cc1de166051b219d953bb5e4ef4/fs/nfsd/stats.c#L121-L124>
    <https://github.com/ctrliq/kernel-src-tree/blob/16fb9808ab2c99979f081987752abcbc5b092eac/fs/nfsd/stats.c#L118-L123>
    <https://github.com/ctrliq/kernel-src-tree/blob/930b64ca0c511521f0abdd1d57ce52b2a6e3476b/fs/nfsd/stats.c#L76-L81>
2.  The `int` return value of `nfsd_stat_init(…)` was left unchanged, unlike the `void` → `struct proc_dir_entry *` change in the upstream. The function in the older version already returns a status code so it could have been utilized. This nullified any changes to the header file `fs/nfsd/stats.h` found in the upstream.
3.  The `-ENOMEM` return code in case of `svc_proc_register(…)` call failure was retained, based on the justification given in the upstream fix which remained valid:
    > svc\_proc\_register() can fail if the dentry can't be allocated, or if an
    > identical dentry already exists. The second case is pretty unlikely in
    > the nfsd\_net construction codepath, so if this happens, return -ENOMEM.
4.  The original changes in 930b64ca0c511521f0abdd1d57ce52b2a6e3476b included additional cleanup steps in the `nfsd_net_init(…)` function of `fs/nfsd/nfsctl.c` in case `nfsd_proc_stat_init(…)` failed: <https://github.com/ctrliq/kernel-src-tree/commit/930b64ca0c511521f0abdd1d57ce52b2a6e3476b#diff-540a099ea05e266ccb0e9fa515be1e018baf46cef98f0f169e509fa43e1b4878R2228-R2229>
    In `ciqlts9_4` this is not necessary, because `nfsd_stat_init(…)` is not even used inside `nfsd_net_init(…)`. Instead it's called in `init_nfsd()` (and only there) in a way which already covers a jump to an appropriate cleanup routine when `nfsd_stat_init(…)` fails:
    <https://github.com/ctrliq/kernel-src-tree/blob/3713f881bfcad9c120fc1e097d9f5e5605a6bd2d/fs/nfsd/nfsctl.c#L1578-L1580>
    As a result there are no changes to the `fs/nfsd/nfsctl.c` file, unlike in the upstream.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-2025-22026 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_4-CVE-2025-22026

    [0/1] Check ABI of kernel [ciqlts9_4-CVE-2025-22026]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-2025-22026/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-2025-22026/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/22244832/boot-test.log>)


# Kselftests: passed relative


## Coverage

`bpf` (only `test_lpm_map`, `test_lru_map`, `test_sock`, `test_verifier`, `test_cgroup_storage`, `test_tag`, `test_tcpnotify_user`, `test_sysctl`), `breakpoints` (only `breakpoint_test`), `capabilities`, `clone3`, `cpu-hotplug`, `cpufreq`, `drivers/dma-buf`, `drivers/net/bonding` (all except `bond_macvlan.sh`), `drivers/net/team`, `exec`, `filesystems/binderfs`, `filesystems/epoll`, `firmware`, `fpu`, `ftrace`, `futex`, `gpio`, `intel_pstate`, `iommu`, `ipc`, `ir`, `kcmp`, `kexec`, `kvm`, `landlock`, `lib`, `livepatch`, `membarrier`, `memfd`, `memory-hotplug`, `mincore`, `mount`, `mqueue`, `nci`, `net/forwarding` (all except `sch_red.sh`, `sch_ets.sh`, `sch_tbf_ets.sh`, `vxlan_bridge_1d_ipv6.sh`, `ip6gre_inner_v6_multipath.sh`, `mirror_gre_vlan_bridge_1q.sh`, `router_bridge_lag.sh`, `mirror_gre_bridge_1d_vlan.sh`, `bridge_igmp.sh`, `sch_tbf_root.sh`, `tc_police.sh`, `q_in_vni.sh`, `dual_vxlan_bridge.sh`, `ipip_hier_gre_keys.sh`, `gre_inner_v6_multipath.sh`, `sch_tbf_prio.sh`, `tc_actions.sh`, `router_bridge_1d_lag.sh`), `net/hsr`, `net/mptcp` (all except `userspace_pm.sh`, `simult_flows.sh`, `mptcp_join.sh`), `net` (all except `reuseport_addr_any.sh`, `srv6_end_dt6_l3vpn_test.sh`, `srv6_end_flavors_test.sh`, `udpgro_fwd.sh`, `udpgso_bench.sh`, `fib_nexthops.sh`, `ip_defrag.sh`, `reuseaddr_conflict`, `srv6_end_dt46_l3vpn_test.sh`, `srv6_end_dt4_l3vpn_test.sh`, `gro.sh`, `xfrm_policy.sh`, `txtimestamp.sh`), `netfilter` (all except `nft_trans_stress.sh`), `nsfs`, `pid_namespace`, `pidfd`, `proc` (all except `proc-pid-vm`, `proc-uptime-001`), `pstore`, `ptrace`, `rlimits`, `rseq`, `seccomp`, `sgx`, `sigaltstack`, `size`, `splice`, `static_keys`, `syscall_user_dispatch`, `tc-testing`, `tdx`, `timens`, `timers`, `tmpfs`, `tpm2`, `tty`, `vDSO`, `x86`, `zram`


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/22244831/kselftests--ciqlts9_4--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-2025-22026&#x2013;run1.log](<https://github.com/user-attachments/files/22244827/kselftests--ciqlts9_4-CVE-2025-22026--run1.log>)
[kselftests&#x2013;ciqlts9\_4-CVE-2025-22026&#x2013;run2.log](<https://github.com/user-attachments/files/22244825/kselftests--ciqlts9_4-CVE-2025-22026--run2.log>)


## Comparison

The tests results between the reference and patched kernel are the same

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4-CVE-2025-22026--run1.log
    Status2   kselftests--ciqlts9_4-CVE-2025-22026--run2.log


# Specific tests: passed

Considering that the change deals with module's initialization routine a simple loading of the `nfsd` module constitutes a reasonable patch test, at least of the success branch.

    [root@ciqlts-9-4 pvts]# modprobe nfsd
    [root@ciqlts-9-4 pvts]# lsmod
    Module                  Size  Used by
    nfsd                  958464  0
    auth_rpcgss           196608  1 nfsd
    nfs_acl                16384  1 nfsd
    lockd                 196608  1 nfsd
    grace                  16384  2 nfsd,lockd
    rfkill                 40960  1
    vfat                   20480  1
    fat                   102400  1 vfat
    intel_rapl_msr         20480  0
    intel_rapl_common      45056  1 intel_rapl_msr
    intel_uncore_frequency_common    16384  0
    isst_if_common         24576  0
    nfit                   86016  0
    libnvdimm             245760  1 nfit
    kvm_intel             442368  0
    kvm                  1335296  1 kvm_intel
    virtio_gpu            102400  0
    irqbypass              16384  1 kvm
    iTCO_wdt               16384  0
    virtio_dma_buf         16384  1 virtio_gpu
    iTCO_vendor_support    16384  1 iTCO_wdt
    rapl                   28672  0
    drm_shmem_helper       28672  1 virtio_gpu
    i2c_i801               40960  0
    i2c_smbus              20480  1 i2c_i801
    pcspkr                 16384  0
    virtio_balloon         28672  0
    drm_kms_helper        245760  3 virtio_gpu
    syscopyarea            16384  1 drm_kms_helper
    sysfillrect            16384  1 drm_kms_helper
    sysimgblt              16384  1 drm_kms_helper
    lpc_ich                28672  0
    fb_sys_fops            16384  1 drm_kms_helper
    joydev                 28672  0
    drm                   741376  4 drm_kms_helper,drm_shmem_helper,virtio_gpu
    xfs                  2510848  2
    libcrc32c              16384  1 xfs
    sr_mod                 28672  0
    cdrom                  90112  1 sr_mod
    sg                     53248  0
    virtio_console         45056  1
    crct10dif_pclmul       16384  1
    crc32_pclmul           16384  0
    crc32c_intel           24576  1
    ahci                   49152  0
    libahci                61440  1 ahci
    ghash_clmulni_intel    16384  0
    virtio_blk             36864  3
    libata                479232  2 libahci,ahci
    virtio_net             81920  0
    net_failover           24576  1 virtio_net
    failover               16384  1 net_failover
    virtiofs               36864  3
    serio_raw              20480  0
    sunrpc                851968  5 nfsd,auth_rpcgss,lockd,nfs_acl
    dm_mirror              32768  0
    dm_region_hash         28672  1 dm_mirror
    dm_log                 28672  2 dm_region_hash,dm_mirror
    dm_mod                237568  2 dm_log,dm_mirror
    fuse                  212992  2 virtiofs

The nfsd statistics implemented by the modified file are available in `/proc/net/rpc/nfsd`:

    [root@ciqlts-9-4 pvts]# cat /proc/net/rpc/nfsd

    rc 0 0 0
    fh 0 0 0 0 0
    io 0 0
    th 0 0 0.000 0.000 0.000 0.000 0.000 0.000 0.000 0.000 0.000 0.000
    ra 0 0 0 0 0 0 0 0 0 0 0 0
    net 0 0 0 0
    rpc 0 0 0 0 0
    proc3 22 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
    proc4 2 0 0
    proc4ops 76 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
    wdeleg_getattr 0

