### PR TITLE
[FIPS-8-Compliant] batch 12 fips-8-compliant/4.18.0-553.16.1

### DIFF
--- a/crypto/algif_hash.c
+++ b/crypto/algif_hash.c
@@ -267,10 +267,6 @@ static int hash_accept(struct socket *sock, struct socket *newsock, int flags,
 		return err;
 
 	err = crypto_ahash_import(&ctx2->req, state);
-	if (err) {
-		sock_orphan(sk2);
-		sock_put(sk2);
-	}
 
 	return err;
 }

--- a/drivers/memstick/host/rtsx_usb_ms.c
+++ b/drivers/memstick/host/rtsx_usb_ms.c
@@ -824,6 +824,7 @@ static int rtsx_usb_ms_drv_remove(struct platform_device *pdev)
 
 	host->eject = true;
 	cancel_work_sync(&host->handle_req);
+	cancel_delayed_work_sync(&host->poll_card);
 
 	mutex_lock(&host->host_mutex);
 	if (host->req) {

--- a/drivers/net/ethernet/intel/i40e/i40e_common.c
+++ b/drivers/net/ethernet/intel/i40e/i40e_common.c
@@ -1063,10 +1063,11 @@ int i40e_pf_reset(struct i40e_hw *hw)
 void i40e_clear_hw(struct i40e_hw *hw)
 {
 	u32 num_queues, base_queue;
-	u32 num_pf_int;
-	u32 num_vf_int;
+	s32 num_pf_int;
+	s32 num_vf_int;
 	u32 num_vfs;
-	u32 i, j;
+	s32 i;
+	u32 j;
 	u32 val;
 	u32 eol = 0x7ff;
 

--- a/drivers/net/usb/ch9200.c
+++ b/drivers/net/usb/ch9200.c
@@ -178,6 +178,7 @@ static int ch9200_mdio_read(struct net_device *netdev, int phy_id, int loc)
 {
 	struct usbnet *dev = netdev_priv(netdev);
 	unsigned char buff[2];
+	int ret;
 
 	netdev_dbg(netdev, "%s phy_id:%02x loc:%02x\n",
 		   __func__, phy_id, loc);
@@ -185,8 +186,10 @@ static int ch9200_mdio_read(struct net_device *netdev, int phy_id, int loc)
 	if (phy_id != 0)
 		return -ENODEV;
 
-	control_read(dev, REQUEST_READ, 0, loc * 2, buff, 0x02,
-		     CONTROL_TIMEOUT_MS);
+	ret = control_read(dev, REQUEST_READ, 0, loc * 2, buff, 0x02,
+			   CONTROL_TIMEOUT_MS);
+	if (ret < 0)
+		return ret;
 
 	return (buff[0] | buff[1] << 8);
 }

--- a/drivers/net/usb/smsc75xx.c
+++ b/drivers/net/usb/smsc75xx.c
@@ -2213,6 +2213,13 @@ static int smsc75xx_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
 		size = (rx_cmd_a & RX_CMD_A_LEN) - RXW_PADDING;
 		align_count = (4 - ((size + RXW_PADDING) % 4)) % 4;
 
+		if (unlikely(size > skb->len)) {
+			netif_dbg(dev, rx_err, dev->net,
+				  "size err rx_cmd_a=0x%08x\n",
+				  rx_cmd_a);
+			return 0;
+		}
+
 		if (unlikely(rx_cmd_a & RX_CMD_A_RED)) {
 			netif_dbg(dev, rx_err, dev->net,
 				  "Error rx_cmd_a=0x%08x\n", rx_cmd_a);
@@ -2225,8 +2232,7 @@ static int smsc75xx_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
 				dev->net->stats.rx_frame_errors++;
 		} else {
 			/* MAX_SINGLE_PACKET_SIZE + 4(CRC) + 2(COE) + 4(Vlan) */
-			if (unlikely(size > (MAX_SINGLE_PACKET_SIZE + ETH_HLEN + 12) ||
-				     size > skb->len)) {
+			if (unlikely(size > (MAX_SINGLE_PACKET_SIZE + ETH_HLEN + 12))) {
 				netif_dbg(dev, rx_err, dev->net,
 					  "size err rx_cmd_a=0x%08x\n",
 					  rx_cmd_a);

--- a/drivers/net/usb/smsc75xx.c
+++ b/drivers/net/usb/smsc75xx.c
@@ -2225,7 +2225,8 @@ static int smsc75xx_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
 				dev->net->stats.rx_frame_errors++;
 		} else {
 			/* MAX_SINGLE_PACKET_SIZE + 4(CRC) + 2(COE) + 4(Vlan) */
-			if (unlikely(size > (MAX_SINGLE_PACKET_SIZE + ETH_HLEN + 12))) {
+			if (unlikely(size > (MAX_SINGLE_PACKET_SIZE + ETH_HLEN + 12) ||
+				     size > skb->len)) {
 				netif_dbg(dev, rx_err, dev->net,
 					  "size err rx_cmd_a=0x%08x\n",
 					  rx_cmd_a);

--- a/drivers/net/wireless/realtek/rtw88/coex.c
+++ b/drivers/net/wireless/realtek/rtw88/coex.c
@@ -309,7 +309,7 @@ static void rtw_coex_tdma_timer_base(struct rtw_dev *rtwdev, u8 type)
 {
 	struct rtw_coex *coex = &rtwdev->coex;
 	struct rtw_coex_stat *coex_stat = &coex->stat;
-	u8 para[2] = {0};
+	u8 para[6] = {};
 	u8 times;
 	u16 tbtt_interval = coex_stat->wl_beacon_interval;
 

--- a/fs/ext4/namei.c
+++ b/fs/ext4/namei.c
@@ -1803,7 +1803,7 @@ static struct ext4_dir_entry_2 *do_split(handle_t *handle, struct inode *dir,
 	 * split it in half by count; each resulting block will have at least
 	 * half the space free.
 	 */
-	if (i > 0)
+	if (i >= 0)
 		split = count - move;
 	else
 		split = count/2;

--- a/fs/ext4/xattr.c
+++ b/fs/ext4/xattr.c
@@ -1137,15 +1137,24 @@ ext4_xattr_inode_dec_ref_all(handle_t *handle, struct inode *parent,
 {
 	struct inode *ea_inode;
 	struct ext4_xattr_entry *entry;
+	struct ext4_iloc iloc;
 	bool dirty = false;
 	unsigned int ea_ino;
 	int err;
 	int credits;
+	void *end;
+
+	if (block_csum)
+		end = (void *)bh->b_data + bh->b_size;
+	else {
+		ext4_get_inode_loc(parent, &iloc);
+		end = (void *)ext4_raw_inode(&iloc) + EXT4_SB(parent->i_sb)->s_inode_size;
+	}
 
 	/* One credit for dec ref on ea_inode, one for orphan list addition, */
 	credits = 2 + extra_credits;
 
-	for (entry = first; !IS_LAST_ENTRY(entry);
+	for (entry = first; (void *)entry < end && !IS_LAST_ENTRY(entry);
 	     entry = EXT4_XATTR_NEXT(entry)) {
 		if (!entry->e_value_inum)
 			continue;

--- a/include/linux/netdevice.h
+++ b/include/linux/netdevice.h
@@ -2469,6 +2469,12 @@ struct net *dev_net(const struct net_device *dev)
 }
 
 static inline
+struct net *dev_net_rcu(const struct net_device *dev)
+{
+	return read_pnet_rcu(&dev->nd_net);
+}
+
+static inline
 void dev_net_set(struct net_device *dev, struct net *net)
 {
 	write_pnet(&dev->nd_net, net);

--- a/include/net/net_namespace.h
+++ b/include/net/net_namespace.h
@@ -362,7 +362,7 @@ static inline struct net *read_pnet(const possible_net_t *pnet)
 #endif
 }
 
-static inline struct net *read_pnet_rcu(possible_net_t *pnet)
+static inline struct net *read_pnet_rcu(const possible_net_t *pnet)
 {
 #ifdef CONFIG_NET_NS
 	return rcu_dereference(pnet->net);

--- a/include/net/net_namespace.h
+++ b/include/net/net_namespace.h
@@ -342,21 +342,30 @@ static inline int check_net(const struct net *net)
 
 typedef struct {
 #ifdef CONFIG_NET_NS
-	struct net *net;
+	struct net __rcu *net;
 #endif
 } possible_net_t;
 
 static inline void write_pnet(possible_net_t *pnet, struct net *net)
 {
 #ifdef CONFIG_NET_NS
-	pnet->net = net;
+	rcu_assign_pointer(pnet->net, net);
 #endif
 }
 
 static inline struct net *read_pnet(const possible_net_t *pnet)
 {
 #ifdef CONFIG_NET_NS
-	return pnet->net;
+	return rcu_dereference_protected(pnet->net, true);
+#else
+	return &init_net;
+#endif
+}
+
+static inline struct net *read_pnet_rcu(possible_net_t *pnet)
+{
+#ifdef CONFIG_NET_NS
+	return rcu_dereference(pnet->net);
 #else
 	return &init_net;
 #endif

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -3345,14 +3345,16 @@ static inline bool child_cfs_rq_on_list(struct cfs_rq *cfs_rq)
 {
 	struct cfs_rq *prev_cfs_rq;
 	struct list_head *prev;
+	struct rq *rq = rq_of(cfs_rq);
 
 	if (cfs_rq->on_list) {
 		prev = cfs_rq->leaf_cfs_rq_list.prev;
 	} else {
-		struct rq *rq = rq_of(cfs_rq);
-
 		prev = rq->tmp_alone_branch;
 	}
+
+	if (prev == &rq->leaf_cfs_rq_list)
+		return false;
 
 	prev_cfs_rq = container_of(prev, struct cfs_rq, leaf_cfs_rq_list);
 

--- a/net/atm/lec.c
+++ b/net/atm/lec.c
@@ -180,6 +180,7 @@ static void
 lec_send(struct atm_vcc *vcc, struct sk_buff *skb)
 {
 	struct net_device *dev = skb->dev;
+	unsigned int len = skb->len;
 
 	ATM_SKB(skb)->vcc = vcc;
 	atm_account_tx(vcc, skb);
@@ -190,7 +191,7 @@ lec_send(struct atm_vcc *vcc, struct sk_buff *skb)
 	}
 
 	dev->stats.tx_packets++;
-	dev->stats.tx_bytes += skb->len;
+	dev->stats.tx_bytes += len;
 }
 
 static void lec_tx_timeout(struct net_device *dev, unsigned int txqueue)

--- a/net/ipv6/ndisc.c
+++ b/net/ipv6/ndisc.c
@@ -400,15 +400,11 @@ static struct sk_buff *ndisc_alloc_skb(struct net_device *dev,
 {
 	int hlen = LL_RESERVED_SPACE(dev);
 	int tlen = dev->needed_tailroom;
-	struct sock *sk = dev_net(dev)->ipv6.ndisc_sk;
 	struct sk_buff *skb;
 
 	skb = alloc_skb(hlen + sizeof(struct ipv6hdr) + len + tlen, GFP_ATOMIC);
-	if (!skb) {
-		ND_PRINTK(0, err, "ndisc: %s failed to allocate an skb\n",
-			  __func__);
+	if (!skb)
 		return NULL;
-	}
 
 	skb->protocol = htons(ETH_P_IPV6);
 	skb->dev = dev;
@@ -419,7 +415,9 @@ static struct sk_buff *ndisc_alloc_skb(struct net_device *dev,
 	/* Manually assign socket ownership as we avoid calling
 	 * sock_alloc_send_pskb() to bypass wmem buffer limits
 	 */
-	skb_set_owner_w(skb, sk);
+	rcu_read_lock();
+	skb_set_owner_w(skb, dev_net_rcu(dev)->ipv6.ndisc_sk);
+	rcu_read_unlock();
 
 	return skb;
 }

--- a/net/sched/sch_ets.c
+++ b/net/sched/sch_ets.c
@@ -74,6 +74,11 @@ static const struct nla_policy ets_class_policy[TCA_ETS_MAX + 1] = {
 	[TCA_ETS_QUANTA_BAND] = { .type = NLA_U32 },
 };
 
+static bool cl_is_active(struct ets_class *cl)
+{
+	return !list_empty(&cl->alist);
+}
+
 static int ets_quantum_parse(struct Qdisc *sch, const struct nlattr *attr,
 			     unsigned int *quantum,
 			     struct netlink_ext_ack *extack)
@@ -414,7 +419,6 @@ static int ets_qdisc_enqueue(struct sk_buff *skb, struct Qdisc *sch,
 	struct ets_sched *q = qdisc_priv(sch);
 	struct ets_class *cl;
 	int err = 0;
-	bool first;
 
 	cl = ets_classify(skb, sch, &err);
 	if (!cl) {
@@ -424,7 +428,6 @@ static int ets_qdisc_enqueue(struct sk_buff *skb, struct Qdisc *sch,
 		return err;
 	}
 
-	first = !cl->qdisc->q.qlen;
 	err = qdisc_enqueue(skb, cl->qdisc, to_free);
 	if (unlikely(err != NET_XMIT_SUCCESS)) {
 		if (net_xmit_drop_count(err)) {
@@ -434,7 +437,7 @@ static int ets_qdisc_enqueue(struct sk_buff *skb, struct Qdisc *sch,
 		return err;
 	}
 
-	if (first && !ets_class_is_strict(q, cl)) {
+	if (!cl_is_active(cl) && !ets_class_is_strict(q, cl)) {
 		list_add_tail(&cl->alist, &q->active);
 		cl->deficit = cl->quantum;
 	}


### PR DESCRIPTION
## Things to note
34e856a4e463f83e1800cd24f8f5dcc287a1d4cd - net: add dev_net_rcu() helper
ed1ca9d753deda057f8ac37bca55b501a67e7c6e - net: treat possible_net_t net pointer as an RCU one and add read_pnet_rcu()
Are both preconditions to 
47873647b609a65c844c7ebfed160259cde2f719 - ndisc: use RCU protection in ndisc_alloc_skb()

This are in the latest 8.10 as well

### FIPS changes
The security team @jason-rodri and @jallisonciq  have discussed this that and that it does not impact certification as this is not touching any math but would like either of them to sign off on this.
64ea2c322637239ada43691cd935fe650f834843 - crypto: algif_hash - fix double free in hash_accept
```
--- a/crypto/algif_hash.c
+++ b/crypto/algif_hash.c
@@ -267,10 +267,6 @@ static int hash_accept(struct socket *sock, struct socket *newsock, int flags,
                return err;

        err = crypto_ahash_import(&ctx2->req, state);
-       if (err) {
-               sock_orphan(sk2);
-               sock_put(sk2);
-       }

        return err;
 }
```

## Commits
```
    i40e: fix MMIO write access to an invalid page in i40e_clear_hw

    jira VULN-72062
    jira VULN-72061
    cve CVE-2025-38200
    commit-author Kyungwook Boo <bookyungwook@gmail.com>
    commit 015bac5daca978448f2671478c553ce1f300c21e
```
```
    wifi: rtw88: fix the 'para' buffer size to avoid reading out of bounds

    jira VULN-71886
    jira VULN-71885
    cve CVE-2025-38159
    commit-author Alexey Kodanev <aleksei.kodanev@bell-sw.com>
    commit 4c2c372de2e108319236203cce6de44d70ae15cd
```
```
    net: ch9200: fix uninitialised access during mii_nway_restart

    jira VULN-71592
    jira VULN-71591
    cve CVE-2025-38086
    commit-author Qasim Ijaz <qasdev00@gmail.com>
    commit 9ad0452c0277b816a435433cca601304cfac7c21
```
```
    crypto: algif_hash - fix double free in hash_accept

    jira VULN-70977
    jira VULN-70976
    cve CVE-2025-38079
    commit-author Ivan Pravdin <ipravdin.official@gmail.com>
    commit b2df03ed4052e97126267e8c13ad4204ea6ba9b6
```
```
    net_sched: ets: Fix double list add in class with netem as child qdisc

    jira VULN-73371
    jira VULN-73370
    cve CVE-2025-37914
    commit-author Victor Nogueira <victor@mojatatu.com>
    commit 1a6d0c00fa07972384b0c308c72db091d49988b6
```
```
    ext4: ignore xattrs past end

    jira VULN-66824
    jira VULN-66823
    cve CVE-2025-37738
    commit-author Bhupesh <bhupesh@igalia.com>
    commit c8e008b60492cf6fd31ef127aea6d02fd3d314cd
```
```
    ext4: fix off-by-one error in do_split

    jira VULN-66672
    jira VULN-66671
    cve CVE-2025-23150
    commit-author Artem Sadovnikov <a.sadovnikov@ispras.ru>
    commit 94824ac9a8aaf2fb3c54b4bdde842db80ffa555d
```
```
    memstick: rtsx_usb_ms: Fix slab-use-after-free in rtsx_usb_ms_drv_remove

    jira VULN-64884
    jira VULN-64883
    cve CVE-2025-22020
    commit-author Luo Qiu <luoqiu@kylinsec.com.cn>
    commit 4676741a3464b300b486e70585c3c9b692be1632
```
```
    net: atm: fix use after free in lec_send()

    jira VULN-56265
    jira VULN-56264
    cve CVE-2025-22004
    commit-author Dan Carpenter <dan.carpenter@linaro.org>
    commit f3009d0d6ab78053117f8857b921a8237f4d17b3
```
```
    sched/fair: Fix potential memory corruption in child_cfs_rq_on_list

    jira VULN-55798
    jira VULN-55797
    cve CVE-2025-21919
    commit-author Zecheng Li <zecheng@google.com>
    commit 3b4035ddbfc8e4521f85569998a7569668cccf51
```
```
    ndisc: use RCU protection in ndisc_alloc_skb()

    jira VULN-54024
    jira VULN-54023
    cve CVE-2025-21764
    commit-author Eric Dumazet <edumazet@google.com>
    commit 628e6d18930bbd21f2d4562228afe27694f66da9
```
```
    net: add dev_net_rcu() helper

    jira VULN-53988
    jira VULN-53989
    cve CVE-2025-38352
    commit-author Eric Dumazet <edumazet@google.com>
    commit 482ad2a4ace2740ca0ff1cbc8f3c7f862f3ab507
```
```
    net: treat possible_net_t net pointer as an RCU one and add read_pnet_rcu()

    jira VULN-53988
    jira VULN-53989
    cve-pre CVE-2025-38352
    commit-author Jiri Pirko <jiri@nvidia.com>
    commit 2034d90ae41ae93e30d492ebcf1f06f97a9cfba6
```
```
    net: usb: smsc75xx: Limit packet length to skb->len

    jira VULN-67487
    jira VULN-67486
    cve CVE-2023-53125
    commit-author Szymon Heidrich <szymon.heidrich@gmail.com>
    commit d8b228318935044dafe3a5bc07ee71a1f1424b8d
```

## BUILD
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kbuild* | head -n1)
/mnt/code/kernel-src-tree-build
Running make mrproper...
[TIMER]{MRPROPER}: 5s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-3d20"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 2100s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-3d20+
[TIMER]{MODULES}: 22s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-3d20+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 20s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-0bc2+ and Index to 3
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 2100s
[TIMER]{MODULES}: 22s
[TIMER]{INSTALL}: 20s
[TIMER]{TOTAL} 2152s
Rebooting in 10 seconds
```

## Kselftests
Note the sha is different than the build as I forgot to rebase my changes after confirming the build worked, ie the commits listed above I needed to move to ahead of the the one they're dependent on so that the kernel will build if we bisect.
```
[jmaple@devbox code]$ ls -rt kselftest.* | tail -n4 | while read line; do echo $line; grep '^ok ' $line | wc -l ; done
kselftest.4.18.0-jmaple_20250910_fips-8-compliant_4.18.0-553.16.1-fdcf+.log
204
kselftest.4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-acb5+.log
204
kselftest.4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-0bc2+.log
204
```