### PR TITLE
[LTS 9.4] CVE-2025-22113, CVE-2025-22121

### DIFF
--- a/fs/ext4/ext4.h
+++ b/fs/ext4/ext4.h
@@ -1732,10 +1732,13 @@ struct ext4_sb_info {
 	const char *s_last_error_func;
 	time64_t s_last_error_time;
 	/*
-	 * If we are in a context where we cannot update error information in
-	 * the on-disk superblock, we queue this work to do it.
+	 * If we are in a context where we cannot update the on-disk
+	 * superblock, we queue the work here.  This is used to update
+	 * the error information in the superblock, and for periodic
+	 * updates of the superblock called from the commit callback
+	 * function.
 	 */
-	struct work_struct s_error_work;
+	struct work_struct s_sb_upd_work;
 
 	/* Ext4 fast commit sub transaction ID */
 	atomic_t s_fc_subtid;

--- a/fs/ext4/ext4.h
+++ b/fs/ext4/ext4.h
@@ -1832,7 +1832,8 @@ static inline int ext4_valid_inum(struct super_block *sb, unsigned long ino)
 enum {
 	EXT4_MF_MNTDIR_SAMPLED,
 	EXT4_MF_FS_ABORTED,	/* Fatal error detected */
-	EXT4_MF_FC_INELIGIBLE	/* Fast commit ineligible */
+	EXT4_MF_FC_INELIGIBLE,	/* Fast commit ineligible */
+	EXT4_MF_JOURNAL_DESTROY	/* Journal is in process of destroying */
 };
 
 static inline void ext4_set_mount_flag(struct super_block *sb, int bit)

--- a/fs/ext4/ext4_jbd2.h
+++ b/fs/ext4/ext4_jbd2.h
@@ -521,6 +521,21 @@ static inline int ext4_journal_destroy(struct ext4_sb_info *sbi, journal_t *jour
 {
 	int err = 0;
 
+	/*
+	 * At this point only two things can be operating on the journal.
+	 * JBD2 thread performing transaction commit and s_sb_upd_work
+	 * issuing sb update through the journal. Once we set
+	 * EXT4_JOURNAL_DESTROY, new ext4_handle_error() calls will not
+	 * queue s_sb_upd_work and ext4_force_commit() makes sure any
+	 * ext4_handle_error() calls from the running transaction commit are
+	 * finished. Hence no new s_sb_upd_work can be queued after we
+	 * flush it here.
+	 */
+	ext4_set_mount_flag(sbi->s_sb, EXT4_MF_JOURNAL_DESTROY);
+
+	ext4_force_commit(sbi->s_sb);
+	flush_work(&sbi->s_sb_upd_work);
+
 	err = jbd2_journal_destroy(journal);
 	sbi->s_journal = NULL;
 

--- a/fs/ext4/ext4_jbd2.h
+++ b/fs/ext4/ext4_jbd2.h
@@ -513,4 +513,18 @@ static inline int ext4_should_dioread_nolock(struct inode *inode)
 	return 1;
 }
 
+/*
+ * Pass journal explicitly as it may not be cached in the sbi->s_journal in some
+ * cases
+ */
+static inline int ext4_journal_destroy(struct ext4_sb_info *sbi, journal_t *journal)
+{
+	int err = 0;
+
+	err = jbd2_journal_destroy(journal);
+	sbi->s_journal = NULL;
+
+	return err;
+}
+
 #endif	/* _EXT4_JBD2_H */

--- a/fs/ext4/inode.c
+++ b/fs/ext4/inode.c
@@ -4788,6 +4788,11 @@ static inline int ext4_iget_extra_inode(struct inode *inode,
 	    *magic == cpu_to_le32(EXT4_XATTR_MAGIC)) {
 		int err;
 
+		err = xattr_check_inode(inode, IHDR(inode, raw_inode),
+					ITAIL(inode, raw_inode));
+		if (err)
+			return err;
+
 		ext4_set_inode_state(inode, EXT4_STATE_XATTR);
 		err = ext4_find_inline_data_nolock(inode);
 		if (!err && ext4_has_inline_data(inode))

--- a/fs/ext4/super.c
+++ b/fs/ext4/super.c
@@ -667,9 +667,13 @@ static void ext4_handle_error(struct super_block *sb, bool force_ro, int error,
 		 * In case the fs should keep running, we need to writeout
 		 * superblock through the journal. Due to lock ordering
 		 * constraints, it may not be safe to do it right here so we
-		 * defer superblock flushing to a workqueue.
+		 * defer superblock flushing to a workqueue. We just need to be
+		 * careful when the journal is already shutting down. If we get
+		 * here in that case, just update the sb directly as the last
+		 * transaction won't commit anyway.
 		 */
-		if (continue_fs && journal)
+		if (continue_fs && journal &&
+		    !ext4_test_mount_flag(sb, EXT4_MF_JOURNAL_DESTROY))
 			schedule_work(&EXT4_SB(sb)->s_sb_upd_work);
 		else
 			ext4_commit_super(sb);
@@ -1208,7 +1212,6 @@ static void ext4_put_super(struct super_block *sb)
 	ext4_unregister_li_request(sb);
 	ext4_quota_off_umount(sb);
 
-	flush_work(&sbi->s_sb_upd_work);
 	destroy_workqueue(sbi->rsv_conversion_wq);
 	ext4_release_orphan_info(sb);
 
@@ -1218,7 +1221,8 @@ static void ext4_put_super(struct super_block *sb)
 		if ((err < 0) && !aborted) {
 			ext4_abort(sb, -err, "Couldn't clean up the journal");
 		}
-	}
+	} else
+		flush_work(&sbi->s_sb_upd_work);
 
 	ext4_es_unregister_shrinker(sbi);
 	timer_shutdown_sync(&sbi->s_err_report);
@@ -4894,8 +4898,6 @@ static int ext4_load_and_init_journal(struct super_block *sb,
 	return 0;
 
 out:
-	/* flush s_sb_upd_work before destroying the journal. */
-	flush_work(&sbi->s_sb_upd_work);
 	ext4_journal_destroy(sbi, sbi->s_journal);
 	return -EINVAL;
 }
@@ -5633,8 +5635,6 @@ failed_mount_wq:
 	sbi->s_ea_block_cache = NULL;
 
 	if (sbi->s_journal) {
-		/* flush s_sb_upd_work before journal destroy. */
-		flush_work(&sbi->s_sb_upd_work);
 		ext4_journal_destroy(sbi, sbi->s_journal);
 	}
 failed_mount3a:

--- a/fs/ext4/super.c
+++ b/fs/ext4/super.c
@@ -1214,8 +1214,7 @@ static void ext4_put_super(struct super_block *sb)
 
 	if (sbi->s_journal) {
 		aborted = is_journal_aborted(sbi->s_journal);
-		err = jbd2_journal_destroy(sbi->s_journal);
-		sbi->s_journal = NULL;
+		err = ext4_journal_destroy(sbi, sbi->s_journal);
 		if ((err < 0) && !aborted) {
 			ext4_abort(sb, -err, "Couldn't clean up the journal");
 		}
@@ -4897,8 +4896,7 @@ static int ext4_load_and_init_journal(struct super_block *sb,
 out:
 	/* flush s_sb_upd_work before destroying the journal. */
 	flush_work(&sbi->s_sb_upd_work);
-	jbd2_journal_destroy(sbi->s_journal);
-	sbi->s_journal = NULL;
+	ext4_journal_destroy(sbi, sbi->s_journal);
 	return -EINVAL;
 }
 
@@ -5637,8 +5635,7 @@ failed_mount_wq:
 	if (sbi->s_journal) {
 		/* flush s_sb_upd_work before journal destroy. */
 		flush_work(&sbi->s_sb_upd_work);
-		jbd2_journal_destroy(sbi->s_journal);
-		sbi->s_journal = NULL;
+		ext4_journal_destroy(sbi, sbi->s_journal);
 	}
 failed_mount3a:
 	ext4_es_unregister_shrinker(sbi);
@@ -5917,7 +5914,7 @@ static journal_t *ext4_get_dev_journal(struct super_block *sb,
 	return journal;
 
 out_journal:
-	jbd2_journal_destroy(journal);
+	ext4_journal_destroy(EXT4_SB(sb), journal);
 out_bdev:
 	blkdev_put(bdev, sb);
 	return NULL;
@@ -6034,8 +6031,7 @@ static int ext4_load_journal(struct super_block *sb,
 	EXT4_SB(sb)->s_journal = journal;
 	err = ext4_clear_journal_err(sb, es);
 	if (err) {
-		EXT4_SB(sb)->s_journal = NULL;
-		jbd2_journal_destroy(journal);
+		ext4_journal_destroy(EXT4_SB(sb), journal);
 		return err;
 	}
 
@@ -6053,7 +6049,7 @@ static int ext4_load_journal(struct super_block *sb,
 	return 0;
 
 err_out:
-	jbd2_journal_destroy(journal);
+	ext4_journal_destroy(EXT4_SB(sb), journal);
 	return err;
 }
 

--- a/fs/ext4/super.c
+++ b/fs/ext4/super.c
@@ -670,7 +670,7 @@ static void ext4_handle_error(struct super_block *sb, bool force_ro, int error,
 		 * defer superblock flushing to a workqueue.
 		 */
 		if (continue_fs && journal)
-			schedule_work(&EXT4_SB(sb)->s_error_work);
+			schedule_work(&EXT4_SB(sb)->s_sb_upd_work);
 		else
 			ext4_commit_super(sb);
 	}
@@ -697,10 +697,10 @@ static void ext4_handle_error(struct super_block *sb, bool force_ro, int error,
 	sb->s_flags |= SB_RDONLY;
 }
 
-static void flush_stashed_error_work(struct work_struct *work)
+static void update_super_work(struct work_struct *work)
 {
 	struct ext4_sb_info *sbi = container_of(work, struct ext4_sb_info,
-						s_error_work);
+						s_sb_upd_work);
 	journal_t *journal = sbi->s_journal;
 	handle_t *handle;
 
@@ -1010,7 +1010,7 @@ __acquires(bitlock)
 		if (!bdev_read_only(sb->s_bdev)) {
 			save_error_info(sb, EFSCORRUPTED, ino, block, function,
 					line);
-			schedule_work(&EXT4_SB(sb)->s_error_work);
+			schedule_work(&EXT4_SB(sb)->s_sb_upd_work);
 		}
 		return;
 	}
@@ -1193,10 +1193,10 @@ static void ext4_put_super(struct super_block *sb)
 	 * Unregister sysfs before destroying jbd2 journal.
 	 * Since we could still access attr_journal_task attribute via sysfs
 	 * path which could have sbi->s_journal->j_task as NULL
-	 * Unregister sysfs before flush sbi->s_error_work.
+	 * Unregister sysfs before flush sbi->s_sb_upd_work.
 	 * Since user may read /proc/fs/ext4/xx/mb_groups during umount, If
 	 * read metadata verify failed then will queue error work.
-	 * flush_stashed_error_work will call start_this_handle may trigger
+	 * update_super_work will call start_this_handle may trigger
 	 * BUG_ON.
 	 */
 	ext4_unregister_sysfs(sb);
@@ -1208,7 +1208,7 @@ static void ext4_put_super(struct super_block *sb)
 	ext4_unregister_li_request(sb);
 	ext4_quota_off_umount(sb);
 
-	flush_work(&sbi->s_error_work);
+	flush_work(&sbi->s_sb_upd_work);
 	destroy_workqueue(sbi->rsv_conversion_wq);
 	ext4_release_orphan_info(sb);
 
@@ -4895,8 +4895,8 @@ static int ext4_load_and_init_journal(struct super_block *sb,
 	return 0;
 
 out:
-	/* flush s_error_work before journal destroy. */
-	flush_work(&sbi->s_error_work);
+	/* flush s_sb_upd_work before destroying the journal. */
+	flush_work(&sbi->s_sb_upd_work);
 	jbd2_journal_destroy(sbi->s_journal);
 	sbi->s_journal = NULL;
 	return -EINVAL;
@@ -5246,7 +5246,7 @@ static int __ext4_fill_super(struct fs_context *fc, struct super_block *sb)
 
 	timer_setup(&sbi->s_err_report, print_daily_error_info, 0);
 	spin_lock_init(&sbi->s_error_lock);
-	INIT_WORK(&sbi->s_error_work, flush_stashed_error_work);
+	INIT_WORK(&sbi->s_sb_upd_work, update_super_work);
 
 	err = ext4_group_desc_init(sb, es, logical_sb_block, &first_not_zeroed);
 	if (err)
@@ -5635,16 +5635,16 @@ failed_mount_wq:
 	sbi->s_ea_block_cache = NULL;
 
 	if (sbi->s_journal) {
-		/* flush s_error_work before journal destroy. */
-		flush_work(&sbi->s_error_work);
+		/* flush s_sb_upd_work before journal destroy. */
+		flush_work(&sbi->s_sb_upd_work);
 		jbd2_journal_destroy(sbi->s_journal);
 		sbi->s_journal = NULL;
 	}
 failed_mount3a:
 	ext4_es_unregister_shrinker(sbi);
 failed_mount3:
-	/* flush s_error_work before sbi destroy */
-	flush_work(&sbi->s_error_work);
+	/* flush s_sb_upd_work before sbi destroy */
+	flush_work(&sbi->s_sb_upd_work);
 	del_timer_sync(&sbi->s_err_report);
 	ext4_stop_mmpd(sbi);
 	ext4_group_desc_free(sbi);
@@ -6507,7 +6507,7 @@ static int __ext4_remount(struct fs_context *fc, struct super_block *sb)
 	}
 
 	/* Flush outstanding errors before changing fs state */
-	flush_work(&sbi->s_error_work);
+	flush_work(&sbi->s_sb_upd_work);
 
 	if ((bool)(fc->sb_flags & SB_RDONLY) != sb_rdonly(sb)) {
 		if (ext4_test_mount_flag(sb, EXT4_MF_FS_ABORTED)) {

--- a/fs/ext4/xattr.c
+++ b/fs/ext4/xattr.c
@@ -649,7 +649,7 @@ ext4_xattr_ibody_get(struct inode *inode, int name_index, const char *name,
 		return error;
 	raw_inode = ext4_raw_inode(&iloc);
 	header = IHDR(inode, raw_inode);
-	end = (void *)raw_inode + EXT4_SB(inode->i_sb)->s_inode_size;
+	end = ITAIL(inode, raw_inode);
 	error = xattr_check_inode(inode, header, end);
 	if (error)
 		goto cleanup;
@@ -794,7 +794,7 @@ ext4_xattr_ibody_list(struct dentry *dentry, char *buffer, size_t buffer_size)
 		return error;
 	raw_inode = ext4_raw_inode(&iloc);
 	header = IHDR(inode, raw_inode);
-	end = (void *)raw_inode + EXT4_SB(inode->i_sb)->s_inode_size;
+	end = ITAIL(inode, raw_inode);
 	error = xattr_check_inode(inode, header, end);
 	if (error)
 		goto cleanup;
@@ -880,7 +880,7 @@ int ext4_get_inode_usage(struct inode *inode, qsize_t *usage)
 			goto out;
 		raw_inode = ext4_raw_inode(&iloc);
 		header = IHDR(inode, raw_inode);
-		end = (void *)raw_inode + EXT4_SB(inode->i_sb)->s_inode_size;
+		end = ITAIL(inode, raw_inode);
 		ret = xattr_check_inode(inode, header, end);
 		if (ret)
 			goto out;
@@ -2211,7 +2211,7 @@ int ext4_xattr_ibody_find(struct inode *inode, struct ext4_xattr_info *i,
 	header = IHDR(inode, raw_inode);
 	is->s.base = is->s.first = IFIRST(header);
 	is->s.here = is->s.first;
-	is->s.end = (void *)raw_inode + EXT4_SB(inode->i_sb)->s_inode_size;
+	is->s.end = ITAIL(inode, raw_inode);
 	if (ext4_test_inode_state(inode, EXT4_STATE_XATTR)) {
 		error = xattr_check_inode(inode, header, is->s.end);
 		if (error)
@@ -2761,7 +2761,7 @@ retry:
 	 */
 
 	base = IFIRST(header);
-	end = (void *)raw_inode + EXT4_SB(inode->i_sb)->s_inode_size;
+	end = ITAIL(inode, raw_inode);
 	min_offs = end - base;
 	total_ino = sizeof(struct ext4_xattr_ibody_header) + sizeof(u32);
 

--- a/fs/ext4/xattr.c
+++ b/fs/ext4/xattr.c
@@ -308,16 +308,13 @@ __ext4_xattr_check_block(struct inode *inode, struct buffer_head *bh,
 	__ext4_xattr_check_block((inode), (bh),  __func__, __LINE__)
 
 
-static inline int
+int
 __xattr_check_inode(struct inode *inode, struct ext4_xattr_ibody_header *header,
 			 void *end, const char *function, unsigned int line)
 {
 	return check_xattrs(inode, NULL, IFIRST(header), end, IFIRST(header),
 			    function, line);
 }
-
-#define xattr_check_inode(inode, header, end) \
-	__xattr_check_inode((inode), (header), (end), __func__, __LINE__)
 
 static int
 xattr_find_entry(struct inode *inode, struct ext4_xattr_entry **pentry,
@@ -650,9 +647,6 @@ ext4_xattr_ibody_get(struct inode *inode, int name_index, const char *name,
 	raw_inode = ext4_raw_inode(&iloc);
 	header = IHDR(inode, raw_inode);
 	end = ITAIL(inode, raw_inode);
-	error = xattr_check_inode(inode, header, end);
-	if (error)
-		goto cleanup;
 	entry = IFIRST(header);
 	error = xattr_find_entry(inode, &entry, end, name_index, name, 0);
 	if (error)
@@ -784,7 +778,6 @@ ext4_xattr_ibody_list(struct dentry *dentry, char *buffer, size_t buffer_size)
 	struct ext4_xattr_ibody_header *header;
 	struct ext4_inode *raw_inode;
 	struct ext4_iloc iloc;
-	void *end;
 	int error;
 
 	if (!ext4_test_inode_state(inode, EXT4_STATE_XATTR))
@@ -794,14 +787,9 @@ ext4_xattr_ibody_list(struct dentry *dentry, char *buffer, size_t buffer_size)
 		return error;
 	raw_inode = ext4_raw_inode(&iloc);
 	header = IHDR(inode, raw_inode);
-	end = ITAIL(inode, raw_inode);
-	error = xattr_check_inode(inode, header, end);
-	if (error)
-		goto cleanup;
 	error = ext4_xattr_list_entries(dentry, IFIRST(header),
 					buffer, buffer_size);
 
-cleanup:
 	brelse(iloc.bh);
 	return error;
 }
@@ -869,7 +857,6 @@ int ext4_get_inode_usage(struct inode *inode, qsize_t *usage)
 	struct ext4_xattr_ibody_header *header;
 	struct ext4_xattr_entry *entry;
 	qsize_t ea_inode_refs = 0;
-	void *end;
 	int ret;
 
 	lockdep_assert_held_read(&EXT4_I(inode)->xattr_sem);
@@ -880,10 +867,6 @@ int ext4_get_inode_usage(struct inode *inode, qsize_t *usage)
 			goto out;
 		raw_inode = ext4_raw_inode(&iloc);
 		header = IHDR(inode, raw_inode);
-		end = ITAIL(inode, raw_inode);
-		ret = xattr_check_inode(inode, header, end);
-		if (ret)
-			goto out;
 
 		for (entry = IFIRST(header); !IS_LAST_ENTRY(entry);
 		     entry = EXT4_XATTR_NEXT(entry))
@@ -2213,9 +2196,6 @@ int ext4_xattr_ibody_find(struct inode *inode, struct ext4_xattr_info *i,
 	is->s.here = is->s.first;
 	is->s.end = ITAIL(inode, raw_inode);
 	if (ext4_test_inode_state(inode, EXT4_STATE_XATTR)) {
-		error = xattr_check_inode(inode, header, is->s.end);
-		if (error)
-			return error;
 		/* Find the named attribute. */
 		error = xattr_find_entry(inode, &is->s.here, is->s.end,
 					 i->name_index, i->name, 0);
@@ -2764,10 +2744,6 @@ retry:
 	end = ITAIL(inode, raw_inode);
 	min_offs = end - base;
 	total_ino = sizeof(struct ext4_xattr_ibody_header) + sizeof(u32);
-
-	error = xattr_check_inode(inode, header, end);
-	if (error)
-		goto cleanup;
 
 	ifree = ext4_xattr_free_space(base, &min_offs, base, &total_ino);
 	if (ifree >= isize_diff)

--- a/fs/ext4/xattr.h
+++ b/fs/ext4/xattr.h
@@ -210,6 +210,13 @@ extern int ext4_xattr_ibody_set(handle_t *handle, struct inode *inode,
 extern struct mb_cache *ext4_xattr_create_cache(void);
 extern void ext4_xattr_destroy_cache(struct mb_cache *);
 
+extern int
+__xattr_check_inode(struct inode *inode, struct ext4_xattr_ibody_header *header,
+		    void *end, const char *function, unsigned int line);
+
+#define xattr_check_inode(inode, header, end) \
+	__xattr_check_inode((inode), (header), (end), __func__, __LINE__)
+
 #ifdef CONFIG_EXT4_FS_SECURITY
 extern int ext4_init_security(handle_t *handle, struct inode *inode,
 			      struct inode *dir, const struct qstr *qstr);

--- a/fs/ext4/xattr.h
+++ b/fs/ext4/xattr.h
@@ -68,6 +68,9 @@ struct ext4_xattr_entry {
 		((void *)raw_inode + \
 		EXT4_GOOD_OLD_INODE_SIZE + \
 		EXT4_I(inode)->i_extra_isize))
+#define ITAIL(inode, raw_inode) \
+	((void *)(raw_inode) + \
+	 EXT4_SB((inode)->i_sb)->s_inode_size)
 #define IFIRST(hdr) ((struct ext4_xattr_entry *)((hdr)+1))
 
 /*


### PR DESCRIPTION
[LTS 9.4]
CVE-2025-22121 VULN-65381
CVE-2025-22113 VULN-65358


# Commits


## CVE-2025-22121

7e3df3850b9ce8f89d636c2fa42e9220dba979c4:

    ext4: introduce ITAIL helper
    
    jira VULN-65381
    cve-pre CVE-2025-22121
    commit-author Ye Bin <yebin10@huawei.com>
    commit 69f3a3039b0d0003de008659cafd5a1eaaa0a7a4

18ee55af91163d10f82e80c658cc9eeffff7bc25:

    ext4: fix out-of-bound read in ext4_xattr_inode_dec_ref_all()
    
    jira VULN-65381
    cve CVE-2025-22121
    commit-author Ye Bin <yebin10@huawei.com>
    commit 5701875f9609b000d91351eaa6bfd97fe2f157f4

The mainline fix 5701875f9609b000d91351eaa6bfd97fe2f157f4 conflicts without 69f3a3039b0d0003de008659cafd5a1eaaa0a7a4. The cve-pre is a previous commit right before 5701875f9609b000d91351eaa6bfd97fe2f157f4 in kernel's history, in fact they were commited at the same time and have the same author, suggesting that it was a single solution split into two commits to keep their scope atomized.


## CVE-2025-22113

73fc46f2738652306bb453d0d6e3435b1fc180df:

    ext4: rename s_error_work to s_sb_upd_work
    
    jira VULN-65358
    cve-pre CVE-2025-22113
    commit-author Theodore Ts'o <tytso@mit.edu>
    commit bb15cea20f211e110150e528fca806f38d5789e0
    upstream-diff |
      Ignored the changes to the `ext4_maybe_update_superblock()' function
      introduced by ff0722de896eb278fca193888d22278c28f2782c which is missing
      from ciqlts9_4 history and is not functionally neutral.

176f3e920dd9999d9d5cbc50eb16b5f98d1cc668:

    ext4: define ext4_journal_destroy wrapper
    
    jira VULN-65358
    cve-pre CVE-2025-22113
    commit-author Ojaswin Mujoo <ojaswin@linux.ibm.com>
    commit 5a02a6204ca37e7c22fbb55a789c503f05e8e89a

4f815fba5cf3ecb85545a49e8eb2be1c2b50a34b:

    ext4: avoid journaling sb update on error if journal is destroying
    
    jira VULN-65358
    cve CVE-2025-22113
    commit-author Ojaswin Mujoo <ojaswin@linux.ibm.com>
    commit ce2f26e73783b4a7c46a86e3af5b5c8de0971790

Naive cherry-picking mainline fix ce2f26e73783b4a7c46a86e3af5b5c8de0971790 resulted in conflicts in all edited places of the modified files `fs/ext4/ext4.h`, `fs/ext4/ext4_jbd2.h`, `fs/ext4/super.c`.

Commit 5a02a6204ca37e7c22fbb55a789c503f05e8e89a introduces the function `ext4_journal_destroy(…)` which is one of the subjects of change in the fix ce2f26e73783b4a7c46a86e3af5b5c8de0971790. The function doesn't introduce any new functionality not present before, only captures a recurring pattern in the `fs/ext4/super.c` file of destroying a sb journal object and nulling out its pointer afterwards. Adding it prevents conflicts in the `fs/ext4/super.c`.

Commit bb15cea20f211e110150e528fca806f38d5789e0 is similarly functionally neutral with its symbols renaming change. Having the `ext4_sb_info` struct's field `s_error_work` renamed to `s_sb_upd_work` prevents conflicts in the `fs/ext4/super.c` file.

Commit ff0722de896eb278fca193888d22278c28f2782c was required to have the bb15cea20f211e110150e528fca806f38d5789e0 cherry-picked cleanly, as the latter was renaming the `s_error_work` symbol also in the `ext4_maybe_update_superblock(…)` function introduced by the former. It provides a simple mechanism to keep the disk superblock updated and the kilobytes written counter more precise as a result (see <https://www.spinics.net/lists/linux-ext4/msg85865.html> for the best description of the issue). Although it's small and local, present in the mainline for two years without major changes (thus stable), providing a fix for what seems to be a bug, not a feature, and allows for cherry-picking the required bb15cea20f211e110150e528fca806f38d5789e0 cleanly, it was decided not to pick it, as that would require pulling in its bugfix ee6a12d0d4d85f3833d177cd382cd417f0ef011b too, increasing the solution complexity of a part which arguably already shouldn't be picked anyway due to its functional non-neutrality. The bb15cea20f211e110150e528fca806f38d5789e0 cherry-picking conflict was resolved manually by ignoring the introduction of `ext4_maybe_update_superblock(…)` function.

The codebase prepared in such a way still conflicted due to ce2f26e73783b4a7c46a86e3af5b5c8de0971790 not expecting the `EXT4_MF_FS_ABORTED` in the enum which it modified by adding the `EXT4_MF_JOURNAL_DESTROY` case. The `EXT4_MF_FS_ABORTED` was removed in 95257987a6387f02970eda707e55a06cce734e18 which wasn't backported to `ciqlts9_4`. Similarly to ff0722de896eb278fca193888d22278c28f2782c it was considered to be included in the solution despite diverging functionally from the fix, but it required its own additional prerequisites which would have complicated the solution beyond acceptable limit. The conflict was resolved manually by simply keeping the `EXT4_MF_FS_ABORTED` member. The `upstream-diff` was omitted as this resolution didn't modify the upstream change in any way (the delta is the same) but dealt with the cherry-picking technicalities.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-batch-4 ./ninja.sh _kabi_checked__x86_64--test--ciqlts9_4-CVE-batch-4

    [0/1] Check ABI of kernel [ciqlts9_4-CVE-batch-4]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts9_4/build_files/kernel-src-tree-ciqlts9_4-CVE-batch-4/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-batch-4/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/22372989/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/22372988/kselftests--ciqlts9_4--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-batch-4&#x2013;run1.log](<https://github.com/user-attachments/files/22372987/kselftests--ciqlts9_4-CVE-batch-4--run1.log>)


## Comparison

The tests results are the same for the reference and the patch.

    $ ktests.xsh diff kselftests*.log

    Column    File
    --------  -------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4-CVE-batch-4--run1.log
    
    TestCase                                               Status0  Status1  Summary
    bpf:test_cgroup_storage                                pass     pass     same
    bpf:test_lpm_map                                       pass     pass     same
    bpf:test_lru_map                                       pass     pass     same
    bpf:test_sock                                          pass     pass     same
    bpf:test_sysctl                                        pass     pass     same
    bpf:test_tag                                           pass     pass     same
    bpf:test_tcpnotify_user                                pass     pass     same
    bpf:test_verifier                                      fail     fail     same
    breakpoints:breakpoint_test                            pass     pass     same
    capabilities:test_execve                               pass     pass     same
    clone3:clone3                                          pass     pass     same
    clone3:clone3_cap_checkpoint_restore                   pass     pass     same
    clone3:clone3_clear_sighand                            pass     pass     same
    clone3:clone3_set_tid                                  pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh                         pass     pass     same
    cpufreq:main.sh                                        fail     fail     same
    drivers/dma-buf:udmabuf                                pass     pass     same
    drivers/net/bonding:bond-arp-interval-causes-panic.sh  pass     pass     same
    drivers/net/bonding:bond-break-lacpdu-tx.sh            fail     fail     same
    drivers/net/bonding:bond-eth-type-change.sh            pass     pass     same
    drivers/net/bonding:bond-lladdr-target.sh              pass     pass     same
    drivers/net/bonding:bond_options.sh                    fail     fail     same
    drivers/net/bonding:dev_addr_lists.sh                  pass     pass     same
    drivers/net/bonding:mode-1-recovery-updelay.sh         pass     pass     same
    drivers/net/bonding:mode-2-recovery-updelay.sh         pass     pass     same
    drivers/net/team:dev_addr_lists.sh                     pass     pass     same
    exec:binfmt_script                                     pass     pass     same
    exec:execveat                                          pass     pass     same
    exec:load_address_16777216                             fail     fail     same
    exec:load_address_2097152                              pass     pass     same
    exec:load_address_4096                                 pass     pass     same
    exec:non-regular                                       fail     fail     same
    exec:recursion-depth                                   pass     pass     same
    filesystems/binderfs:binderfs_test                     fail     fail     same
    filesystems/epoll:epoll_wakeup_test                    pass     pass     same
    firmware:fw_run_tests.sh                               skip     skip     same
    fpu:run_test_fpu.sh                                    skip     skip     same
    fpu:test_fpu                                           pass     pass     same
    ftrace:ftracetest                                      fail     fail     same
    futex:run.sh                                           pass     pass     same
    gpio:gpio-mockup.sh                                    fail     fail     same
    intel_pstate:run.sh                                    pass     pass     same
    iommu:iommufd                                          fail     fail     same
    iommu:iommufd_fail_nth                                 pass     pass     same
    ipc:msgque                                             pass     pass     same
    ir:ir_loopback.sh                                      skip     skip     same
    kcmp:kcmp_test                                         pass     pass     same
    kexec:test_kexec_file_load.sh                          skip     skip     same
    kexec:test_kexec_load.sh                               skip     skip     same
    kvm:access_tracking_perf_test                          pass     pass     same
    kvm:amx_test                                           fail     fail     same
    kvm:cpuid_test                                         fail     fail     same
    kvm:cr4_cpuid_sync_test                                fail     fail     same
    kvm:debug_regs                                         fail     fail     same
    kvm:demand_paging_test                                 pass     pass     same
    kvm:dirty_log_page_splitting_test                      fail     fail     same
    kvm:dirty_log_perf_test                                pass     pass     same
    kvm:dirty_log_test                                     fail     fail     same
    kvm:exit_on_emulation_failure_test                     fail     fail     same
    kvm:fix_hypercall_test                                 fail     fail     same
    kvm:get_msr_index_features                             fail     fail     same
    kvm:guest_memfd_test                                   pass     pass     same
    kvm:guest_print_test                                   pass     pass     same
    kvm:hardware_disable_test                              pass     pass     same
    kvm:hyperv_clock                                       fail     fail     same
    kvm:hyperv_cpuid                                       fail     fail     same
    kvm:hyperv_evmcs                                       fail     fail     same
    kvm:hyperv_extended_hypercalls                         fail     fail     same
    kvm:hyperv_features                                    fail     fail     same
    kvm:hyperv_ipi                                         fail     fail     same
    kvm:hyperv_svm_test                                    fail     fail     same
    kvm:hyperv_tlb_flush                                   fail     fail     same
    kvm:kvm_binary_stats_test                              pass     pass     same
    kvm:kvm_clock_test                                     fail     fail     same
    kvm:kvm_create_max_vcpus                               pass     pass     same
    kvm:kvm_page_table_test                                pass     pass     same
    kvm:kvm_pv_test                                        fail     fail     same
    kvm:max_guest_memory_test                              pass     pass     same
    kvm:max_vcpuid_cap_test                                fail     fail     same
    kvm:memslot_modification_stress_test                   pass     pass     same
    kvm:memslot_perf_test                                  pass     pass     same
    kvm:mmio_warning_test                                  fail     fail     same
    kvm:monitor_mwait_test                                 fail     fail     same
    kvm:nested_exceptions_test                             fail     fail     same
    kvm:nx_huge_pages_test.sh                              fail     fail     same
    kvm:platform_info_test                                 fail     fail     same
    kvm:pmu_event_filter_test                              fail     fail     same
    kvm:private_mem_conversions_test                       fail     fail     same
    kvm:private_mem_kvm_exits_test                         fail     fail     same
    kvm:recalc_apic_map_test                               fail     fail     same
    kvm:rseq_test                                          fail     fail     same
    kvm:set_boot_cpu_id                                    fail     fail     same
    kvm:set_memory_region_test                             pass     pass     same
    kvm:set_sregs_test                                     fail     fail     same
    kvm:sev_migrate_tests                                  fail     fail     same
    kvm:smaller_maxphyaddr_emulation_test                  fail     fail     same
    kvm:smm_test                                           fail     fail     same
    kvm:state_test                                         fail     fail     same
    kvm:steal_time                                         pass     pass     same
    kvm:svm_int_ctl_test                                   fail     fail     same
    kvm:svm_nested_shutdown_test                           fail     fail     same
    kvm:svm_nested_soft_inject_test                        fail     fail     same
    kvm:svm_vmcall_test                                    fail     fail     same
    kvm:sync_regs_test                                     fail     fail     same
    kvm:system_counter_offset_test                         pass     pass     same
    kvm:triple_fault_event_test                            fail     fail     same
    kvm:tsc_msrs_test                                      fail     fail     same
    kvm:tsc_scaling_sync                                   fail     fail     same
    kvm:ucna_injection_test                                fail     fail     same
    kvm:userspace_io_test                                  fail     fail     same
    kvm:userspace_msr_exit_test                            fail     fail     same
    kvm:vmx_apic_access_test                               fail     fail     same
    kvm:vmx_close_while_nested_test                        fail     fail     same
    kvm:vmx_dirty_log_test                                 fail     fail     same
    kvm:vmx_exception_with_invalid_guest_state             fail     fail     same
    kvm:vmx_invalid_nested_guest_state                     fail     fail     same
    kvm:vmx_msrs_test                                      fail     fail     same
    kvm:vmx_nested_tsc_scaling_test                        fail     fail     same
    kvm:vmx_pmu_caps_test                                  fail     fail     same
    kvm:vmx_preemption_timer_test                          fail     fail     same
    kvm:vmx_set_nested_state_test                          fail     fail     same
    kvm:vmx_tsc_adjust_test                                fail     fail     same
    kvm:xapic_ipi_test                                     fail     fail     same
    kvm:xapic_state_test                                   fail     fail     same
    kvm:xcr0_cpuid_test                                    fail     fail     same
    kvm:xen_shinfo_test                                    fail     fail     same
    kvm:xen_vmcall_test                                    fail     fail     same
    kvm:xss_msr_test                                       fail     fail     same
    landlock:base_test                                     fail     fail     same
    landlock:fs_test                                       fail     fail     same
    landlock:ptrace_test                                   fail     fail     same
    lib:bitmap.sh                                          skip     skip     same
    lib:prime_numbers.sh                                   pass     pass     same
    lib:printf.sh                                          skip     skip     same
    lib:scanf.sh                                           skip     skip     same
    lib:strscpy.sh                                         skip     skip     same
    livepatch:test-callbacks.sh                            pass     pass     same
    livepatch:test-ftrace.sh                               pass     pass     same
    livepatch:test-livepatch.sh                            pass     pass     same
    livepatch:test-shadow-vars.sh                          pass     pass     same
    livepatch:test-state.sh                                pass     pass     same
    livepatch:test-sysfs.sh                                pass     pass     same
    membarrier:membarrier_test_multi_thread                pass     pass     same
    membarrier:membarrier_test_single_thread               pass     pass     same
    memfd:memfd_test                                       pass     pass     same
    memfd:run_fuse_test.sh                                 pass     pass     same
    memfd:run_hugetlbfs_test.sh                            pass     pass     same
    memory-hotplug:mem-on-off-test.sh                      pass     pass     same
    mincore:mincore_selftest                               fail     fail     same
    mount:run_nosymfollow.sh                               pass     pass     same
    mount:run_unprivileged_remount.sh                      pass     pass     same
    mqueue:mq_open_tests                                   pass     pass     same
    mqueue:mq_perf_tests                                   pass     pass     same
    nci:nci_dev                                            fail     fail     same
    net/forwarding:bridge_locked_port.sh                   pass     pass     same
    net/forwarding:bridge_mdb.sh                           skip     skip     same
    net/forwarding:bridge_mdb_host.sh                      pass     pass     same
    net/forwarding:bridge_mdb_max.sh                       skip     skip     same
    net/forwarding:bridge_mdb_port_down.sh                 pass     pass     same
    net/forwarding:bridge_mld.sh                           pass     pass     same
    net/forwarding:bridge_port_isolation.sh                pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh                    pass     pass     same
    net/forwarding:bridge_vlan_aware.sh                    pass     pass     same
    net/forwarding:bridge_vlan_mcast.sh                    pass     pass     same
    net/forwarding:bridge_vlan_unaware.sh                  pass     pass     same
    net/forwarding:custom_multipath_hash.sh                fail     fail     same
    net/forwarding:ethtool.sh                              skip     skip     same
    net/forwarding:ethtool_extended_state.sh               skip     skip     same
    net/forwarding:gre_custom_multipath_hash.sh            fail     fail     same
    net/forwarding:gre_inner_v4_multipath.sh               pass     pass     same
    net/forwarding:gre_multipath.sh                        pass     pass     same
    net/forwarding:gre_multipath_nh.sh                     fail     fail     same
    net/forwarding:gre_multipath_nh_res.sh                 fail     fail     same
    net/forwarding:hw_stats_l3.sh                          skip     skip     same
    net/forwarding:hw_stats_l3_gre.sh                      skip     skip     same
    net/forwarding:ip6_forward_instats_vrf.sh              skip     skip     same
    net/forwarding:ip6gre_custom_multipath_hash.sh         fail     fail     same
    net/forwarding:ip6gre_flat.sh                          pass     pass     same
    net/forwarding:ip6gre_flat_key.sh                      pass     pass     same
    net/forwarding:ip6gre_flat_keys.sh                     pass     pass     same
    net/forwarding:ip6gre_hier.sh                          pass     pass     same
    net/forwarding:ip6gre_hier_key.sh                      pass     pass     same
    net/forwarding:ip6gre_hier_keys.sh                     pass     pass     same
    net/forwarding:ip6gre_inner_v4_multipath.sh            pass     pass     same
    net/forwarding:ipip_flat_gre.sh                        pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh                    pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh                   pass     pass     same
    net/forwarding:ipip_hier_gre.sh                        pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh                    pass     pass     same
    net/forwarding:local_termination.sh                    skip     skip     same
    net/forwarding:loopback.sh                             skip     skip     same
    net/forwarding:mirror_gre.sh                           pass     pass     same
    net/forwarding:mirror_gre_bound.sh                     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh                 pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh                 pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh             pass     pass     same
    net/forwarding:mirror_gre_changes.sh                   pass     pass     same
    net/forwarding:mirror_gre_flower.sh                    pass     pass     same
    net/forwarding:mirror_gre_lag_lacp.sh                  pass     pass     same
    net/forwarding:mirror_gre_neigh.sh                     pass     pass     same
    net/forwarding:mirror_gre_nh.sh                        pass     pass     same
    net/forwarding:mirror_gre_vlan.sh                      pass     pass     same
    net/forwarding:mirror_vlan.sh                          pass     pass     same
    net/forwarding:no_forwarding.sh                        pass     pass     same
    net/forwarding:pedit_dsfield.sh                        pass     pass     same
    net/forwarding:pedit_ip.sh                             pass     pass     same
    net/forwarding:pedit_l4port.sh                         pass     pass     same
    net/forwarding:q_in_vni_ipv6.sh                        pass     pass     same
    net/forwarding:router.sh                               skip     skip     same
    net/forwarding:router_bridge.sh                        pass     pass     same
    net/forwarding:router_bridge_1d.sh                     pass     pass     same
    net/forwarding:router_bridge_pvid_vlan_upper.sh        pass     pass     same
    net/forwarding:router_bridge_vlan.sh                   pass     pass     same
    net/forwarding:router_bridge_vlan_upper.sh             pass     pass     same
    net/forwarding:router_bridge_vlan_upper_pvid.sh        pass     pass     same
    net/forwarding:router_broadcast.sh                     pass     pass     same
    net/forwarding:router_mpath_nh.sh                      fail     fail     same
    net/forwarding:router_mpath_nh_res.sh                  pass     pass     same
    net/forwarding:router_multicast.sh                     skip     skip     same
    net/forwarding:router_multipath.sh                     fail     fail     same
    net/forwarding:router_nh.sh                            pass     pass     same
    net/forwarding:router_vid_1.sh                         pass     pass     same
    net/forwarding:skbedit_priority.sh                     pass     pass     same
    net/forwarding:tc_chains.sh                            pass     pass     same
    net/forwarding:tc_flower.sh                            pass     pass     same
    net/forwarding:tc_flower_cfm.sh                        fail     fail     same
    net/forwarding:tc_flower_l2_miss.sh                    fail     fail     same
    net/forwarding:tc_flower_router.sh                     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh                        pass     pass     same
    net/forwarding:tc_shblocks.sh                          pass     pass     same
    net/forwarding:tc_tunnel_key.sh                        skip     skip     same
    net/forwarding:tc_vlan_modify.sh                       pass     pass     same
    net/forwarding:vxlan_asymmetric.sh                     pass     pass     same
    net/forwarding:vxlan_asymmetric_ipv6.sh                pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh                      pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh            pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472_ipv6.sh       pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh                      pass     pass     same
    net/forwarding:vxlan_bridge_1q_ipv6.sh                 pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh            pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472_ipv6.sh       pass     pass     same
    net/forwarding:vxlan_symmetric.sh                      pass     pass     same
    net/forwarding:vxlan_symmetric_ipv6.sh                 pass     pass     same
    net/hsr:hsr_ping.sh                                    fail     fail     same
    net/mptcp:diag.sh                                      pass     pass     same
    net/mptcp:mptcp_connect.sh                             pass     pass     same
    net/mptcp:mptcp_sockopt.sh                             pass     pass     same
    net/mptcp:pm_netlink.sh                                pass     pass     same
    net:altnames.sh                                        pass     pass     same
    net:bareudp.sh                                         pass     pass     same
    net:big_tcp.sh                                         skip     skip     same
    net:cmsg_so_mark.sh                                    pass     pass     same
    net:devlink_port_split.py                              skip     skip     same
    net:drop_monitor_tests.sh                              skip     skip     same
    net:fcnal-test.sh                                      skip     skip     same
    net:fib-onlink-tests.sh                                pass     pass     same
    net:fib_nexthop_multiprefix.sh                         pass     pass     same
    net:fib_nexthop_nongw.sh                               pass     pass     same
    net:fib_rule_tests.sh                                  pass     pass     same
    net:fib_tests.sh                                       fail     fail     same
    net:fin_ack_lat.sh                                     pass     pass     same
    net:gre_gso.sh                                         skip     skip     same
    net:icmp.sh                                            fail     fail     same
    net:icmp_redirect.sh                                   pass     pass     same
    net:io_uring_zerocopy_tx.sh                            fail     fail     same
    net:ip6_gre_headroom.sh                                pass     pass     same
    net:ipv6_flowlabel.sh                                  pass     pass     same
    net:l2_tos_ttl_inherit.sh                              skip     skip     same
    net:l2tp.sh                                            pass     pass     same
    net:msg_zerocopy.sh                                    pass     pass     same
    net:netdevice.sh                                       pass     pass     same
    net:pmtu.sh                                            fail     fail     same
    net:psock_snd.sh                                       pass     pass     same
    net:reuseaddr_ports_exhausted.sh                       pass     pass     same
    net:reuseport_bpf                                      pass     pass     same
    net:reuseport_bpf_cpu                                  pass     pass     same
    net:reuseport_bpf_numa                                 pass     pass     same
    net:reuseport_dualstack                                pass     pass     same
    net:route_localnet.sh                                  pass     pass     same
    net:rps_default_mask.sh                                pass     pass     same
    net:rtnetlink.sh                                       skip     skip     same
    net:run_afpackettests                                  pass     pass     same
    net:run_netsocktests                                   pass     pass     same
    net:rxtimestamp.sh                                     pass     pass     same
    net:so_txtime.sh                                       pass     pass     same
    net:srv6_end_next_csid_l3vpn_test.sh                   pass     pass     same
    net:srv6_hencap_red_l3vpn_test.sh                      pass     pass     same
    net:srv6_hl2encap_red_l2vpn_test.sh                    pass     pass     same
    net:stress_reuseport_listen.sh                         pass     pass     same
    net:tcp_fastopen_backup_key.sh                         pass     pass     same
    net:test_blackhole_dev.sh                              fail     fail     same
    net:test_bpf.sh                                        pass     pass     same
    net:test_bridge_neigh_suppress.sh                      skip     skip     same
    net:test_vxlan_fdb_changelink.sh                       pass     pass     same
    net:test_vxlan_under_vrf.sh                            pass     pass     same
    net:tls                                                pass     pass     same
    net:traceroute.sh                                      pass     pass     same
    net:udpgro.sh                                          fail     fail     same
    net:udpgro_bench.sh                                    fail     fail     same
    net:udpgso.sh                                          pass     pass     same
    net:unicast_extensions.sh                              pass     pass     same
    net:veth.sh                                            fail     fail     same
    net:vrf-xfrm-tests.sh                                  pass     pass     same
    net:vrf_route_leaking.sh                               pass     pass     same
    net:vrf_strict_mode_test.sh                            pass     pass     same
    netfilter:bridge_brouter.sh                            skip     skip     same
    netfilter:conntrack_icmp_related.sh                    fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh                   fail     fail     same
    netfilter:conntrack_vrf.sh                             skip     skip     same
    netfilter:ipip-conntrack-mtu.sh                        skip     skip     same
    netfilter:ipvs.sh                                      skip     skip     same
    netfilter:nf_nat_edemux.sh                             skip     skip     same
    netfilter:nft_audit.sh                                 fail     fail     same
    netfilter:nft_concat_range.sh                          fail     fail     same
    netfilter:nft_conntrack_helper.sh                      skip     skip     same
    netfilter:nft_fib.sh                                   skip     skip     same
    netfilter:nft_flowtable.sh                             fail     fail     same
    netfilter:nft_meta.sh                                  pass     pass     same
    netfilter:nft_nat.sh                                   skip     skip     same
    netfilter:nft_queue.sh                                 skip     skip     same
    netfilter:rpath.sh                                     pass     pass     same
    nsfs:owner                                             pass     pass     same
    nsfs:pidns                                             pass     pass     same
    pid_namespace:regression_enomem                        pass     pass     same
    pidfd:pidfd_fdinfo_test                                pass     pass     same
    pidfd:pidfd_getfd_test                                 pass     pass     same
    pidfd:pidfd_open_test                                  pass     pass     same
    pidfd:pidfd_poll_test                                  pass     pass     same
    pidfd:pidfd_setns_test                                 pass     pass     same
    pidfd:pidfd_test                                       pass     pass     same
    pidfd:pidfd_wait                                       pass     pass     same
    proc:fd-001-lookup                                     pass     pass     same
    proc:fd-002-posix-eq                                   pass     pass     same
    proc:fd-003-kthread                                    pass     pass     same
    proc:proc-fsconfig-hidepid                             pass     pass     same
    proc:proc-loadavg-001                                  pass     pass     same
    proc:proc-multiple-procfs                              pass     pass     same
    proc:proc-self-map-files-001                           pass     pass     same
    proc:proc-self-map-files-002                           pass     pass     same
    proc:proc-self-syscall                                 pass     pass     same
    proc:proc-self-wchan                                   pass     pass     same
    proc:proc-subset-pid                                   pass     pass     same
    proc:proc-uptime-002                                   pass     pass     same
    proc:read                                              pass     pass     same
    proc:self                                              pass     pass     same
    proc:setns-dcache                                      pass     pass     same
    proc:setns-sysvipc                                     pass     pass     same
    proc:thread-self                                       pass     pass     same
    pstore:pstore_post_reboot_tests                        skip     skip     same
    pstore:pstore_tests                                    fail     fail     same
    ptrace:get_syscall_info                                pass     pass     same
    ptrace:peeksiginfo                                     pass     pass     same
    ptrace:vmaccess                                        fail     fail     same
    rlimits:rlimits-per-userns                             pass     pass     same
    rseq:basic_percpu_ops_test                             pass     pass     same
    rseq:basic_test                                        pass     pass     same
    rseq:param_test                                        pass     pass     same
    rseq:param_test_benchmark                              pass     pass     same
    rseq:param_test_compare_twice                          pass     pass     same
    rseq:run_param_test.sh                                 pass     pass     same
    seccomp:seccomp_benchmark                              pass     pass     same
    seccomp:seccomp_bpf                                    pass     pass     same
    sgx:test_sgx                                           fail     fail     same
    sigaltstack:sas                                        pass     pass     same
    size:get_size                                          pass     pass     same
    splice:default_file_splice_read.sh                     pass     pass     same
    splice:short_splice_read.sh                            fail     fail     same
    static_keys:test_static_keys.sh                        skip     skip     same
    syscall_user_dispatch:sud_benchmark                    pass     pass     same
    syscall_user_dispatch:sud_test                         pass     pass     same
    tc-testing:tdc.sh                                      fail     fail     same
    tdx:tdx_guest_test                                     fail     fail     same
    timens:clock_nanosleep                                 pass     pass     same
    timens:exec                                            pass     pass     same
    timens:futex                                           pass     pass     same
    timens:procfs                                          pass     pass     same
    timens:timens                                          pass     pass     same
    timens:timer                                           pass     pass     same
    timens:timerfd                                         pass     pass     same
    timens:vfork_exec                                      pass     pass     same
    timers:inconsistency-check                             pass     pass     same
    timers:mqueue-lat                                      pass     pass     same
    timers:nanosleep                                       pass     pass     same
    timers:nsleep-lat                                      pass     pass     same
    timers:posix_timers                                    pass     pass     same
    timers:rtcpie                                          pass     pass     same
    timers:set-timer-lat                                   pass     pass     same
    timers:threadtest                                      pass     pass     same
    tmpfs:bug-link-o-tmpfile                               pass     pass     same
    tpm2:test_smoke.sh                                     skip     skip     same
    tpm2:test_space.sh                                     skip     skip     same
    tty:tty_tstamp_update                                  skip     skip     same
    vDSO:vdso_standalone_test_x86                          pass     pass     same
    vDSO:vdso_test_abi                                     pass     pass     same
    vDSO:vdso_test_clock_getres                            pass     pass     same
    vDSO:vdso_test_correctness                             pass     pass     same
    vDSO:vdso_test_getcpu                                  pass     pass     same
    vDSO:vdso_test_gettimeofday                            pass     pass     same
    x86:amx_64                                             fail     fail     same
    x86:check_initial_reg_state_64                         pass     pass     same
    x86:corrupt_xstate_header_64                           fail     fail     same
    x86:fsgsbase_64                                        fail     fail     same
    x86:fsgsbase_restore_64                                fail     fail     same
    x86:ioperm_64                                          pass     pass     same
    x86:iopl_64                                            pass     pass     same
    x86:lam_64                                             fail     fail     same
    x86:mov_ss_trap_64                                     fail     fail     same
    x86:sigaltstack_64                                     fail     fail     same
    x86:sigreturn_64                                       fail     fail     same
    x86:single_step_syscall_64                             fail     fail     same
    x86:syscall_arg_fault_64                               fail     fail     same
    x86:syscall_nt_64                                      pass     pass     same
    x86:syscall_numbering_64                               fail     fail     same
    x86:sysret_rip_64                                      fail     fail     same
    x86:sysret_ss_attrs_64                                 pass     pass     same
    x86:test_mremap_vdso_64                                pass     pass     same
    x86:test_vsyscall_64                                   pass     pass     same
    zram:zram.sh                                           pass     pass     same

