### PR TITLE
[LTS 8.6] CVE-2023-0597

### DIFF
--- a/arch/x86/include/asm/cpu_entry_area.h
+++ b/arch/x86/include/asm/cpu_entry_area.h
@@ -94,7 +94,6 @@ struct cpu_entry_area {
 	 */
 	struct cea_exception_stacks estacks;
 #endif
-#ifdef CONFIG_CPU_SUP_INTEL
 	/*
 	 * Per CPU debug store for Intel performance monitoring. Wastes a
 	 * full page at the moment.
@@ -105,11 +104,13 @@ struct cpu_entry_area {
 	 * Reserve enough fixmap PTEs.
 	 */
 	struct debug_store_buffers cpu_debug_buffers;
-#endif
 };
 
-#define CPU_ENTRY_AREA_SIZE	(sizeof(struct cpu_entry_area))
-#define CPU_ENTRY_AREA_TOT_SIZE	(CPU_ENTRY_AREA_SIZE * NR_CPUS)
+#define CPU_ENTRY_AREA_SIZE		(sizeof(struct cpu_entry_area))
+#define CPU_ENTRY_AREA_ARRAY_SIZE	(CPU_ENTRY_AREA_SIZE * NR_CPUS)
+
+/* Total size includes the readonly IDT mapping page as well: */
+#define CPU_ENTRY_AREA_TOTAL_SIZE	(CPU_ENTRY_AREA_ARRAY_SIZE + PAGE_SIZE)
 
 DECLARE_PER_CPU(struct cpu_entry_area *, cpu_entry_area);
 DECLARE_PER_CPU(struct cea_exception_stacks *, cea_exception_stacks);
@@ -117,13 +118,14 @@ DECLARE_PER_CPU(struct cea_exception_stacks *, cea_exception_stacks);
 extern void setup_cpu_entry_areas(void);
 extern void cea_set_pte(void *cea_vaddr, phys_addr_t pa, pgprot_t flags);
 
+/* Single page reserved for the readonly IDT mapping: */
 #define	CPU_ENTRY_AREA_RO_IDT		CPU_ENTRY_AREA_BASE
 #define CPU_ENTRY_AREA_PER_CPU		(CPU_ENTRY_AREA_RO_IDT + PAGE_SIZE)
 
 #define CPU_ENTRY_AREA_RO_IDT_VADDR	((void *)CPU_ENTRY_AREA_RO_IDT)
 
 #define CPU_ENTRY_AREA_MAP_SIZE			\
-	(CPU_ENTRY_AREA_PER_CPU + CPU_ENTRY_AREA_TOT_SIZE - CPU_ENTRY_AREA_BASE)
+	(CPU_ENTRY_AREA_PER_CPU + CPU_ENTRY_AREA_ARRAY_SIZE - CPU_ENTRY_AREA_BASE)
 
 extern struct cpu_entry_area *get_cpu_entry_area(int cpu);
 

--- a/arch/x86/include/asm/cpu_entry_area.h
+++ b/arch/x86/include/asm/cpu_entry_area.h
@@ -107,10 +107,6 @@ struct cpu_entry_area {
 };
 
 #define CPU_ENTRY_AREA_SIZE		(sizeof(struct cpu_entry_area))
-#define CPU_ENTRY_AREA_ARRAY_SIZE	(CPU_ENTRY_AREA_SIZE * NR_CPUS)
-
-/* Total size includes the readonly IDT mapping page as well: */
-#define CPU_ENTRY_AREA_TOTAL_SIZE	(CPU_ENTRY_AREA_ARRAY_SIZE + PAGE_SIZE)
 
 DECLARE_PER_CPU(struct cpu_entry_area *, cpu_entry_area);
 DECLARE_PER_CPU(struct cea_exception_stacks *, cea_exception_stacks);
@@ -124,8 +120,14 @@ extern void cea_set_pte(void *cea_vaddr, phys_addr_t pa, pgprot_t flags);
 
 #define CPU_ENTRY_AREA_RO_IDT_VADDR	((void *)CPU_ENTRY_AREA_RO_IDT)
 
-#define CPU_ENTRY_AREA_MAP_SIZE			\
-	(CPU_ENTRY_AREA_PER_CPU + CPU_ENTRY_AREA_ARRAY_SIZE - CPU_ENTRY_AREA_BASE)
+#ifdef CONFIG_X86_32
+#define CPU_ENTRY_AREA_MAP_SIZE		(CPU_ENTRY_AREA_PER_CPU +		\
+					 (CPU_ENTRY_AREA_SIZE * NR_CPUS) -	\
+					 CPU_ENTRY_AREA_BASE)
+#else
+#define CPU_ENTRY_AREA_MAP_SIZE		P4D_SIZE
+#endif
+
 
 extern struct cpu_entry_area *get_cpu_entry_area(int cpu);
 

--- a/arch/x86/include/asm/kasan.h
+++ b/arch/x86/include/asm/kasan.h
@@ -28,9 +28,12 @@
 #ifdef CONFIG_KASAN
 void __init kasan_early_init(void);
 void __init kasan_init(void);
+void __init kasan_populate_shadow_for_vaddr(void *va, size_t size, int nid);
 #else
 static inline void kasan_early_init(void) { }
 static inline void kasan_init(void) { }
+static inline void kasan_populate_shadow_for_vaddr(void *va, size_t size,
+						   int nid) { }
 #endif
 
 #endif

--- a/arch/x86/include/asm/pgtable_32_types.h
+++ b/arch/x86/include/asm/pgtable_32_types.h
@@ -44,11 +44,11 @@ extern bool __vmalloc_start_set; /* set once high_memory is set */
  * Define this here and validate with BUILD_BUG_ON() in pgtable_32.c
  * to avoid include recursion hell
  */
-#define CPU_ENTRY_AREA_PAGES	(NR_CPUS * 40)
+#define CPU_ENTRY_AREA_PAGES	(NR_CPUS * 39)
 
-#define CPU_ENTRY_AREA_BASE						\
-	((FIXADDR_TOT_START - PAGE_SIZE * (CPU_ENTRY_AREA_PAGES + 1))   \
-	 & PMD_MASK)
+/* The +1 is for the readonly IDT page: */
+#define CPU_ENTRY_AREA_BASE	\
+	((FIXADDR_TOT_START - PAGE_SIZE*(CPU_ENTRY_AREA_PAGES+1)) & PMD_MASK)
 
 #define LDT_BASE_ADDR		\
 	((CPU_ENTRY_AREA_BASE - PAGE_SIZE) & PMD_MASK)

--- a/arch/x86/mm/cpu_entry_area.c
+++ b/arch/x86/mm/cpu_entry_area.c
@@ -97,7 +97,7 @@ cea_map_percpu_pages(void *cea_vaddr, void *ptr, int pages, pgprot_t prot)
 					early_pfn_to_nid(PFN_DOWN(pa)));
 
 	for ( ; pages; pages--, cea_vaddr+= PAGE_SIZE, ptr += PAGE_SIZE)
-		cea_set_pte(cea_vaddr, pa, prot);
+		cea_set_pte(cea_vaddr, per_cpu_ptr_to_phys(ptr), prot);
 }
 
 static void __init percpu_setup_debug_store(unsigned int cpu)

--- a/arch/x86/mm/cpu_entry_area.c
+++ b/arch/x86/mm/cpu_entry_area.c
@@ -186,7 +186,9 @@ static __init void setup_cpu_entry_area_ptes(void)
 #ifdef CONFIG_X86_32
 	unsigned long start, end;
 
-	BUILD_BUG_ON(CPU_ENTRY_AREA_PAGES * PAGE_SIZE < CPU_ENTRY_AREA_MAP_SIZE);
+	/* The +1 is for the readonly IDT: */
+	BUILD_BUG_ON((CPU_ENTRY_AREA_PAGES+1)*PAGE_SIZE != CPU_ENTRY_AREA_MAP_SIZE);
+	BUILD_BUG_ON(CPU_ENTRY_AREA_TOTAL_SIZE != CPU_ENTRY_AREA_MAP_SIZE);
 	BUG_ON(CPU_ENTRY_AREA_BASE & ~PMD_MASK);
 
 	start = CPU_ENTRY_AREA_BASE;

--- a/arch/x86/mm/cpu_entry_area.c
+++ b/arch/x86/mm/cpu_entry_area.c
@@ -11,6 +11,7 @@
 #include <asm/fixmap.h>
 #include <asm/desc.h>
 #include <asm/kasan.h>
+#include <asm/setup.h>
 
 static DEFINE_PER_CPU_PAGE_ALIGNED(struct entry_stack_page, entry_stack_storage);
 
@@ -29,6 +30,12 @@ static __init void init_cea_offsets(void)
 {
 	unsigned int max_cea;
 	unsigned int i, j;
+
+	if (!kaslr_enabled()) {
+		for_each_possible_cpu(i)
+			per_cpu(_cea_offset, i) = i;
+		return;
+	}
 
 	max_cea = (CPU_ENTRY_AREA_MAP_SIZE - PAGE_SIZE) / CPU_ENTRY_AREA_SIZE;
 

--- a/arch/x86/mm/cpu_entry_area.c
+++ b/arch/x86/mm/cpu_entry_area.c
@@ -9,6 +9,7 @@
 #include <asm/pgtable.h>
 #include <asm/fixmap.h>
 #include <asm/desc.h>
+#include <asm/kasan.h>
 
 static DEFINE_PER_CPU_PAGE_ALIGNED(struct entry_stack_page, entry_stack_storage);
 
@@ -49,8 +50,13 @@ void cea_set_pte(void *cea_vaddr, phys_addr_t pa, pgprot_t flags)
 static void __init
 cea_map_percpu_pages(void *cea_vaddr, void *ptr, int pages, pgprot_t prot)
 {
+	phys_addr_t pa = per_cpu_ptr_to_phys(ptr);
+
+	kasan_populate_shadow_for_vaddr(cea_vaddr, pages * PAGE_SIZE,
+					early_pfn_to_nid(PFN_DOWN(pa)));
+
 	for ( ; pages; pages--, cea_vaddr+= PAGE_SIZE, ptr += PAGE_SIZE)
-		cea_set_pte(cea_vaddr, per_cpu_ptr_to_phys(ptr), prot);
+		cea_set_pte(cea_vaddr, pa, prot);
 }
 
 static void __init percpu_setup_debug_store(unsigned int cpu)

--- a/arch/x86/mm/cpu_entry_area.c
+++ b/arch/x86/mm/cpu_entry_area.c
@@ -4,6 +4,7 @@
 #include <linux/percpu.h>
 #include <linux/kallsyms.h>
 #include <linux/kcore.h>
+#include <linux/prandom.h>
 
 #include <asm/cpu_entry_area.h>
 #include <asm/pgtable.h>
@@ -16,12 +17,52 @@ static DEFINE_PER_CPU_PAGE_ALIGNED(struct entry_stack_page, entry_stack_storage)
 #ifdef CONFIG_X86_64
 static DEFINE_PER_CPU_PAGE_ALIGNED(struct exception_stacks, exception_stacks);
 DEFINE_PER_CPU(struct cea_exception_stacks*, cea_exception_stacks);
+
+static DEFINE_PER_CPU_READ_MOSTLY(unsigned long, _cea_offset);
+
+static __always_inline unsigned int cea_offset(unsigned int cpu)
+{
+	return per_cpu(_cea_offset, cpu);
+}
+
+static __init void init_cea_offsets(void)
+{
+	unsigned int max_cea;
+	unsigned int i, j;
+
+	max_cea = (CPU_ENTRY_AREA_MAP_SIZE - PAGE_SIZE) / CPU_ENTRY_AREA_SIZE;
+
+	/* O(sodding terrible) */
+	for_each_possible_cpu(i) {
+		unsigned int cea;
+
+again:
+		cea = prandom_u32_max(max_cea);
+
+		for_each_possible_cpu(j) {
+			if (cea_offset(j) == cea)
+				goto again;
+
+			if (i == j)
+				break;
+		}
+
+		per_cpu(_cea_offset, i) = cea;
+	}
+}
+#else /* !X86_64 */
+
+static __always_inline unsigned int cea_offset(unsigned int cpu)
+{
+	return cpu;
+}
+static inline void init_cea_offsets(void) { }
 #endif
 
 /* Is called from entry code, so must be noinstr */
 noinstr struct cpu_entry_area *get_cpu_entry_area(int cpu)
 {
-	unsigned long va = CPU_ENTRY_AREA_PER_CPU + cpu * CPU_ENTRY_AREA_SIZE;
+	unsigned long va = CPU_ENTRY_AREA_PER_CPU + cea_offset(cpu) * CPU_ENTRY_AREA_SIZE;
 	BUILD_BUG_ON(sizeof(struct cpu_entry_area) % PAGE_SIZE != 0);
 
 	return (struct cpu_entry_area *) va;
@@ -194,7 +235,6 @@ static __init void setup_cpu_entry_area_ptes(void)
 
 	/* The +1 is for the readonly IDT: */
 	BUILD_BUG_ON((CPU_ENTRY_AREA_PAGES+1)*PAGE_SIZE != CPU_ENTRY_AREA_MAP_SIZE);
-	BUILD_BUG_ON(CPU_ENTRY_AREA_TOTAL_SIZE != CPU_ENTRY_AREA_MAP_SIZE);
 	BUG_ON(CPU_ENTRY_AREA_BASE & ~PMD_MASK);
 
 	start = CPU_ENTRY_AREA_BASE;
@@ -209,6 +249,8 @@ static __init void setup_cpu_entry_area_ptes(void)
 void __init setup_cpu_entry_areas(void)
 {
 	unsigned int cpu;
+
+	init_cea_offsets();
 
 	setup_cpu_entry_area_ptes();
 

--- a/arch/x86/mm/cpu_entry_area.c
+++ b/arch/x86/mm/cpu_entry_area.c
@@ -91,11 +91,6 @@ void cea_set_pte(void *cea_vaddr, phys_addr_t pa, pgprot_t flags)
 static void __init
 cea_map_percpu_pages(void *cea_vaddr, void *ptr, int pages, pgprot_t prot)
 {
-	phys_addr_t pa = per_cpu_ptr_to_phys(ptr);
-
-	kasan_populate_shadow_for_vaddr(cea_vaddr, pages * PAGE_SIZE,
-					early_pfn_to_nid(PFN_DOWN(pa)));
-
 	for ( ; pages; pages--, cea_vaddr+= PAGE_SIZE, ptr += PAGE_SIZE)
 		cea_set_pte(cea_vaddr, per_cpu_ptr_to_phys(ptr), prot);
 }
@@ -181,6 +176,9 @@ static void __init setup_cpu_entry_area(unsigned int cpu)
 		PAGE_KERNEL_RO : PAGE_KERNEL;
 	pgprot_t tss_prot = PAGE_KERNEL;
 #endif
+
+	kasan_populate_shadow_for_vaddr(cea, CPU_ENTRY_AREA_SIZE,
+					early_cpu_to_node(cpu));
 
 	cea_set_pte(&cea->gdt, get_cpu_gdt_paddr(cpu), gdt_prot);
 

--- a/arch/x86/mm/kasan_init_64.c
+++ b/arch/x86/mm/kasan_init_64.c
@@ -291,6 +291,18 @@ void __init kasan_early_init(void)
 	kasan_map_early_shadow(init_top_pgt);
 }
 
+void __init kasan_populate_shadow_for_vaddr(void *va, size_t size, int nid)
+{
+	unsigned long shadow_start, shadow_end;
+
+	shadow_start = (unsigned long)kasan_mem_to_shadow(va);
+	shadow_start = round_down(shadow_start, PAGE_SIZE);
+	shadow_end = (unsigned long)kasan_mem_to_shadow(va + size);
+	shadow_end = round_up(shadow_end, PAGE_SIZE);
+
+	kasan_populate_shadow(shadow_start, shadow_end, nid);
+}
+
 void __init kasan_init(void)
 {
 	int i;
@@ -353,9 +365,6 @@ void __init kasan_init(void)
 	kasan_populate_early_shadow(
 		kasan_mem_to_shadow((void *)PAGE_OFFSET + MAXMEM),
 		shadow_cpu_entry_begin);
-
-	kasan_populate_shadow((unsigned long)shadow_cpu_entry_begin,
-			      (unsigned long)shadow_cpu_entry_end, 0);
 
 	kasan_populate_early_shadow(shadow_cpu_entry_end,
 			kasan_mem_to_shadow((void *)__START_KERNEL_map));


### PR DESCRIPTION
[LTS 8.6]
CVE-2023-0597
VULN-3958


# Problem

<https://access.redhat.com/security/cve/CVE-2023-0597>
> A possible unauthorized memory access flaw was found in the Linux kernel cpu\_entry\_area mapping of X86 CPU data to memory, where a user may guess the location of exception stack(s) or other important data. This issue could allow a local user to gain access to some important data with expected location in memory.


# Affected: yes

This flaw is independent of any config options and affects all x86 kernels. The commit 97e3d26b5e5f371b3ee223d94dd123e6c442ba80 solving the issue is absent from `ciqlts8_6`'s history, along with other accompanying changes (see [Solution](#orgfd49027)). Additionally, the options settings for related randomization techniques found in `configs/kernel-x86_64.config`

<https://github.com/ctrliq/kernel-src-tree/blob/58ac55466f2ef630d981eb8a0dcdea8d0f12e517/configs/kernel-x86_64.config#L4565-L4566>

clearly display the desire to have the randomization in place wherever it may apply.


<a id="orgfd49027"></a>

# Solution

The official mainline fix for CVE-2023-0597 is 97e3d26b5e5f371b3ee223d94dd123e6c442ba80, but the actual solution is complicated on LTS 8.6 by the non-backported changes to kernel's memory mapping as well as by multiple fixes of the fix present in the mainline.

Consider the branched-off timeline of changes to the 97e3d26b5e5f371b3ee223d94dd123e6c442ba80-affected files:

    Label    File
    -------  -------------------------------------
    A        arch/x86/include/asm/cpu_entry_area.h
    B        arch/x86/include/asm/pgtable_areas.h
    C        arch/x86/kernel/hw_breakpoint.c
    D        arch/x86/mm/cpu_entry_area.c

    | Id | ABCD | kernel-mainline                          |       Date | Descr                                                                               | ciqlts8_6                                  |
    |----+------+------------------------------------------+------------+-------------------------------------------------------------------------------------+--------------------------------------------|
    |    | ---# | decb9ac4a9739c16e228f7b2918bfdca34cc89a9 | 2024-08-25 | x86/cpu_entry_area: Annotate percpu_setup_exception_stacks() as __init              |                                            |
    |  5 | ---# | a3f547addcaa10df5a226526bc9e2d9a94542344 | 2023-03-22 | x86/mm: Do not shuffle CPU entry areas without KASLR                                |                                            |
    |    | --#- | 7914695743d598b189d549f2f57af24aa5633705 | 2023-01-31 | x86/amd: Cache debug register values in percpu variables                            |                                            |
    |    | ---# | 3c202d14a9d73fb63c3dccb18feac5618c21e1c4 | 2022-12-20 | prandom: remove prandom_u32_max()                                                   |                                            |
    |  4 | ---# | 97650148a15e0b30099d6175ffe278b9f55ec66a | 2022-12-15 | x86/mm: Populate KASAN shadow for entire per-CPU range of CPU entry area            |                                            |
    |  3 | ---# | 80d72a8f76e8f3f0b5a70b8c7022578e17bde8e7 | 2022-12-15 | x86/mm: Recompute physical address for every page of per-CPU CEA mapping            |                                            |
    |  0 | #### | 97e3d26b5e5f371b3ee223d94dd123e6c442ba80 | 2022-12-15 | x86/mm: Randomize per-cpu entry area                                                |                                            |
    |  2 | ---# | 3f148f3318140035e87decc1214795ff0755757b | 2022-12-15 | x86/kasan: Map shadow for percpu pages on demand                                    |                                            |
    |    | ---# | d76c4f7a610ac56c5b06e34258859945e77d190c | 2022-11-22 | x86/cpu: Remove X86_FEATURE_XENPV usage in setup_cpu_entry_area()                   |                                            |
    |    | #--- | e87f4152e542610d0b4c6c8548964a68a59d2040 | 2022-04-04 | task_stack, x86/cea: Force-inline stack helpers                                     |                                            |
    |    | #--# | 541ac97186d9ea88491961a46284de3603c914fd | 2021-10-06 | x86/sev: Make the #VC exception stacks part of the default stacks storage           |                                            |
    |    | --#- | 3943abf2dbfae9ea4d2da05c1db569a0603f76da | 2021-02-05 | x86/debug: Prevent data breakpoints on cpu_dr7                                      |                                            |
    |    | --#- | c4bed4b96918ff1d062ee81fdae4d207da4fa9b0 | 2021-02-05 | x86/debug: Prevent data breakpoints on __per_cpu_offset                             |                                            |
    |    | --#- | 9ad22e165994ccb64d85b68499eaef97342c175b | 2021-02-01 | x86/debug: Fix DR6 handling                                                         |                                            |
    |    | ---# | 6b27edd74a5e9669120f7bd0ae1f475d124c1042 | 2020-09-09 | x86/dumpstack/64: Add noinstr version of get_stack_info()                           | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | #--- | 02772fb9b68e6a72a5e17f994048df832fe2b15e | 2020-09-09 | x86/sev-es: Allocate and map an IST stack for #VC handler                           | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | --#- | d53d9bc0cf783e93b374de3895145c7375e570ba | 2020-09-04 | x86/debug: Change thread.debugreg6 to thread.virtual_dr6                            |                                            |
    |    | --#- | f4956cf83ed12271bdbd5b547f3378add72bbffb | 2020-09-04 | x86/debug: Support negative polarity DR6 bits                                       | ~ 927f65e976a77f9c9d29b4a50d4b8157aff37f26 |
    |    | --#- | 21d44be7b6ff4c254dc971e2c99d4082dd470afd | 2020-09-04 | x86/debug: Simplify hw_breakpoint_handler()                                         |                                            |
    |    | --#- | b84d42b6c6ac6a60519286e72b69f2dbf08dfb70 | 2020-09-04 | x86/debug: Remove aout_dump_debugregs()                                             |                                            |
    |    | --#- | df561f6688fef775baa341a0f5d960becd248b11 | 2020-08-23 | treewide: Use fallthrough pseudo-keyword                                            | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | #--# | fd501d4f0399700011acde486576c7c1eb8e7a61 | 2020-06-11 | x86/entry: Remove DBn stacks                                                        | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | --#- | 84b6a3491567a540f955e18d8e615493afa36df0 | 2020-06-11 | x86/entry: Optimize local_db_save() for virt                                        |                                            |
    |    | --#- | fdef24dfccb7be06e6ebe11d6c6c56987421870f | 2020-06-11 | x86/hw_breakpoint: Prevent data breakpoints on user_pcid_flush_mask                 |                                            |
    |    | --#- | f9fe0b89f05441c6e4034e024c2c75a0d93024c1 | 2020-06-11 | x86/hw_breakpoint: Prevent data breakpoints on per_cpu cpu_tss_rw                   |                                            |
    |    | --#- | 97417cb9ad4ed052d7a4c5c0d75db1ff1b0981fb | 2020-06-11 | x86/hw_breakpoint: Prevent data breakpoints on direct GDT                           |                                            |
    |    | --#- | d390e6de89d30402bd06056c40cea72328aec9b1 | 2020-06-11 | x86/hw_breakpoint: Add within_area() to check data breakpoints                      |                                            |
    |    | --#- | 9f58fdde95c9509a4ded27a6d0035e79294002b4 | 2020-06-11 | x86/db: Split out dr6/7 handling                                                    | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | --#- | 24ae0c91cbc57c2deb0401bd653453a508acdcee | 2020-06-11 | x86/hw_breakpoint: Prevent data breakpoints on cpu_entry_area                       |                                            |
    |    | ---# | 65fddcfca8ad14778f71a57672fd01e8112d30fa | 2020-06-09 | mm: reorder includes after introduction of linux/pgtable.h                          |                                            |
    |    | ---# | ca5999fde0a1761665a38e4c9a72dbcd7d190a81 | 2020-06-09 | mm: introduce include/linux/pgtable.h                                               |                                            |
    |    | ---# | 593309423cbad0fab659a685834416cf12d8f581 | 2020-04-14 | x86/32: Remove CONFIG_DOUBLEFAULT                                                   |                                            |
    |    | ##-- | 186525bd6b83efc592672e2d6185e4d7c810d2b4 | 2019-12-10 | mm, x86/mm: Untangle address space layout definitions from basic pgtable type…      |                                            |
    |    | #--# | dc4e0021b00b5a4ecba56fae509217776592b0aa | 2019-11-26 | x86/doublefault/32: Move #DF stack and TSS to cpu_entry_area                        |                                            |
    |  1 | #--# | 05b042a1944322844eaae7ea596d5f154166d68a | 2019-11-25 | x86/pti/32: Calculate the various PTI cpu_entry_area sizes correctly, make the…     |                                            |
    |    | #--- | 880a98c339961eaa074393e3a2117cbe9125b8bb | 2019-11-21 | x86/cpu_entry_area: Add guard page for entry stack on 32bit                         |                                            |
    |    | ---# | 6b546e1c9ad2a25f874f8bc6077d0f55f9446414 | 2019-11-16 | x86/tss: Fix and move VMX BUILD_BUG_ON()                                            | # a1c405ca16baa1afc756c1d4ccbcc0c3a00cb453 |
    |    | #--- | 6184488a19be96d89cb6c36fb4bc277198309484 | 2019-10-01 | x86: Use the correct SPDX License Identifier in headers                             |                                            |
    |    | --#- | 1a59d1b8e05ea6ab45f7e18897de1ef0e6bc3da6 | 2019-05-30 | treewide: Replace GPLv2 boilerplate/reference with SPDX - rule 156                  |                                            |
    |    | #--# | 2a594d4ccf3f10f80b77d71bd3dad10813ac0137 | 2019-04-17 | x86/exceptions: Split debug IST stack                                               | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | #--- | 1bdb67e5aa2d5d43c48cb7d93393fcba276c9e71 | 2019-04-17 | x86/exceptions: Enable IST guard pages                                              | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | #--- | 3207426925d2b4da390be8068df1d1c2b36e5918 | 2019-04-17 | x86/exceptions: Disconnect IST index and stack order                                | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | #--# | 7623f37e411156e6e09b95cf5c76e509c5fda640 | 2019-04-17 | x86/cpu_entry_area: Provide exception stack accessor                                | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | ---# | a4af767ae59cc579569bbfe49513a0037d5989ee | 2019-04-17 | x86/cpu_entry_area: Prepare for IST guard pages                                     | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | #--# | 019b17b3ffe48100e52f609ca1c6ed6e5a40cba1 | 2019-04-17 | x86/exceptions: Add structs for exception stacks                                    | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | ---# | 881a463cf21dbf83aab2cf6c9a359f34f88c2491 | 2019-04-17 | x86/cpu_entry_area: Cleanup setup functions                                         | # 604239d6f80ebd4301c47285d7305d7262dc69a6 |
    |    | --#- | e898e69d6b9475bf123f99b3c5d1a67bb7cb2361 | 2019-03-22 | x86/hw_breakpoints: Make default case in hw_breakpoint_arch_parse() return an error |                                            |
    |    | ---# | ba2ba356b2c849ec62d5fefa9cd4168163b13211 | 2019-02-08 | x86/cpu_entry_area: Move percpu_setup_debug_store() to __init section               | ~ cfe70862b56bc8d9b13ca055348ca01c446ca605 |
    |    | --#- | fab940755d1d78377901450b6ee7c77356e06821 | 2019-01-30 | x86/hw_breakpoints, kprobes: Remove kprobes ifdeffery                               |                                            |
    |    | --#- | 6fcebf1302b43e7a610d1d2fa89f41e693249aa5 | 2019-01-26 | x86/kernel: Mark expected switch-case fall-throughs                                 |                                            |
    |    | #--# | bf904d2762ee6fc1e4acfcb0772bbfb4a27ad8a6 | 2018-09-12 | x86/pti/64: Remove the SYSCALL64 entry trampoline                                   | ~ e2093e17c786fae6762be28d622e0dfeefb6d37a |
    |    | ---# | 6855dc41b24619c3d1de3dbd27dd0546b0e45272 | 2018-08-14 | x86: Add entry trampolines to kcore                                                 | ~ f472db7b53074bb1e36e626e139b0afabdc5d9d0 |
    |    | ---# | d83212d5dd6761625fe87cc23016bbaa47303271 | 2018-08-14 | kallsyms, x86: Export addresses of PTI entry trampolines                            | ~ 2e5dbe65824c98ee7602b2afef51eec8fd06d93f |
    |    | --#- | a0baf043c5cfa3a489a63ac50f5201c31a651e21 | 2018-06-26 | perf/arch/x86: Implement hw_breakpoint_arch_parse()                                 | ~ 94bbfa1bcb24b573c0fababaac1574c6b947866a |
    |    | --#- | 8e983ff9ac02a8fb454ed09c2462bdb3617006a8 | 2018-06-26 | perf/hw_breakpoint: Pass arch breakpoint struct to arch_check_bp_in_kernelspace()   | ~ 70558b454254ddaa55838662c2d9dad5b039f07a |
    |    | ---# | 0f561fce4d6979a50415616896512f87a6d1d5c8 | 2018-04-12 | x86/pti: Enable global pages for shared areas                                       | = 0f561fce4d6979a50415616896512f87a6d1d5c8 |

The commits identified with  `0`, `1`, `2`, `3`, `4`, `5` comprise the solution proposed in this PR.

-   Commit `0` is the CVE-2023-0597 fix proper, with some considerable upstream diffs, discussed below.
-   Commit `1` was picked to ease some conflicts for `0`.
-   Commit `5` is an official bugfix to `0`.
-   Commits `2`, `3`, `4` are unofficial bugfixes to `0`, and also serve as prerequisites for `5`.

The complete relations list - official and actual - are as follows:

    1 --prereq--> 0  *
    2 --bugfix--> 0
    2 --prereq--> 0  *
    2 --prereq--> 5
    3 --bugfix--> 2  *
    3 --prereq--> 5
    4 --bugfix--> 2  *
    4 --prereq--> 5
    5 --bugfix--> 0  *

Marked with asterisk `*` are the ones which were able to be expressed in commit headlines with the `cve-pre`, `cve-bf` attributes.

Commentary on the applied changes:

1.  Commit `1` (05b042a1944322844eaae7ea596d5f154166d68a) fixes a bug with the calculation of cpu entry area size and renames some constants in `arch/x86/include/asm/cpu_entry_area.h` which are later modified by `0`. Its "Fixes" attribute points to the very previous commit 880a98c339961eaa074393e3a2117cbe9125b8bb, but it merely exposed the bug, not introduced it.
2.  Commit `2` (3f148f3318140035e87decc1214795ff0755757b) is actually a bugfix of `0`, but it was put earlier in mainline's history - note the *AuthorDate* 2022-10-27 of `0` and 2022-10-28 of `2`, as well as 3f148f3318140035e87decc1214795ff0755757b's message:
    > Thanks to the 0day folks for finding and reporting this to be an issue.
    > 
    > [ dhansen: tweak changelog since this will get committed before peterz's
    >            actual cpu-entry-area randomization ]
    
    It was cherry-picked before `0` to preserve the ordering in `kernel-mainline`, and marked as `cve-pre` to avoid possible confusion around `cve-bf` and because it might as well be treated as preparation for the fix.
3.  Commit `0` (97e3d26b5e5f371b3ee223d94dd123e6c442ba80) was picked with the following changes from the upstream:
    1.  Ignored changes in `arch/x86/kernel/hw_breakpoint.c`. The modified function `within_cpu_entry()` doesn't exist in `ciqlts8_6` revision. The conflict might have been resolved purely by cherry picking 24ae0c91cbc57c2deb0401bd653453a508acdcee, d390e6de89d30402bd06056c40cea72328aec9b1, 97417cb9ad4ed052d7a4c5c0d75db1ff1b0981fb, but that would have resulted in introducing dead code: `within_area()` and `within_cpu_entry()` functions.
    2.  Moved the `arch/x86/include/asm/pgtable_areas.h` changes to `arch/x86/include/asm/cpu_entry_area.h`. This had to be done because of the 186525bd6b83efc592672e2d6185e4d7c810d2b4 commit missing from `ciqlts8_6` history, which factored out the relevant #defines from `cpu_entry_area.h` to `pgtable_areas.h`. It was decided not to backport this commit as prerequisite since it's too extensive and making changes not related to the patch.
    3.  Made small adaptation of changes relating to `cea_offset()` definitions in `arch/x86/mm/cpu_entry_area.c` which was necessary because of the dc4e0021b00b5a4ecba56fae509217776592b0aa commit missing from `ciqlts8_6` history. It was too functionality-intrusive to backport as prerequisite for auto resolution of just this single conflict.
4.  Commits `3` (80d72a8f76e8f3f0b5a70b8c7022578e17bde8e7) and `4` (97650148a15e0b30099d6175ffe278b9f55ec66a) expand on the `2` bugfix so must had been included for completeness.
5.  Commit `5` (a3f547addcaa10df5a226526bc9e2d9a94542344) makes the randomization implemented in `0` configurable, which it should have been from the beginning. Commits `2`, `3`, `4` were included also because they were `5`'s prerequisite:
    > Since we have 3f148f331814 ("x86/kasan: Map shadow for percpu pages on
    > demand") and followups, we can use the more relaxed guard
    > kasrl\_enabled() (in contrast to kaslr\_memory\_enabled()).


# kABI check: passed

    DEBUG=1 CVE=CVE-2023-0597 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_6-CVE-2023-0597

    [0/1] Check ABI of kernel [ciqlts8_6-CVE-2023-0597]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2023-0597/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2023-0597/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/22525584/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/22525585/kselftests--ciqlts8_6--run1.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2023-0597&#x2013;run1.log](<https://github.com/user-attachments/files/22525586/kselftests--ciqlts8_6-CVE-2023-0597--run1.log>)


## Comparison

The tests results for the reference kernel and the patch are the same

    $ ktests.xsh diff  kselftests*.log

    Column    File
    --------  ---------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6-CVE-2023-0597--run1.log
    
    TestCase                                     Status0  Status1  Summary
    android:run.sh                               skip     skip     same
    bpf:get_cgroup_id_user                       pass     pass     same
    bpf:test_bpftool.sh                          pass     pass     same
    bpf:test_bpftool_build.sh                    pass     pass     same
    bpf:test_bpftool_metadata.sh                 pass     pass     same
    bpf:test_cgroup_storage                      pass     pass     same
    bpf:test_dev_cgroup                          pass     pass     same
    bpf:test_doc_build.sh                        pass     pass     same
    bpf:test_flow_dissector.sh                   pass     pass     same
    bpf:test_lirc_mode2.sh                       pass     pass     same
    bpf:test_lpm_map                             pass     pass     same
    bpf:test_lru_map                             fail     fail     same
    bpf:test_lwt_ip_encap.sh                     pass     pass     same
    bpf:test_lwt_seg6local.sh                    pass     pass     same
    bpf:test_netcnt                              pass     pass     same
    bpf:test_offload.py                          pass     pass     same
    bpf:test_skb_cgroup_id.sh                    pass     pass     same
    bpf:test_sock                                pass     pass     same
    bpf:test_sock_addr.sh                        pass     pass     same
    bpf:test_sysctl                              pass     pass     same
    bpf:test_tag                                 pass     pass     same
    bpf:test_tc_edt.sh                           pass     pass     same
    bpf:test_tc_tunnel.sh                        pass     pass     same
    bpf:test_tcp_check_syncookie.sh              pass     pass     same
    bpf:test_tcpnotify_user                      pass     pass     same
    bpf:test_tunnel.sh                           pass     pass     same
    bpf:test_verifier                            pass     pass     same
    bpf:test_verifier_log                        pass     pass     same
    bpf:test_xdp_meta.sh                         pass     pass     same
    bpf:test_xdp_redirect.sh                     pass     pass     same
    bpf:test_xdp_veth.sh                         pass     pass     same
    bpf:test_xdp_vlan_mode_generic.sh            pass     pass     same
    bpf:test_xdp_vlan_mode_native.sh             pass     pass     same
    bpf:test_xdping.sh                           pass     pass     same
    bpf:urandom_read                             pass     pass     same
    breakpoints:breakpoint_test                  pass     pass     same
    capabilities:test_execve                     pass     pass     same
    core:close_range_test                        pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh               pass     pass     same
    cpufreq:main.sh                              fail     fail     same
    exec:execveat                                pass     pass     same
    firmware:fw_run_tests.sh                     skip     skip     same
    fpu:run_test_fpu.sh                          skip     skip     same
    fpu:test_fpu                                 pass     pass     same
    ftrace:ftracetest                            fail     fail     same
    futex:run.sh                                 pass     pass     same
    gpio:gpio-mockup.sh                          fail     fail     same
    intel_pstate:run.sh                          pass     pass     same
    ipc:msgque                                   pass     pass     same
    kcmp:kcmp_test                               pass     pass     same
    kexec:test_kexec_file_load.sh                skip     skip     same
    kexec:test_kexec_load.sh                     skip     skip     same
    kvm:access_tracking_perf_test                fail     fail     same
    kvm:amx_test                                 fail     fail     same
    kvm:cr4_cpuid_sync_test                      fail     fail     same
    kvm:debug_regs                               fail     fail     same
    kvm:demand_paging_test                       pass     pass     same
    kvm:dirty_log_perf_test                      pass     pass     same
    kvm:dirty_log_test                           fail     fail     same
    kvm:emulator_error_test                      fail     fail     same
    kvm:evmcs_test                               fail     fail     same
    kvm:get_cpuid_test                           fail     fail     same
    kvm:get_msr_index_features                   fail     fail     same
    kvm:hardware_disable_test                    pass     pass     same
    kvm:hyperv_clock                             fail     fail     same
    kvm:hyperv_cpuid                             fail     fail     same
    kvm:hyperv_features                          fail     fail     same
    kvm:kvm_binary_stats_test                    pass     pass     same
    kvm:kvm_create_max_vcpus                     skip     skip     same
    kvm:kvm_page_table_test                      pass     pass     same
    kvm:kvm_pv_test                              fail     fail     same
    kvm:memslot_modification_stress_test         pass     pass     same
    kvm:memslot_perf_test                        fail     fail     same
    kvm:mmio_warning_test                        fail     fail     same
    kvm:mmu_role_test                            fail     fail     same
    kvm:platform_info_test                       fail     fail     same
    kvm:rseq_test                                fail     fail     same
    kvm:set_boot_cpu_id                          fail     fail     same
    kvm:set_memory_region_test                   pass     pass     same
    kvm:set_sregs_test                           fail     fail     same
    kvm:smm_test                                 fail     fail     same
    kvm:state_test                               fail     fail     same
    kvm:steal_time                               pass     pass     same
    kvm:svm_int_ctl_test                         fail     fail     same
    kvm:svm_vmcall_test                          fail     fail     same
    kvm:sync_regs_test                           fail     fail     same
    kvm:tsc_msrs_test                            fail     fail     same
    kvm:userspace_msr_exit_test                  fail     fail     same
    kvm:vmx_apic_access_test                     fail     fail     same
    kvm:vmx_close_while_nested_test              fail     fail     same
    kvm:vmx_dirty_log_test                       fail     fail     same
    kvm:vmx_nested_tsc_scaling_test              fail     fail     same
    kvm:vmx_pmu_msrs_test                        fail     fail     same
    kvm:vmx_preemption_timer_test                fail     fail     same
    kvm:vmx_set_nested_state_test                fail     fail     same
    kvm:vmx_tsc_adjust_test                      fail     fail     same
    kvm:xapic_ipi_test                           fail     fail     same
    kvm:xen_shinfo_test                          fail     fail     same
    kvm:xen_vmcall_test                          fail     fail     same
    kvm:xss_msr_test                             fail     fail     same
    lib:bitmap.sh                                skip     skip     same
    lib:prime_numbers.sh                         skip     skip     same
    lib:printf.sh                                skip     skip     same
    lib:scanf.sh                                 fail     fail     same
    livepatch:test-callbacks.sh                  pass     pass     same
    livepatch:test-ftrace.sh                     pass     pass     same
    livepatch:test-livepatch.sh                  pass     pass     same
    livepatch:test-shadow-vars.sh                pass     pass     same
    livepatch:test-state.sh                      pass     pass     same
    membarrier:membarrier_test_multi_thread      pass     pass     same
    membarrier:membarrier_test_single_thread     pass     pass     same
    memfd:memfd_test                             pass     pass     same
    memfd:run_fuse_test.sh                       fail     fail     same
    memfd:run_hugetlbfs_test.sh                  pass     pass     same
    memory-hotplug:mem-on-off-test.sh            pass     pass     same
    mount:run_tests.sh                           pass     pass     same
    net/forwarding:bridge_port_isolation.sh      pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh          pass     pass     same
    net/forwarding:bridge_vlan_aware.sh          fail     fail     same
    net/forwarding:bridge_vlan_unaware.sh        pass     pass     same
    net/forwarding:ethtool.sh                    fail     fail     same
    net/forwarding:gre_multipath.sh              fail     fail     same
    net/forwarding:ip6_forward_instats_vrf.sh    fail     fail     same
    net/forwarding:ipip_flat_gre.sh              pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh          pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh         pass     pass     same
    net/forwarding:ipip_hier_gre.sh              pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh          pass     pass     same
    net/forwarding:loopback.sh                   skip     skip     same
    net/forwarding:mirror_gre.sh                 fail     fail     same
    net/forwarding:mirror_gre_bound.sh           pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh       pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh       pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh   pass     pass     same
    net/forwarding:mirror_gre_changes.sh         fail     fail     same
    net/forwarding:mirror_gre_flower.sh          fail     fail     same
    net/forwarding:mirror_gre_lag_lacp.sh        pass     pass     same
    net/forwarding:mirror_gre_neigh.sh           pass     pass     same
    net/forwarding:mirror_gre_nh.sh              pass     pass     same
    net/forwarding:mirror_gre_vlan.sh            pass     pass     same
    net/forwarding:mirror_vlan.sh                pass     pass     same
    net/forwarding:router.sh                     fail     fail     same
    net/forwarding:router_bridge.sh              pass     pass     same
    net/forwarding:router_bridge_vlan.sh         pass     pass     same
    net/forwarding:router_broadcast.sh           fail     fail     same
    net/forwarding:router_multicast.sh           fail     fail     same
    net/forwarding:router_multipath.sh           fail     fail     same
    net/forwarding:router_vid_1.sh               pass     pass     same
    net/forwarding:tc_chains.sh                  pass     pass     same
    net/forwarding:tc_flower.sh                  pass     pass     same
    net/forwarding:tc_flower_router.sh           pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh              pass     pass     same
    net/forwarding:tc_shblocks.sh                pass     pass     same
    net/forwarding:tc_vlan_modify.sh             pass     pass     same
    net/forwarding:vxlan_asymmetric.sh           pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh            fail     fail     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh  pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh            fail     fail     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh  pass     pass     same
    net/forwarding:vxlan_symmetric.sh            pass     pass     same
    net/mptcp:diag.sh                            pass     pass     same
    net/mptcp:mptcp_connect.sh                   pass     pass     same
    net/mptcp:mptcp_sockopt.sh                   pass     pass     same
    net/mptcp:pm_netlink.sh                      pass     pass     same
    net:bareudp.sh                               pass     pass     same
    net:devlink_port_split.py                    pass     pass     same
    net:drop_monitor_tests.sh                    skip     skip     same
    net:fcnal-test.sh                            pass     pass     same
    net:fib-onlink-tests.sh                      pass     pass     same
    net:fib_rule_tests.sh                        fail     fail     same
    net:fib_tests.sh                             pass     pass     same
    net:gre_gso.sh                               pass     pass     same
    net:icmp_redirect.sh                         pass     pass     same
    net:ip6_gre_headroom.sh                      pass     pass     same
    net:ipv6_flowlabel.sh                        pass     pass     same
    net:l2tp.sh                                  pass     pass     same
    net:msg_zerocopy.sh                          fail     fail     same
    net:netdevice.sh                             pass     pass     same
    net:pmtu.sh                                  pass     pass     same
    net:psock_snd.sh                             fail     fail     same
    net:reuseaddr_conflict                       pass     pass     same
    net:reuseport_bpf                            pass     pass     same
    net:reuseport_bpf_cpu                        pass     pass     same
    net:reuseport_bpf_numa                       pass     pass     same
    net:reuseport_dualstack                      pass     pass     same
    net:rtnetlink.sh                             skip     skip     same
    net:run_afpackettests                        pass     pass     same
    net:run_netsocktests                         pass     pass     same
    net:rxtimestamp.sh                           pass     pass     same
    net:so_txtime.sh                             fail     fail     same
    net:test_bpf.sh                              pass     pass     same
    net:test_vxlan_fdb_changelink.sh             pass     pass     same
    net:tls                                      pass     pass     same
    net:traceroute.sh                            pass     pass     same
    net:udpgro.sh                                fail     fail     same
    net:udpgro_bench.sh                          fail     fail     same
    net:udpgso.sh                                pass     pass     same
    net:veth.sh                                  fail     fail     same
    net:vrf-xfrm-tests.sh                        pass     pass     same
    netfilter:conntrack_icmp_related.sh          fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh         fail     fail     same
    netfilter:ipvs.sh                            skip     skip     same
    netfilter:nft_flowtable.sh                   fail     fail     same
    netfilter:nft_meta.sh                        pass     pass     same
    netfilter:nft_nat.sh                         skip     skip     same
    netfilter:nft_queue.sh                       skip     skip     same
    nsfs:owner                                   pass     pass     same
    nsfs:pidns                                   pass     pass     same
    proc:fd-001-lookup                           pass     pass     same
    proc:fd-002-posix-eq                         pass     pass     same
    proc:fd-003-kthread                          pass     pass     same
    proc:proc-loadavg-001                        pass     pass     same
    proc:proc-self-map-files-001                 pass     pass     same
    proc:proc-self-map-files-002                 fail     fail     same
    proc:proc-self-syscall                       pass     pass     same
    proc:proc-self-wchan                         pass     pass     same
    proc:proc-uptime-001                         pass     pass     same
    proc:proc-uptime-002                         pass     pass     same
    proc:read                                    pass     pass     same
    proc:setns-dcache                            fail     fail     same
    pstore:pstore_post_reboot_tests              skip     skip     same
    pstore:pstore_tests                          fail     fail     same
    ptrace:peeksiginfo                           pass     pass     same
    ptrace:vmaccess                              fail     fail     same
    rseq:basic_percpu_ops_test                   pass     pass     same
    rseq:basic_test                              pass     pass     same
    rseq:param_test                              pass     pass     same
    rseq:param_test_benchmark                    pass     pass     same
    rseq:param_test_compare_twice                pass     pass     same
    rseq:run_param_test.sh                       fail     fail     same
    sgx:test_sgx                                 fail     fail     same
    sigaltstack:sas                              pass     pass     same
    size:get_size                                pass     pass     same
    splice:default_file_splice_read.sh           pass     pass     same
    static_keys:test_static_keys.sh              skip     skip     same
    tc-testing:tdc.sh                            pass     pass     same
    timens:clock_nanosleep                       pass     pass     same
    timens:exec                                  pass     pass     same
    timens:procfs                                pass     pass     same
    timens:timens                                pass     pass     same
    timens:timer                                 pass     pass     same
    timens:timerfd                               pass     pass     same
    timers:inconsistency-check                   fail     fail     same
    timers:mqueue-lat                            pass     pass     same
    timers:nanosleep                             pass     pass     same
    timers:nsleep-lat                            fail     fail     same
    timers:posix_timers                          pass     pass     same
    timers:rtcpie                                pass     pass     same
    timers:set-timer-lat                         fail     fail     same
    timers:threadtest                            pass     pass     same
    tpm2:test_smoke.sh                           fail     fail     same
    tpm2:test_space.sh                           fail     fail     same
    vm:run_vmtests                               fail     fail     same
    x86:amx_64                                   fail     fail     same
    x86:check_initial_reg_state_64               pass     pass     same
    x86:corrupt_xstate_header_64                 pass     pass     same
    x86:fsgsbase_64                              pass     pass     same
    x86:fsgsbase_restore_64                      pass     pass     same
    x86:ioperm_64                                pass     pass     same
    x86:iopl_64                                  pass     pass     same
    x86:mov_ss_trap_64                           pass     pass     same
    x86:mpx-mini-test_64                         fail     fail     same
    x86:protection_keys_64                       pass     pass     same
    x86:sigaltstack_64                           pass     pass     same
    x86:sigreturn_64                             pass     pass     same
    x86:single_step_syscall_64                   pass     pass     same
    x86:syscall_nt_64                            pass     pass     same
    x86:sysret_rip_64                            pass     pass     same
    x86:sysret_ss_attrs_64                       pass     pass     same
    x86:test_mremap_vdso_64                      pass     pass     same
    x86:test_vdso_64                             pass     pass     same
    x86:test_vsyscall_64                         pass     pass     same
    zram:zram.sh                                 pass     pass     same

