### PR TITLE
[LTS 8.6] CVE-2022-42720

### DIFF
--- a/net/wireless/scan.c
+++ b/net/wireless/scan.c
@@ -143,18 +143,12 @@ static inline void bss_ref_get(struct cfg80211_registered_device *rdev,
 	lockdep_assert_held(&rdev->bss_lock);
 
 	bss->refcount++;
-	if (bss->pub.hidden_beacon_bss) {
-		bss = container_of(bss->pub.hidden_beacon_bss,
-				   struct cfg80211_internal_bss,
-				   pub);
-		bss->refcount++;
-	}
-	if (bss->pub.transmitted_bss) {
-		bss = container_of(bss->pub.transmitted_bss,
-				   struct cfg80211_internal_bss,
-				   pub);
-		bss->refcount++;
-	}
+
+	if (bss->pub.hidden_beacon_bss)
+		bss_from_pub(bss->pub.hidden_beacon_bss)->refcount++;
+
+	if (bss->pub.transmitted_bss)
+		bss_from_pub(bss->pub.transmitted_bss)->refcount++;
 }
 
 static inline void bss_ref_put(struct cfg80211_registered_device *rdev,
@@ -1734,6 +1728,8 @@ cfg80211_bss_update(struct cfg80211_registered_device *rdev,
 		new->refcount = 1;
 		INIT_LIST_HEAD(&new->hidden_list);
 		INIT_LIST_HEAD(&new->pub.nontrans_list);
+		/* we'll set this later if it was non-NULL */
+		new->pub.transmitted_bss = NULL;
 
 		if (rcu_access_pointer(tmp->pub.proberesp_ies)) {
 			hidden = rb_find_bss(rdev, tmp, BSS_CMP_HIDE_ZLEN);
@@ -1985,10 +1981,15 @@ cfg80211_inform_single_bss_data(struct wiphy *wiphy,
 		spin_lock_bh(&rdev->bss_lock);
 		if (cfg80211_add_nontrans_list(non_tx_data->tx_bss,
 					       &res->pub)) {
-			if (__cfg80211_unlink_bss(rdev, res))
+			if (__cfg80211_unlink_bss(rdev, res)) {
 				rdev->bss_generation++;
+				res = NULL;
+			}
 		}
 		spin_unlock_bh(&rdev->bss_lock);
+
+		if (!res)
+			return NULL;
 	}
 
 	trace_cfg80211_return_bss(&res->pub);

--- a/net/wireless/scan.c
+++ b/net/wireless/scan.c
@@ -1982,11 +1982,13 @@ cfg80211_inform_single_bss_data(struct wiphy *wiphy,
 		/* this is a nontransmitting bss, we need to add it to
 		 * transmitting bss' list if it is not there
 		 */
+		spin_lock_bh(&rdev->bss_lock);
 		if (cfg80211_add_nontrans_list(non_tx_data->tx_bss,
 					       &res->pub)) {
 			if (__cfg80211_unlink_bss(rdev, res))
 				rdev->bss_generation++;
 		}
+		spin_unlock_bh(&rdev->bss_lock);
 	}
 
 	trace_cfg80211_return_bss(&res->pub);


### PR DESCRIPTION
[LTS 8.6]
CVE-2022-42720
VULN-3807


# Problem

<https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=0b7808818cb9df6680f98996b8e9a439fa7bcc2f>

> wifi: cfg80211: fix BSS refcounting bugs
> 
> There are multiple refcounting bugs related to multi-BSSID:
>  - In bss\_ref\_get(), if the BSS has a hidden\_beacon\_bss, then
>    the bss pointer is overwritten before checking for the
>    transmitted BSS, which is clearly wrong. Fix this by using
>    the bss\_from\_pub() macro.
> 
>  - In cfg80211\_bss\_update() we copy the transmitted\_bss pointer
>    from tmp into new, but then if we release new, we'll unref
>    it erroneously. We already set the pointer and ref it, but
>    need to NULL it since it was copied from the tmp data.
> 
>  - In cfg80211\_inform\_single\_bss\_data(), if adding to the non-
>    transmitted list fails, we unlink the BSS and yet still we
>    return it, but this results in returning an entry without
>    a reference. We shouldn't return it anyway if it was broken
>    enough to not get added there.
> 
> This fixes CVE-2022-42720.


# Affected: yes

The official bug source tagged by the bug fix 0b7808818cb9df6680f98996b8e9a439fa7bcc2f is a3584f56de1c808d4383a275b4a74467b19e5645. This commit can't be found in `ciqlts8_6`'s history neither natively nor as a backport, although the code introduced by a3584f56de1c808d4383a275b4a74467b19e5645 can be found in the bulk commit e19ec644e33dc798b1499d8c0482e2a70dfc1b22. Along with the naive cherry-pick generating conflicts this situation required a case-by-case analysis of the issues addressed by 0b7808818cb9df6680f98996b8e9a439fa7bcc2f to confirm their applicability to LTS 8.6 codebase.


## `bss_ref_get()`

> In bss\_ref\_get(), if the BSS has a hidden\_beacon\_bss, then the bss pointer is overwritten before checking for the transmitted BSS, which is clearly wrong. Fix this by using the bss\_from\_pub() macro.

This bug applies to LTS 8.6 with the code path being

<https://github.com/ctrliq/kernel-src-tree/blob/0f0d831f82fba26db30b6b053e86984e56975d66/net/wireless/scan.c#L147-L149>

then

<https://github.com/ctrliq/kernel-src-tree/blob/0f0d831f82fba26db30b6b053e86984e56975d66/net/wireless/scan.c#L152>


## `cfg80211_bss_update()`

> In cfg80211\_bss\_update() we copy the transmitted\_bss pointer from tmp into new, but then if we release new, we'll unref it erroneously. We already set the pointer and ref it, but need to NULL it since it was copied from the tmp data.

This bug applies to LTS 8.6. Below the description interspersed with links to the relevant `ciqlts8_6` code fragments:

> In cfg80211\_bss\_update() we copy the transmitted\_bss pointer from tmp into new

<https://github.com/ctrliq/kernel-src-tree/blob/0f0d831f82fba26db30b6b053e86984e56975d66/net/wireless/scan.c#L1733>

> but then if we release new,

<https://github.com/ctrliq/kernel-src-tree/blob/0f0d831f82fba26db30b6b053e86984e56975d66/net/wireless/scan.c#L1759>

<https://github.com/ctrliq/kernel-src-tree/blob/0f0d831f82fba26db30b6b053e86984e56975d66/net/wireless/scan.c#L1766>

> we'll unref it erroneously

<https://github.com/ctrliq/kernel-src-tree/blob/0f0d831f82fba26db30b6b053e86984e56975d66/net/wireless/scan.c#L181>

> We already set the pointer and ref it

<https://github.com/ctrliq/kernel-src-tree/blob/0f0d831f82fba26db30b6b053e86984e56975d66/net/wireless/scan.c#L1777-L1778>

> but need to NULL it since it was copied from the tmp data.


<a id="org128241f"></a>

## `cfg80211_inform_single_bss_data()`

> In cfg80211\_inform\_single\_bss\_data(), if adding to the non- transmitted list fails, we unlink the BSS and yet still we return it, but this results in returning an entry without a reference. We shouldn't return it anyway if it was broken enough to not get added there.

This bug applies to LTS 8.6. Failure of adding to the nontransmitted list and unlinking:

<https://github.com/ctrliq/kernel-src-tree/blob/0f0d831f82fba26db30b6b053e86984e56975d66/net/wireless/scan.c#L1985-L1989>

Returning the value without a reference:

<https://github.com/ctrliq/kernel-src-tree/blob/0f0d831f82fba26db30b6b053e86984e56975d66/net/wireless/scan.c#L1994>

It was arguably introduced earlier than a3584f56de1c808d4383a275b4a74467b19e5645, namely in 0b8fb8235be8be99a197e8d948fc0a2df8dc261a.


# Solution

Applying 0b7808818cb9df6680f98996b8e9a439fa7bcc2f required pulling in 8a610cf5bfc8f30e6d7fc1a2c5c196c0d8d909c4 to avoid conflicts for the [cfg80211\_inform\_single\_bss\_data()](#org128241f) case. Coincidentally, another bug was fixed with it (no CVE associated). From the commit's message:

> Synchronize additions to nontrans\_list of transmitting BSS with
> bss\_lock to avoid races. Also when cfg80211\_add\_nontrans\_list() fails
> \_\_cfg80211\_unlink\_bss() needs bss\_lock to be held (has lockdep assert
> on bss\_lock). So protect the whole block with bss\_lock to avoid
> races and warnings. Found during code review.


# kABI check: passed

    $ DEBUG=1 CVE=CVE-2022-42720 ./ninja.sh _kabi_checked__x86_64--test--ciqlts8_6-CVE-2022-42720

    [0/1] Check ABI of kernel [ciqlts8_6-CVE-2022-42720]
    ++ uname -m
    + python3 /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/check-kabi -k /data/src/ctrliq-github/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64 -s vms/x86_64--build--ciqlts8_6/build_files/kernel-src-tree-ciqlts8_6-CVE-2022-42720/Module.symvers
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2022-42720/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/22542761/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/22542762/kselftests--ciqlts8_6--run1.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2022-42720&#x2013;run1.log](<https://github.com/user-attachments/files/22542763/kselftests--ciqlts8_6-CVE-2022-42720--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2022-42720&#x2013;run2.log](<https://github.com/user-attachments/files/22542764/kselftests--ciqlts8_6-CVE-2022-42720--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff  kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6-CVE-2022-42720--run1.log
    Status2   kselftests--ciqlts8_6-CVE-2022-42720--run2.log
    
    TestCase                                     Status0  Status1  Status2  Summary
    android:run.sh                               skip     skip     skip     same
    bpf:get_cgroup_id_user                       pass     pass     pass     same
    bpf:test_bpftool.sh                          pass     pass     pass     same
    bpf:test_bpftool_build.sh                    pass     pass     pass     same
    bpf:test_bpftool_metadata.sh                 pass     pass     pass     same
    bpf:test_cgroup_storage                      pass     pass     pass     same
    bpf:test_dev_cgroup                          pass     pass     pass     same
    bpf:test_doc_build.sh                        pass     pass     pass     same
    bpf:test_flow_dissector.sh                   pass     pass     pass     same
    bpf:test_lirc_mode2.sh                       pass     pass     pass     same
    bpf:test_lpm_map                             pass     pass     pass     same
    bpf:test_lru_map                             fail     fail     fail     same
    bpf:test_lwt_ip_encap.sh                     pass     pass     pass     same
    bpf:test_lwt_seg6local.sh                    pass     pass     pass     same
    bpf:test_netcnt                              pass     pass     pass     same
    bpf:test_offload.py                          pass     pass     pass     same
    bpf:test_skb_cgroup_id.sh                    pass     pass     pass     same
    bpf:test_sock                                pass     pass     pass     same
    bpf:test_sock_addr.sh                        pass     pass     pass     same
    bpf:test_sysctl                              pass     pass     pass     same
    bpf:test_tag                                 pass     pass     pass     same
    bpf:test_tc_edt.sh                           pass     pass     pass     same
    bpf:test_tc_tunnel.sh                        pass     pass     pass     same
    bpf:test_tcp_check_syncookie.sh              pass     pass     pass     same
    bpf:test_tcpnotify_user                      pass     pass     pass     same
    bpf:test_tunnel.sh                           pass     pass     pass     same
    bpf:test_verifier                            pass     pass     pass     same
    bpf:test_verifier_log                        pass     pass     pass     same
    bpf:test_xdp_meta.sh                         pass     pass     pass     same
    bpf:test_xdp_redirect.sh                     pass     pass     pass     same
    bpf:test_xdp_veth.sh                         pass     pass     pass     same
    bpf:test_xdp_vlan_mode_generic.sh            pass     pass     pass     same
    bpf:test_xdp_vlan_mode_native.sh             pass     pass     pass     same
    bpf:test_xdping.sh                           pass     pass     pass     same
    bpf:urandom_read                             pass     pass     pass     same
    breakpoints:breakpoint_test                  pass     pass     pass     same
    capabilities:test_execve                     pass     pass     pass     same
    core:close_range_test                        pass     pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh               pass     pass     pass     same
    cpufreq:main.sh                              fail     fail     fail     same
    exec:execveat                                pass     pass     pass     same
    firmware:fw_run_tests.sh                     skip     skip     skip     same
    fpu:run_test_fpu.sh                          skip     skip     skip     same
    fpu:test_fpu                                 pass     pass     pass     same
    ftrace:ftracetest                            fail     fail     fail     same
    futex:run.sh                                 pass     pass     pass     same
    gpio:gpio-mockup.sh                          fail     fail     fail     same
    intel_pstate:run.sh                          pass     pass     pass     same
    ipc:msgque                                   pass     pass     pass     same
    kcmp:kcmp_test                               pass     pass     pass     same
    kexec:test_kexec_file_load.sh                skip     skip     skip     same
    kexec:test_kexec_load.sh                     skip     skip     skip     same
    kvm:access_tracking_perf_test                fail     fail     fail     same
    kvm:amx_test                                 fail     fail     fail     same
    kvm:cr4_cpuid_sync_test                      fail     fail     fail     same
    kvm:debug_regs                               fail     fail     fail     same
    kvm:demand_paging_test                       pass     pass     pass     same
    kvm:dirty_log_perf_test                      pass     pass     pass     same
    kvm:dirty_log_test                           fail     fail     fail     same
    kvm:emulator_error_test                      fail     fail     fail     same
    kvm:evmcs_test                               fail     fail     fail     same
    kvm:get_cpuid_test                           fail     fail     fail     same
    kvm:get_msr_index_features                   fail     fail     fail     same
    kvm:hardware_disable_test                    pass     pass     pass     same
    kvm:hyperv_clock                             fail     fail     fail     same
    kvm:hyperv_cpuid                             fail     fail     fail     same
    kvm:hyperv_features                          fail     fail     fail     same
    kvm:kvm_binary_stats_test                    pass     pass     pass     same
    kvm:kvm_create_max_vcpus                     skip     skip     skip     same
    kvm:kvm_page_table_test                      pass     pass     pass     same
    kvm:kvm_pv_test                              fail     fail     fail     same
    kvm:memslot_modification_stress_test         pass     pass     pass     same
    kvm:memslot_perf_test                        fail     fail     fail     same
    kvm:mmio_warning_test                        fail     fail     fail     same
    kvm:mmu_role_test                            fail     fail     fail     same
    kvm:platform_info_test                       fail     fail     fail     same
    kvm:rseq_test                                fail     fail     fail     same
    kvm:set_boot_cpu_id                          fail     fail     fail     same
    kvm:set_memory_region_test                   pass     pass     pass     same
    kvm:set_sregs_test                           fail     fail     fail     same
    kvm:smm_test                                 fail     fail     fail     same
    kvm:state_test                               fail     fail     fail     same
    kvm:steal_time                               pass     pass     pass     same
    kvm:svm_int_ctl_test                         fail     fail     fail     same
    kvm:svm_vmcall_test                          fail     fail     fail     same
    kvm:sync_regs_test                           fail     fail     fail     same
    kvm:tsc_msrs_test                            fail     fail     fail     same
    kvm:userspace_msr_exit_test                  fail     fail     fail     same
    kvm:vmx_apic_access_test                     fail     fail     fail     same
    kvm:vmx_close_while_nested_test              fail     fail     fail     same
    kvm:vmx_dirty_log_test                       fail     fail     fail     same
    kvm:vmx_nested_tsc_scaling_test              fail     fail     fail     same
    kvm:vmx_pmu_msrs_test                        fail     fail     fail     same
    kvm:vmx_preemption_timer_test                fail     fail     fail     same
    kvm:vmx_set_nested_state_test                fail     fail     fail     same
    kvm:vmx_tsc_adjust_test                      fail     fail     fail     same
    kvm:xapic_ipi_test                           fail     fail     fail     same
    kvm:xen_shinfo_test                          fail     fail     fail     same
    kvm:xen_vmcall_test                          fail     fail     fail     same
    kvm:xss_msr_test                             fail     fail     fail     same
    lib:bitmap.sh                                skip     skip     skip     same
    lib:prime_numbers.sh                         skip     skip     skip     same
    lib:printf.sh                                skip     skip     skip     same
    lib:scanf.sh                                 fail     fail     fail     same
    livepatch:test-callbacks.sh                  pass     pass     pass     same
    livepatch:test-ftrace.sh                     pass     pass     pass     same
    livepatch:test-livepatch.sh                  pass     pass     pass     same
    livepatch:test-shadow-vars.sh                pass     pass     pass     same
    livepatch:test-state.sh                      pass     pass     pass     same
    membarrier:membarrier_test_multi_thread      pass     pass     pass     same
    membarrier:membarrier_test_single_thread     pass     pass     pass     same
    memfd:memfd_test                             pass     pass     pass     same
    memfd:run_fuse_test.sh                       fail     fail     fail     same
    memfd:run_hugetlbfs_test.sh                  pass     pass     pass     same
    memory-hotplug:mem-on-off-test.sh            pass     pass     pass     same
    mount:run_tests.sh                           pass     pass     pass     same
    net/forwarding:bridge_port_isolation.sh      pass     pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh          pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh          fail     fail     fail     same
    net/forwarding:bridge_vlan_unaware.sh        pass     pass     pass     same
    net/forwarding:ethtool.sh                    fail     fail     fail     same
    net/forwarding:gre_multipath.sh              fail     fail     fail     same
    net/forwarding:ip6_forward_instats_vrf.sh    fail     fail     fail     same
    net/forwarding:ipip_flat_gre.sh              pass     pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh          pass     pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh         pass     pass     pass     same
    net/forwarding:ipip_hier_gre.sh              pass     pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh          pass     pass     pass     same
    net/forwarding:loopback.sh                   skip     skip     skip     same
    net/forwarding:mirror_gre.sh                 fail     fail     fail     same
    net/forwarding:mirror_gre_bound.sh           pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh       pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh       pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh   pass     pass     pass     same
    net/forwarding:mirror_gre_changes.sh         fail     fail     fail     same
    net/forwarding:mirror_gre_flower.sh          fail     fail     fail     same
    net/forwarding:mirror_gre_lag_lacp.sh        pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh           pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh              pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh            pass     pass     pass     same
    net/forwarding:mirror_vlan.sh                pass     pass     pass     same
    net/forwarding:router.sh                     fail     fail     fail     same
    net/forwarding:router_bridge.sh              pass     pass     pass     same
    net/forwarding:router_bridge_vlan.sh         pass     pass     pass     same
    net/forwarding:router_broadcast.sh           fail     fail     fail     same
    net/forwarding:router_multicast.sh           fail     fail     fail     same
    net/forwarding:router_multipath.sh           fail     fail     fail     same
    net/forwarding:router_vid_1.sh               pass     pass     pass     same
    net/forwarding:tc_chains.sh                  pass     pass     pass     same
    net/forwarding:tc_flower.sh                  pass     pass     pass     same
    net/forwarding:tc_flower_router.sh           pass     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh              pass     pass     pass     same
    net/forwarding:tc_shblocks.sh                pass     pass     pass     same
    net/forwarding:tc_vlan_modify.sh             pass     pass     pass     same
    net/forwarding:vxlan_asymmetric.sh           pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh  pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh  pass     pass     pass     same
    net/forwarding:vxlan_symmetric.sh            pass     pass     pass     same
    net/mptcp:diag.sh                            pass     pass     pass     same
    net/mptcp:mptcp_connect.sh                   pass     pass     pass     same
    net/mptcp:mptcp_sockopt.sh                   pass     pass     pass     same
    net/mptcp:pm_netlink.sh                      pass     pass     pass     same
    net:bareudp.sh                               pass     pass     pass     same
    net:devlink_port_split.py                    pass     pass     pass     same
    net:drop_monitor_tests.sh                    skip     skip     skip     same
    net:fcnal-test.sh                            pass     pass     pass     same
    net:fib-onlink-tests.sh                      pass     pass     pass     same
    net:fib_rule_tests.sh                        fail     fail     fail     same
    net:fib_tests.sh                             pass     pass     pass     same
    net:gre_gso.sh                               pass     pass     pass     same
    net:icmp_redirect.sh                         pass     pass     pass     same
    net:ip6_gre_headroom.sh                      pass     pass     pass     same
    net:ipv6_flowlabel.sh                        pass     pass     pass     same
    net:l2tp.sh                                  pass     pass     pass     same
    net:msg_zerocopy.sh                          fail     fail     fail     same
    net:netdevice.sh                             pass     pass     pass     same
    net:pmtu.sh                                  pass     pass     pass     same
    net:psock_snd.sh                             fail     fail     fail     same
    net:reuseaddr_conflict                       pass     pass     pass     same
    net:reuseport_bpf                            pass     pass     pass     same
    net:reuseport_bpf_cpu                        pass     pass     pass     same
    net:reuseport_bpf_numa                       pass     pass     pass     same
    net:reuseport_dualstack                      pass     pass     pass     same
    net:rtnetlink.sh                             skip     skip     skip     same
    net:run_afpackettests                        pass     pass     pass     same
    net:run_netsocktests                         pass     pass     pass     same
    net:rxtimestamp.sh                           pass     pass     pass     same
    net:so_txtime.sh                             fail     fail     fail     same
    net:test_bpf.sh                              pass     pass     pass     same
    net:test_vxlan_fdb_changelink.sh             pass     pass     pass     same
    net:tls                                      pass     pass     pass     same
    net:traceroute.sh                            pass     pass     pass     same
    net:udpgro.sh                                fail     fail     fail     same
    net:udpgro_bench.sh                          fail     fail     fail     same
    net:udpgso.sh                                pass     pass     pass     same
    net:veth.sh                                  fail     fail     fail     same
    net:vrf-xfrm-tests.sh                        pass     pass     pass     same
    netfilter:conntrack_icmp_related.sh          fail     fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh         fail     fail     fail     same
    netfilter:ipvs.sh                            skip     skip     skip     same
    netfilter:nft_flowtable.sh                   fail     fail     fail     same
    netfilter:nft_meta.sh                        pass     pass     pass     same
    netfilter:nft_nat.sh                         skip     skip     skip     same
    netfilter:nft_queue.sh                       skip     skip     skip     same
    nsfs:owner                                   pass     pass     pass     same
    nsfs:pidns                                   pass     pass     pass     same
    proc:fd-001-lookup                           pass     pass     pass     same
    proc:fd-002-posix-eq                         pass     pass     pass     same
    proc:fd-003-kthread                          pass     pass     pass     same
    proc:proc-loadavg-001                        pass     pass     pass     same
    proc:proc-self-map-files-001                 pass     pass     pass     same
    proc:proc-self-map-files-002                 fail     fail     fail     same
    proc:proc-self-syscall                       pass     pass     pass     same
    proc:proc-self-wchan                         pass     pass     pass     same
    proc:proc-uptime-001                         pass     pass     pass     same
    proc:proc-uptime-002                         pass     pass     pass     same
    proc:read                                    pass     pass     pass     same
    proc:setns-dcache                            fail     fail     fail     same
    pstore:pstore_post_reboot_tests              skip     skip     skip     same
    pstore:pstore_tests                          fail     fail     fail     same
    ptrace:peeksiginfo                           pass     pass     pass     same
    ptrace:vmaccess                              fail     fail     fail     same
    rseq:basic_percpu_ops_test                   pass     pass     pass     same
    rseq:basic_test                              pass     pass     pass     same
    rseq:param_test                              pass     pass     pass     same
    rseq:param_test_benchmark                    pass     pass     pass     same
    rseq:param_test_compare_twice                pass     pass     pass     same
    rseq:run_param_test.sh                       fail     fail     fail     same
    sgx:test_sgx                                 fail     fail     fail     same
    sigaltstack:sas                              pass     pass     pass     same
    size:get_size                                pass     pass     pass     same
    splice:default_file_splice_read.sh           pass     pass     pass     same
    static_keys:test_static_keys.sh              skip     skip     skip     same
    tc-testing:tdc.sh                            pass     pass     pass     same
    timens:clock_nanosleep                       pass     pass     pass     same
    timens:exec                                  pass     pass     pass     same
    timens:procfs                                pass     pass     pass     same
    timens:timens                                pass     pass     pass     same
    timens:timer                                 pass     pass     pass     same
    timens:timerfd                               pass     pass     pass     same
    timers:inconsistency-check                   fail     fail     fail     same
    timers:mqueue-lat                            pass     pass     pass     same
    timers:nanosleep                             pass     pass     pass     same
    timers:nsleep-lat                            fail     fail     fail     same
    timers:posix_timers                          pass     pass     pass     same
    timers:rtcpie                                pass     pass     pass     same
    timers:set-timer-lat                         fail     fail     fail     same
    timers:threadtest                            pass     pass     pass     same
    tpm2:test_smoke.sh                           fail     fail     fail     same
    tpm2:test_space.sh                           fail     fail     fail     same
    vm:run_vmtests                               fail     fail     fail     same
    x86:amx_64                                   fail     fail     fail     same
    x86:check_initial_reg_state_64               pass     pass     pass     same
    x86:corrupt_xstate_header_64                 pass     pass     pass     same
    x86:fsgsbase_64                              pass     pass     pass     same
    x86:fsgsbase_restore_64                      pass     pass     pass     same
    x86:ioperm_64                                pass     pass     pass     same
    x86:iopl_64                                  pass     pass     pass     same
    x86:mov_ss_trap_64                           pass     pass     pass     same
    x86:mpx-mini-test_64                         fail     fail     fail     same
    x86:protection_keys_64                       pass     pass     pass     same
    x86:sigaltstack_64                           pass     pass     pass     same
    x86:sigreturn_64                             pass     pass     pass     same
    x86:single_step_syscall_64                   pass     pass     pass     same
    x86:syscall_nt_64                            pass     pass     pass     same
    x86:sysret_rip_64                            pass     pass     pass     same
    x86:sysret_ss_attrs_64                       pass     pass     pass     same
    x86:test_mremap_vdso_64                      pass     pass     pass     same
    x86:test_vdso_64                             pass     pass     pass     same
    x86:test_vsyscall_64                         pass     pass     pass     same
    zram:zram.sh                                 pass     pass     pass     same

