### PR TITLE
[cbr79] Many VULNs 9-26-25

### DIFF
--- a/drivers/misc/vmw_vmci/vmci_queue_pair.c
+++ b/drivers/misc/vmw_vmci/vmci_queue_pair.c
@@ -938,6 +938,7 @@ static int qp_notify_peer_local(bool attach, struct vmci_handle handle)
 	u32 context_id = vmci_get_context_id();
 	struct vmci_event_qp ev;
 
+	memset(&ev, 0, sizeof(ev));
 	ev.msg.hdr.dst = vmci_make_handle(context_id, VMCI_EVENT_HANDLER);
 	ev.msg.hdr.src = vmci_make_handle(VMCI_HYPERVISOR_CONTEXT_ID,
 					  VMCI_CONTEXT_RESOURCE_ID);
@@ -1549,6 +1550,7 @@ static int qp_notify_peer(bool attach,
 	 * kernel.
 	 */
 
+	memset(&ev, 0, sizeof(ev));
 	ev.msg.hdr.dst = vmci_make_handle(peer_id, VMCI_EVENT_HANDLER);
 	ev.msg.hdr.src = vmci_make_handle(VMCI_HYPERVISOR_CONTEXT_ID,
 					  VMCI_CONTEXT_RESOURCE_ID);

--- a/drivers/scsi/lpfc/lpfc_sli.c
+++ b/drivers/scsi/lpfc/lpfc_sli.c
@@ -5441,9 +5441,9 @@ lpfc_sli4_get_ctl_attr(struct lpfc_hba *phba)
 	phba->sli4_hba.lnk_info.lnk_no =
 		bf_get(lpfc_cntl_attr_lnk_numb, cntl_attr);
 
-	memset(phba->BIOSVersion, 0, sizeof(phba->BIOSVersion));
-	strlcat(phba->BIOSVersion, (char *)cntl_attr->bios_ver_str,
+	memcpy(phba->BIOSVersion, cntl_attr->bios_ver_str,
 		sizeof(phba->BIOSVersion));
+	phba->BIOSVersion[sizeof(phba->BIOSVersion) - 1] = '\0';
 
 	lpfc_printf_log(phba, KERN_INFO, LOG_SLI,
 			"3086 lnk_type:%d, lnk_numb:%d, bios_ver:%s\n",

--- a/fs/ext4/namei.c
+++ b/fs/ext4/namei.c
@@ -1593,7 +1593,7 @@ static struct ext4_dir_entry_2 *do_split(handle_t *handle, struct inode *dir,
 	 * split it in half by count; each resulting block will have at least
 	 * half the space free.
 	 */
-	if (i > 0)
+	if (i >= 0)
 		split = count - move;
 	else
 		split = count/2;

--- a/net/sched/sch_hfsc.c
+++ b/net/sched/sch_hfsc.c
@@ -204,7 +204,10 @@ eltree_insert(struct hfsc_class *cl)
 static inline void
 eltree_remove(struct hfsc_class *cl)
 {
-	rb_erase(&cl->el_node, &cl->sched->eligible);
+	if (!RB_EMPTY_NODE(&cl->el_node)) {
+		rb_erase(&cl->el_node, &cl->sched->eligible);
+		RB_CLEAR_NODE(&cl->el_node);
+	}
 }
 
 static inline void
@@ -1225,7 +1228,8 @@ hfsc_qlen_notify(struct Qdisc *sch, unsigned long arg)
 	/* vttree is now handled in update_vf() so that update_vf(cl, 0, 0)
 	 * needs to be called explicitly to remove a class from vttree.
 	 */
-	update_vf(cl, 0, 0);
+	if (cl->cl_nactive)
+		update_vf(cl, 0, 0);
 	if (cl->cl_flags & HFSC_RSC)
 		eltree_remove(cl);
 }


### PR DESCRIPTION
### Commits

```
    misc/vmw_vmci: fix an infoleak in vmci_host_do_receive_datagram()

    jira VULN-65834
    cve CVE-2022-49788
    commit-author Alexander Potapenko <glider@google.com>
    commit e5b0d06d9b10f5f43101bd6598b076c347f9295f
```

```
    ext4: fix off-by-one error in do_split

    jira VULN-66668
    cve CVE-2025-23150
    commit-author Artem Sadovnikov <a.sadovnikov@ispras.ru>
    commit 94824ac9a8aaf2fb3c54b4bdde842db80ffa555d
```

```
    sch_hfsc: make hfsc_qlen_notify() idempotent

    jira VULN-71943
    cve CVE-2025-38177
    commit-author Cong Wang <xiyou.wangcong@gmail.com>
    commit 51eb3b65544c9efd6a1026889ee5fb5aa62da3bb
```

```
    scsi: lpfc: Use memcpy() for BIOS version

    jira VULN-72452
    cve CVE-2025-38332
    commit-author Daniel Wagner <wagi@kernel.org>
    commit ae82eaf4aeea060bb736c3e20c0568b67c701d7d
```

### Build Log

```
/home/brett/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 9s
x86_64 architecture detected, copying config
‘configs/kernel-3.10.0-x86_64.config’ -> ‘.config’
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqcbr7_9_many-vulns-9-26-25-f74987c"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf --silentoldconfig Kconfig
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/syscalls/../include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/syscalls/../include/generated/asm/syscalls_32.h
--
  H16TOFW firmware/edgeport/down2.fw
  IHEX2FW firmware/whiteheat_loader.fw
  IHEX2FW firmware/whiteheat.fw
  IHEX2FW firmware/keyspan_pda/keyspan_pda.fw
  IHEX2FW firmware/keyspan_pda/xircom_pgs.fw
[TIMER]{BUILD}: 630s
Making Modules
  INSTALL arch/x86/crypto/aesni-intel.ko
  INSTALL arch/x86/crypto/ablk_helper.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
--
  INSTALL /lib/firmware/whiteheat_loader.fw
  INSTALL /lib/firmware/whiteheat.fw
  INSTALL /lib/firmware/keyspan_pda/keyspan_pda.fw
  INSTALL /lib/firmware/keyspan_pda/xircom_pgs.fw
  DEPMOD  3.10.0-bmastbergen_ciqcbr7_9_many-vulns-9-26-25-f74987c+
[TIMER]{MODULES}: 19s
Making Install
sh ./arch/x86/boot/install.sh 3.10.0-bmastbergen_ciqcbr7_9_many-vulns-9-26-25-f74987c+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 30s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-3.10.0-bmastbergen_ciqcbr7_9_many-vulns-9-26-25-f74987c+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 9s
[TIMER]{BUILD}: 630s
[TIMER]{MODULES}: 19s
[TIMER]{INSTALL}: 30s
[TIMER]{TOTAL} 694s
Rebooting in 10 seconds

```

### Testing

[selftest-3.10.0-1160.119.1.el7_9.ciqcbr.8.1.x86_64-1.log](https://github.com/user-attachments/files/22564950/selftest-3.10.0-1160.119.1.el7_9.ciqcbr.8.1.x86_64-1.log)

[selftest-3.10.0-bmastbergen_ciqcbr7_9_many-vulns-9-26-25-f74987c+-1.log](https://github.com/user-attachments/files/22564952/selftest-3.10.0-bmastbergen_ciqcbr7_9_many-vulns-9-26-25-f74987c%2B-1.log)

```
brett@lycia ~/ciq/many-79-vulns-9-26-25
 % grep ^ok selftest-3.10.0-1160.119.1.el7_9.ciqcbr.8.1.x86_64-1.log | wc -l
4
brett@lycia ~/ciq/many-79-vulns-9-26-25
 % grep ^ok selftest-3.10.0-bmastbergen_ciqcbr7_9_many-vulns-9-26-25-f74987c+-1.log | wc -l
4
brett@lycia ~/ciq/many-79-vulns-9-26-25
 % grep ok <(diff -adU0 <(grep ^ok selftest-3.10.0-1160.119.1.el7_9.ciqcbr.8.1.x86_64-1.log | sort -h) <(grep ^ok selftest-3.10.0-bmastbergen_ciqcbr7_9_many-vulns-9-26-25-f74987c+-1.log | sort -h))
brett@lycia ~/ciq/many-79-vulns-9-26-25
 %
```