### PR TITLE
[FIPS 8 Compliant] Many CVES

### DIFF
--- a/fs/namespace.c
+++ b/fs/namespace.c
@@ -2290,6 +2290,10 @@ static int do_change_type(struct path *path, int ms_flags)
 		return -EINVAL;
 
 	namespace_lock();
+	if (!check_mnt(mnt)) {
+		err = -EINVAL;
+		goto out_unlock;
+	}
 	if (type == MS_SHARED) {
 		err = invent_group_ids(mnt, recurse);
 		if (err)

--- a/fs/namespace.c
+++ b/fs/namespace.c
@@ -2254,6 +2254,19 @@ static int graft_tree(struct mount *mnt, struct mount *p, struct mountpoint *mp)
 	return attach_recursive_mnt(mnt, p, mp, NULL);
 }
 
+static int may_change_propagation(const struct mount *m)
+{
+	struct mnt_namespace *ns = m->mnt_ns;
+
+        // it must be mounted in some namespace
+        if (IS_ERR_OR_NULL(ns))         // is_mounted()
+                return -EINVAL;
+        // and the caller must be admin in userns of that namespace
+        if (!ns_capable(ns->user_ns, CAP_SYS_ADMIN))
+                return -EPERM;
+        return 0;
+}
+
 /*
  * Sanity check the flags to change_mnt_propagation.
  */
@@ -2290,10 +2303,10 @@ static int do_change_type(struct path *path, int ms_flags)
 		return -EINVAL;
 
 	namespace_lock();
-	if (!check_mnt(mnt)) {
-		err = -EINVAL;
+	err = may_change_propagation(mnt);
+	if (err)
 		goto out_unlock;
-	}
+
 	if (type == MS_SHARED) {
 		err = invent_group_ids(mnt, recurse);
 		if (err)

--- a/net/core/filter.c
+++ b/net/core/filter.c
@@ -3497,13 +3497,20 @@ static int bpf_skb_net_grow(struct sk_buff *skb, u32 off, u32 len_diff,
 	if (skb_is_gso(skb)) {
 		struct skb_shared_info *shinfo = skb_shinfo(skb);
 
-		/* Due to header grow, MSS needs to be downgraded. */
-		if (!(flags & BPF_F_ADJ_ROOM_FIXED_GSO))
-			skb_decrease_gso_size(shinfo, len_diff);
-
 		/* Header must be checked, and gso_segs recomputed. */
 		shinfo->gso_type |= gso_type;
 		shinfo->gso_segs = 0;
+
+		/* Due to header growth, MSS needs to be downgraded.
+		 * There is a BUG_ON() when segmenting the frag_list with
+		 * head_frag true, so linearize the skb after downgrading
+		 * the MSS.
+		 */
+		if (!(flags & BPF_F_ADJ_ROOM_FIXED_GSO)) {
+			skb_decrease_gso_size(shinfo, len_diff);
+			if (shinfo->frag_list)
+				return skb_linearize(skb);
+		}
 	}
 
 	return 0;

--- a/net/ipv4/udp_offload.c
+++ b/net/ipv4/udp_offload.c
@@ -11,6 +11,7 @@
  */
 
 #include <linux/skbuff.h>
+#include <net/ip6_checksum.h>
 #include <net/udp.h>
 #include <net/protocol.h>
 #include <net/inet_common.h>
@@ -276,8 +277,26 @@ struct sk_buff *__udp_gso_segment(struct sk_buff *gso_skb,
 	__sum16 check;
 	__be16 newlen;
 
-	if (skb_shinfo(gso_skb)->gso_type & SKB_GSO_FRAGLIST)
-		return __udp_gso_segment_list(gso_skb, features, is_ipv6);
+	if (skb_shinfo(gso_skb)->gso_type & SKB_GSO_FRAGLIST) {
+		 /* Detect modified geometry and pass those to skb_segment. */
+		if (skb_pagelen(gso_skb) - sizeof(*uh) == skb_shinfo(gso_skb)->gso_size)
+			return __udp_gso_segment_list(gso_skb, features, is_ipv6);
+
+		 /* Setup csum, as fraglist skips this in udp4_gro_receive. */
+		gso_skb->csum_start = skb_transport_header(gso_skb) - gso_skb->head;
+		gso_skb->csum_offset = offsetof(struct udphdr, check);
+		gso_skb->ip_summed = CHECKSUM_PARTIAL;
+
+		uh = udp_hdr(gso_skb);
+		if (is_ipv6)
+			uh->check = ~udp_v6_check(gso_skb->len,
+						  &ipv6_hdr(gso_skb)->saddr,
+						  &ipv6_hdr(gso_skb)->daddr, 0);
+		else
+			uh->check = ~udp_v4_check(gso_skb->len,
+						  ip_hdr(gso_skb)->saddr,
+						  ip_hdr(gso_skb)->daddr, 0);
+	}
 
 	mss = skb_shinfo(gso_skb)->gso_size;
 	if (gso_skb->len <= sizeof(*uh) + mss)

--- a/net/ipv4/udp_offload.c
+++ b/net/ipv4/udp_offload.c
@@ -276,11 +276,16 @@ struct sk_buff *__udp_gso_segment(struct sk_buff *gso_skb,
 	bool copy_dtor;
 	__sum16 check;
 	__be16 newlen;
+	int ret = 0;
 
 	if (skb_shinfo(gso_skb)->gso_type & SKB_GSO_FRAGLIST) {
 		 /* Detect modified geometry and pass those to skb_segment. */
 		if (skb_pagelen(gso_skb) - sizeof(*uh) == skb_shinfo(gso_skb)->gso_size)
 			return __udp_gso_segment_list(gso_skb, features, is_ipv6);
+
+		ret = __skb_linearize(gso_skb);
+		if (ret)
+			return ERR_PTR(ret);
 
 		 /* Setup csum, as fraglist skips this in udp4_gro_receive. */
 		gso_skb->csum_start = skb_transport_header(gso_skb) - gso_skb->head;

--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -398,6 +398,8 @@ EXPORT_SYMBOL_GPL(vsock_enqueue_accept);
 
 static bool vsock_use_local_transport(unsigned int remote_cid)
 {
+	lockdep_assert_held(&vsock_register_mutex);
+
 	if (!transport_local)
 		return false;
 
@@ -455,6 +457,8 @@ int vsock_assign_transport(struct vsock_sock *vsk, struct vsock_sock *psk)
 
 	remote_flags = vsk->remote_addr.svm_flags;
 
+	mutex_lock(&vsock_register_mutex);
+
 	switch (sk->sk_type) {
 	case SOCK_DGRAM:
 		new_transport = transport_dgram;
@@ -469,12 +473,15 @@ int vsock_assign_transport(struct vsock_sock *vsk, struct vsock_sock *psk)
 			new_transport = transport_h2g;
 		break;
 	default:
-		return -ESOCKTNOSUPPORT;
+		ret = -ESOCKTNOSUPPORT;
+		goto err;
 	}
 
 	if (vsk->transport) {
-		if (vsk->transport == new_transport)
-			return 0;
+		if (vsk->transport == new_transport) {
+			ret = 0;
+			goto err;
+		}
 
 		/* transport->release() must be called with sock lock acquired.
 		 * This path can only be taken during vsock_stream_connect(),
@@ -489,8 +496,16 @@ int vsock_assign_transport(struct vsock_sock *vsk, struct vsock_sock *psk)
 	/* We increase the module refcnt to prevent the transport unloading
 	 * while there are open sockets assigned to it.
 	 */
-	if (!new_transport || !try_module_get(new_transport->module))
-		return -ENODEV;
+	if (!new_transport || !try_module_get(new_transport->module)) {
+		ret = -ENODEV;
+		goto err;
+	}
+
+	/* It's safe to release the mutex after a successful try_module_get().
+	 * Whichever transport `new_transport` points at, it won't go away until
+	 * the last module_put() below or in vsock_deassign_transport().
+	 */
+	mutex_unlock(&vsock_register_mutex);
 
 	ret = new_transport->init(vsk, psk);
 	if (ret) {
@@ -501,6 +516,9 @@ int vsock_assign_transport(struct vsock_sock *vsk, struct vsock_sock *psk)
 	vsk->transport = new_transport;
 
 	return 0;
+err:
+	mutex_unlock(&vsock_register_mutex);
+	return ret;
 }
 EXPORT_SYMBOL_GPL(vsock_assign_transport);
 


### PR DESCRIPTION
## Commits
```
    use uniform permission checks for all mount propagation changes

    jira VULN-98606
    jira VULN-98607
    cve-bf CVE-2025-38498
    commit-author Al Viro <viro@zeniv.linux.org.uk>
    commit cffd0441872e7f6b1fce5e78fb1c99187a291330
    upstream-diff This is a partial backport due to missing 9ffb14ef61ba
            which introduces do_set_group(). This is where the below
            operation on diffferent aspects of the same thing is introduced.
            This change does however introduce some additional safety checks
            which should be considered.
```
```
    net: fix udp gso skb_segment after pull from frag_list

    jira VULN-156444
    jira VULN-156445
    cve CVE-2025-38124
    commit-author Shiming Cheng <shiming.cheng@mediatek.com>
    commit 3382a1ed7f778db841063f5d7e317ac55f9e7f72
```
```
    bpf: Fix a segment issue when downgrading gso_size

    jira VULN-38750
    jira VULN-38751
    cve CVE-2024-42281
    commit-author Fred Li <dracodingfly@gmail.com>
    commit fa5ef655615a01533035c6139248c5b33aa27028
```
```
    do_change_type(): refuse to operate on unmounted/not ours mounts

    jira VULN-98607
    jira VULN-98606
    cve CVE-2025-38498
    commit-author Al Viro <viro@zeniv.linux.org.uk>
    commit 12f147ddd6de7382dad54812e65f3f08d05809fc
```
```
    vsock: Fix transport_* TOCTOU

    jira VULN-80682
    jira VULN-80681
    cve CVE-2025-38461
    commit-author Michal Luczaj <mhal@rbox.co>
    commit 687aa0c5581b8d4aa87fd92973e4ee576b550cdf
```
```
    gso: fix udp gso fraglist segmentation after pull from frag_list

    jira VULN-45766
    jira VULN-45767
    cve cve-2024-49978
    commit-author Willem de Bruijn <willemb@google.com>
    commit a1e40ac5b5e9077fe1f7ae0eb88034db0f9ae1ab
    upstream-diff contextual diff is off due to massive reworks.
            In addition __udpv6_gso_segment_list_csum definition is not
            included.  This was included via "net/gro.h" via 75082e7f4680
            which is a bug fix to 4721031c3559 "net: move gro definitions to
            include/net/gro.h". Since we also do not have that we're just
            directly including net/ip6_checksum.h to this file.
```

## Build
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kbuild* | head -n1)
/mnt/code/kernel-src-tree-build
Running make mrproper...
  CLEAN   cscope.in.out cscope.po.out cscope.out cscope.files
[TIMER]{MRPROPER}: 4s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_udp_gso_fraglist-106adb1d0a8f"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1894s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-jmaple_udp_gso_fraglist-106adb1d0a8f+
[TIMER]{MODULES}: 17s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-jmaple_udp_gso_fraglist-106adb1d0a8f+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 18s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-jmaple_udp_gso_fraglist-8f2f35383ed4+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 4s
[TIMER]{BUILD}: 1894s
[TIMER]{MODULES}: 17s
[TIMER]{INSTALL}: 18s
[TIMER]{TOTAL} 1938s
Rebooting in 10 seconds
```

## KeslfTests
```
[jmaple@devbox code]$ ./get_kselftest_diff.sh
kselftest.4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-0bc2+.log
204
kselftest.4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-d70e+.log
204
kselftest.4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-9a06+.log
204
kselftest.4.18.0-jmaple_udp_gso_fraglist-106adb1d0a8f+.log
204
Before: kselftest.4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-9a06+.log
After: kselftest.4.18.0-jmaple_udp_gso_fraglist-106adb1d0a8f+.log
Diff:
No differences found.
```

### get_kselftest_diff.sh experimental script
```
#!/bin/bash

FILES=$(ls -rt kselftest.* | tail -n4)

while read -r line; do
        echo $line; grep '^ok ' $line | wc -l ;
done <<< "$FILES"

BEFORE=""
AFTER+=""

while read -r line; do
    BEFORE=${AFTER}
    AFTER=${line}
done <<< "$FILES"

echo "Before: $BEFORE"
echo "After: $AFTER"
echo "Diff:"
DIFF=$(grep ok <(diff -adU0 <(grep ^ok "${BEFORE}" | sort -h) <(grep ^ok "${AFTER}" | sort -h)))
if [ -z "$DIFF" ]; then
    echo "No differences found."
else
    echo "$DIFF"
fi
```