### PR TITLE
[FIPS 9.2] gro / gso CVEs

### DIFF
--- a/net/core/filter.c
+++ b/net/core/filter.c
@@ -3481,13 +3481,20 @@ static int bpf_skb_net_grow(struct sk_buff *skb, u32 off, u32 len_diff,
 	if (skb_is_gso(skb)) {
 		struct skb_shared_info *shinfo = skb_shinfo(skb);
 
-		/* Due to header grow, MSS needs to be downgraded. */
-		if (!(flags & BPF_F_ADJ_ROOM_FIXED_GSO))
-			skb_decrease_gso_size(shinfo, len_diff);
-
 		/* Header must be checked, and gso_segs recomputed. */
 		shinfo->gso_type |= gso_type;
 		shinfo->gso_segs = 0;
+
+		/* Due to header growth, MSS needs to be downgraded.
+		 * There is a BUG_ON() when segmenting the frag_list with
+		 * head_frag true, so linearize the skb after downgrading
+		 * the MSS.
+		 */
+		if (!(flags & BPF_F_ADJ_ROOM_FIXED_GSO)) {
+			skb_decrease_gso_size(shinfo, len_diff);
+			if (shinfo->frag_list)
+				return skb_linearize(skb);
+		}
 	}
 
 	return 0;

--- a/net/ipv4/udp_offload.c
+++ b/net/ipv4/udp_offload.c
@@ -272,11 +272,16 @@ struct sk_buff *__udp_gso_segment(struct sk_buff *gso_skb,
 	bool copy_dtor;
 	__sum16 check;
 	__be16 newlen;
+	int ret = 0;
 
 	if (skb_shinfo(gso_skb)->gso_type & SKB_GSO_FRAGLIST) {
 		 /* Detect modified geometry and pass those to skb_segment. */
 		if (skb_pagelen(gso_skb) - sizeof(*uh) == skb_shinfo(gso_skb)->gso_size)
 			return __udp_gso_segment_list(gso_skb, features, is_ipv6);
+
+		ret = __skb_linearize(gso_skb);
+		if (ret)
+			return ERR_PTR(ret);
 
 		 /* Setup csum, as fraglist skips this in udp4_gro_receive. */
 		gso_skb->csum_start = skb_transport_header(gso_skb) - gso_skb->head;

--- a/net/ipv4/udp_offload.c
+++ b/net/ipv4/udp_offload.c
@@ -273,8 +273,26 @@ struct sk_buff *__udp_gso_segment(struct sk_buff *gso_skb,
 	__sum16 check;
 	__be16 newlen;
 
-	if (skb_shinfo(gso_skb)->gso_type & SKB_GSO_FRAGLIST)
-		return __udp_gso_segment_list(gso_skb, features, is_ipv6);
+	if (skb_shinfo(gso_skb)->gso_type & SKB_GSO_FRAGLIST) {
+		 /* Detect modified geometry and pass those to skb_segment. */
+		if (skb_pagelen(gso_skb) - sizeof(*uh) == skb_shinfo(gso_skb)->gso_size)
+			return __udp_gso_segment_list(gso_skb, features, is_ipv6);
+
+		 /* Setup csum, as fraglist skips this in udp4_gro_receive. */
+		gso_skb->csum_start = skb_transport_header(gso_skb) - gso_skb->head;
+		gso_skb->csum_offset = offsetof(struct udphdr, check);
+		gso_skb->ip_summed = CHECKSUM_PARTIAL;
+
+		uh = udp_hdr(gso_skb);
+		if (is_ipv6)
+			uh->check = ~udp_v6_check(gso_skb->len,
+						  &ipv6_hdr(gso_skb)->saddr,
+						  &ipv6_hdr(gso_skb)->daddr, 0);
+		else
+			uh->check = ~udp_v4_check(gso_skb->len,
+						  ip_hdr(gso_skb)->saddr,
+						  ip_hdr(gso_skb)->daddr, 0);
+	}
 
 	mss = skb_shinfo(gso_skb)->gso_size;
 	if (gso_skb->len <= sizeof(*uh) + mss)


### PR DESCRIPTION
## Commits
```
    net: fix udp gso skb_segment after pull from frag_list

    jira VULN-71810
    cve CVE-2025-38124
    commit-author Shiming Cheng <shiming.cheng@mediatek.com>
    commit 3382a1ed7f778db841063f5d7e317ac55f9e7f72
```
```
    gso: fix udp gso fraglist segmentation after pull from frag_list

    jira VULN-45771
    cve CVE-2024-49978
    commit-author Willem de Bruijn <willemb@google.com>
    commit a1e40ac5b5e9077fe1f7ae0eb88034db0f9ae1ab
```
```
    bpf: Fix a segment issue when downgrading gso_size

    jira VULN-38755
    cve CVE-2024-42281
    commit-author Fred Li <dracodingfly@gmail.com>
    commit fa5ef655615a01533035c6139248c5b33aa27028
```

## Build
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kbuild* | head -n1)
/mnt/code/kernel-src-tree-build
Running make mrproper...
[TIMER]{MRPROPER}: 5s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
--
  BTF [M] sound/virtio/virtio_snd.ko
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] sound/xen/snd_xen_front.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1331s
Making Modules
  INSTALL /lib/modules/5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  STRIP   /lib/modules/5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+/kernel/sound/usb/snd-usb-audio.ko
  SIGN    /lib/modules/5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+
[TIMER]{MODULES}: 6s
Making Install
sh ./arch/x86/boot/install.sh \
        5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 24s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-4db430364722+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 1331s
[TIMER]{MODULES}: 6s
[TIMER]{INSTALL}: 24s
[TIMER]{TOTAL} 1370s
Rebooting in 10 seconds
```

## KselfTest
```
[jmaple@devbox code]$ ./get_kselftest_diff.sh
kselftest.5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64.log
314
kselftest.5.14.0-_jmaple__fips-9-compliant_5.14.0-284.30.1-f298ec762bf8+.log
313
kselftest.5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-4db430364722+.log
314
kselftest.5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+.log
327
Before: kselftest.5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-4db430364722+.log
After: kselftest.5.14.0-jmaple_fips-9-compliant_5.14.0-284.30.1-5acbf59af082+.log
Diff:
+ok 11 selftests: proc: proc-uptime-001
+ok 12 selftests: x86: fsgsbase_restore_64
+ok 13 selftests: x86: sigaltstack_64
+ok 14 selftests: x86: fsgsbase_64
+ok 15 selftests: x86: sysret_rip_64
+ok 16 selftests: x86: syscall_numbering_64
+ok 17 selftests: x86: corrupt_xstate_header_64
+ok 2 selftests: x86: sysret_ss_attrs_64
+ok 3 selftests: x86: syscall_nt_64
+ok 4 selftests: x86: test_mremap_vdso_64
+ok 5 selftests: x86: check_initial_reg_state_64
-ok 6 selftests: net: tls
+ok 7 selftests: x86: iopl_64
+ok 8 selftests: x86: ioperm_64
+ok 9 selftests: x86: test_vsyscall_64
```