### PR TITLE
[FIPS 8 Compliant] CVE-2024-58002

### DIFF
--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1532,6 +1532,40 @@ static void uvc_ctrl_send_slave_event(struct uvc_video_chain *chain,
 	uvc_ctrl_send_event(chain, handle, ctrl, mapping, val, changes);
 }
 
+static void uvc_ctrl_set_handle(struct uvc_fh *handle, struct uvc_control *ctrl,
+				struct uvc_fh *new_handle)
+{
+	lockdep_assert_held(&handle->chain->ctrl_mutex);
+
+	if (new_handle) {
+		if (ctrl->handle)
+			dev_warn_ratelimited(&handle->stream->dev->udev->dev,
+					     "UVC non compliance: Setting an async control with a pending operation.");
+
+		if (new_handle == ctrl->handle)
+			return;
+
+		if (ctrl->handle) {
+			WARN_ON(!ctrl->handle->pending_async_ctrls);
+			if (ctrl->handle->pending_async_ctrls)
+				ctrl->handle->pending_async_ctrls--;
+		}
+
+		ctrl->handle = new_handle;
+		handle->pending_async_ctrls++;
+		return;
+	}
+
+	/* Cannot clear the handle for a control not owned by us.*/
+	if (WARN_ON(ctrl->handle != handle))
+		return;
+
+	ctrl->handle = NULL;
+	if (WARN_ON(!handle->pending_async_ctrls))
+		return;
+	handle->pending_async_ctrls--;
+}
+
 void uvc_ctrl_status_event(struct uvc_video_chain *chain,
 			   struct uvc_control *ctrl, const u8 *data)
 {
@@ -1542,7 +1576,8 @@ void uvc_ctrl_status_event(struct uvc_video_chain *chain,
 	mutex_lock(&chain->ctrl_mutex);
 
 	handle = ctrl->handle;
-	ctrl->handle = NULL;
+	if (handle)
+		uvc_ctrl_set_handle(handle, ctrl, NULL);
 
 	list_for_each_entry(mapping, &ctrl->info.mappings, list) {
 		s32 value = __uvc_ctrl_get_value(mapping, data);
@@ -1818,7 +1853,7 @@ static int uvc_ctrl_commit_entity(struct uvc_device *dev,
 
 		if (!rollback && handle &&
 		    ctrl->info.flags & UVC_CTRL_FLAG_ASYNCHRONOUS)
-			ctrl->handle = handle;
+			uvc_ctrl_set_handle(handle, ctrl, handle);
 	}
 
 	return 0;
@@ -2747,6 +2782,30 @@ int uvc_ctrl_init_device(struct uvc_device *dev)
 	}
 
 	return 0;
+}
+
+void uvc_ctrl_cleanup_fh(struct uvc_fh *handle)
+{
+	struct uvc_entity *entity;
+
+	mutex_lock(&handle->chain->ctrl_mutex);
+
+	if (!handle->pending_async_ctrls) {
+		mutex_unlock(&handle->chain->ctrl_mutex);
+		return;
+	}
+
+	list_for_each_entry(entity, &handle->chain->dev->entities, list) {
+		unsigned int i;
+		for (i = 0; i < entity->ncontrols; ++i) {
+			if (entity->controls[i].handle != handle)
+				continue;
+			uvc_ctrl_set_handle(handle, &entity->controls[i], NULL);
+		}
+	}
+
+	WARN_ON(handle->pending_async_ctrls);
+	mutex_unlock(&handle->chain->ctrl_mutex);
 }
 
 /*

--- a/drivers/media/usb/uvc/uvc_v4l2.c
+++ b/drivers/media/usb/uvc/uvc_v4l2.c
@@ -658,6 +658,8 @@ static int uvc_v4l2_release(struct file *file)
 
 	uvc_dbg(stream->dev, CALLS, "%s\n", __func__);
 
+	uvc_ctrl_cleanup_fh(handle);
+
 	/* Only free resources if this is a privileged handle. */
 	if (uvc_has_privileges(handle))
 		uvc_queue_release(&stream->queue);

--- a/drivers/media/usb/uvc/uvcvideo.h
+++ b/drivers/media/usb/uvc/uvcvideo.h
@@ -329,7 +329,11 @@ struct uvc_video_chain {
 	struct uvc_entity *processing;		/* Processing unit */
 	struct uvc_entity *selector;		/* Selector unit */
 
-	struct mutex ctrl_mutex;		/* Protects ctrl.info */
+	struct mutex ctrl_mutex;		/*
+						 * Protects ctrl.info,
+						 * ctrl.handle and
+						 * uvc_fh.pending_async_ctrls
+						 */
 
 	struct v4l2_prio_state prio;		/* V4L2 priority state */
 	u32 caps;				/* V4L2 chain-wide caps */
@@ -604,6 +608,7 @@ struct uvc_fh {
 	struct uvc_video_chain *chain;
 	struct uvc_streaming *stream;
 	enum uvc_handle_state state;
+	unsigned int pending_async_ctrls;
 };
 
 struct uvc_driver {
@@ -787,6 +792,8 @@ int uvc_ctrl_is_accessible(struct uvc_video_chain *chain, u32 v4l2_id,
 
 int uvc_xu_ctrl_query(struct uvc_video_chain *chain,
 		      struct uvc_xu_control_query *xqry);
+
+void uvc_ctrl_cleanup_fh(struct uvc_fh *handle);
 
 /* Utility functions */
 struct usb_host_endpoint *uvc_find_endpoint(struct usb_host_interface *alts,


### PR DESCRIPTION
Basically the 8.10 version of this PR: https://github.com/ctrliq/kernel-src-tree/pull/548

```
    media: uvcvideo: Remove dangling pointers

    jira VULN-53462
    jira VULN-53461
    cve CVE-2024-58002
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit 221cd51efe4565501a3dbf04cc011b537dcce7fb
    upstream-diff used kernel-lt 5.15 commit 117f7a2975baa4b7d702d3f4830d5a4ebd0c6d50
            This is due to missing both:
             - e8c07082a810 - Kbuild: move to -std=gnu11
             - 54da6a092431 - locking: Introduce __cleanup() based infrastructure
```
```
    media: uvcvideo: Only save async fh if success

    jira VULN-53462
    jira VULN-53461
    cve-pre CVE-2024-58002
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit d9fecd096f67a4469536e040a8a10bbfb665918b
```
```
    media: uvcvideo: Refactor iterators

    jira VULN-53462
    jira VULN-53461
    cve-pre CVE-2024-58002
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit 64627daf0c5f7838111f52bbbd1a597cb5d6871a
```

## BUILD 
```
[jmaple@devbox code]$ egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kbuild* | head -n1)
/mnt/code/kernel-src-tree-build
Running make mrproper...
  CLEAN   cscope.in.out cscope.po.out cscope.out cscope.files
[TIMER]{MRPROPER}: 5s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_fips-8-compliant_4.18.0-553.16.1-f51d42ab35ac"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1923s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-jmaple_fips-8-compliant_4.18.0-553.16.1-f51d42ab35ac+
[TIMER]{MODULES}: 15s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-jmaple_fips-8-compliant_4.18.0-553.16.1-f51d42ab35ac+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 22s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-jmaple_fips-8-compliant_4.18.0-553.16.1-f51d42ab35ac+ and Index to 0
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 1923s
[TIMER]{MODULES}: 15s
[TIMER]{INSTALL}: 22s
[TIMER]{TOTAL} 1969s
Rebooting in 10 seconds
```

## KSelfTest
```
[jmaple@devbox code]$ ./get_kselftest_diff.sh
kselftest.4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-d70e+.log
204
kselftest.4.18.0-jmaple_batch_12_fips-8-compliant_4.18.0-553.16.1-9a06+.log
204
kselftest.4.18.0-jmaple_udp_gso_fraglist-106adb1d0a8f+.log
204
kselftest.4.18.0-jmaple_fips-8-compliant_4.18.0-553.16.1-f51d42ab35ac+.log
204
Before: kselftest.4.18.0-jmaple_udp_gso_fraglist-106adb1d0a8f+.log
After: kselftest.4.18.0-jmaple_fips-8-compliant_4.18.0-553.16.1-f51d42ab35ac+.log
Diff:
No differences found.
```

### KselfTest Diff Experimental
```
#!/bin/bash

FILES=$(ls -rt kselftest.* | tail -n4)

while read -r line; do
        echo $line; grep '^ok ' $line | wc -l ;
done <<< "$FILES"

BEFORE=""
AFTER+=""

while read -r line; do
    BEFORE=${AFTER}
    AFTER=${line}
done <<< "$FILES"

echo "Before: $BEFORE"
echo "After: $AFTER"
echo "Diff:"
DIFF=$(grep ok <(diff -adU0 <(grep ^ok "${BEFORE}" | sort -h) <(grep ^ok "${AFTER}" | sort -h)))
if [ -z "$DIFF" ]; then
    echo "No differences found."
else
    echo "$DIFF"
fi
```