### PR TITLE
[lts92] Many VULNs 9-29-25

### DIFF
--- a/drivers/i2c/busses/i2c-designware-master.c
+++ b/drivers/i2c/busses/i2c-designware-master.c
@@ -298,6 +298,7 @@ static int amd_i2c_dw_xfer_quirk(struct i2c_adapter *adap, struct i2c_msg *msgs,
 
 	dev->msgs = msgs;
 	dev->msgs_num = num_msgs;
+	dev->msg_write_idx = 0;
 	i2c_dw_xfer_init(dev);
 	i2c_dw_disable_int(dev);
 

--- a/include/linux/netdevice.h
+++ b/include/linux/netdevice.h
@@ -2471,6 +2471,12 @@ struct net *dev_net(const struct net_device *dev)
 }
 
 static inline
+struct net *dev_net_rcu(const struct net_device *dev)
+{
+	return read_pnet_rcu(&dev->nd_net);
+}
+
+static inline
 void dev_net_set(struct net_device *dev, struct net *net)
 {
 	write_pnet(&dev->nd_net, net);

--- a/include/net/net_namespace.h
+++ b/include/net/net_namespace.h
@@ -348,21 +348,30 @@ static inline void put_net_track(struct net *net, netns_tracker *tracker)
 
 typedef struct {
 #ifdef CONFIG_NET_NS
-	struct net *net;
+	struct net __rcu *net;
 #endif
 } possible_net_t;
 
 static inline void write_pnet(possible_net_t *pnet, struct net *net)
 {
 #ifdef CONFIG_NET_NS
-	pnet->net = net;
+	rcu_assign_pointer(pnet->net, net);
 #endif
 }
 
 static inline struct net *read_pnet(const possible_net_t *pnet)
 {
 #ifdef CONFIG_NET_NS
-	return pnet->net;
+	return rcu_dereference_protected(pnet->net, true);
+#else
+	return &init_net;
+#endif
+}
+
+static inline struct net *read_pnet_rcu(possible_net_t *pnet)
+{
+#ifdef CONFIG_NET_NS
+	return rcu_dereference(pnet->net);
 #else
 	return &init_net;
 #endif

--- a/include/net/net_namespace.h
+++ b/include/net/net_namespace.h
@@ -368,7 +368,7 @@ static inline struct net *read_pnet(const possible_net_t *pnet)
 #endif
 }
 
-static inline struct net *read_pnet_rcu(possible_net_t *pnet)
+static inline struct net *read_pnet_rcu(const possible_net_t *pnet)
 {
 #ifdef CONFIG_NET_NS
 	return rcu_dereference(pnet->net);

--- a/net/bridge/br_device.c
+++ b/net/bridge/br_device.c
@@ -38,6 +38,11 @@ netdev_tx_t br_dev_xmit(struct sk_buff *skb, struct net_device *dev)
 	const unsigned char *dest;
 	u16 vid = 0;
 
+	if (unlikely(!pskb_may_pull(skb, ETH_HLEN))) {
+		kfree_skb(skb);
+		return NETDEV_TX_OK;
+	}
+
 	memset(skb->cb, 0, sizeof(struct br_input_skb_cb));
 
 	rcu_read_lock();

--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -4101,21 +4101,20 @@ struct sk_buff *skb_segment(struct sk_buff *head_skb,
 	struct sk_buff *segs = NULL;
 	struct sk_buff *tail = NULL;
 	struct sk_buff *list_skb = skb_shinfo(head_skb)->frag_list;
-	skb_frag_t *frag = skb_shinfo(head_skb)->frags;
 	unsigned int mss = skb_shinfo(head_skb)->gso_size;
 	unsigned int doffset = head_skb->data - skb_mac_header(head_skb);
-	struct sk_buff *frag_skb = head_skb;
 	unsigned int offset = doffset;
 	unsigned int tnl_hlen = skb_tnl_header_len(head_skb);
 	unsigned int partial_segs = 0;
 	unsigned int headroom;
 	unsigned int len = head_skb->len;
+	struct sk_buff *frag_skb;
+	skb_frag_t *frag;
 	__be16 proto;
 	bool csum, sg;
-	int nfrags = skb_shinfo(head_skb)->nr_frags;
 	int err = -ENOMEM;
 	int i = 0;
-	int pos;
+	int nfrags, pos;
 
 	if ((skb_shinfo(head_skb)->gso_type & SKB_GSO_DODGY) &&
 	    mss != GSO_BY_FRAGS && mss != skb_headlen(head_skb)) {
@@ -4192,6 +4191,13 @@ normal:
 	headroom = skb_headroom(head_skb);
 	pos = skb_headlen(head_skb);
 
+	if (skb_orphan_frags(head_skb, GFP_ATOMIC))
+		return ERR_PTR(-ENOMEM);
+
+	nfrags = skb_shinfo(head_skb)->nr_frags;
+	frag = skb_shinfo(head_skb)->frags;
+	frag_skb = head_skb;
+
 	do {
 		struct sk_buff *nskb;
 		skb_frag_t *nskb_frag;
@@ -4212,6 +4218,10 @@ normal:
 		    (skb_headlen(list_skb) == len || sg)) {
 			BUG_ON(skb_headlen(list_skb) > len);
 
+			nskb = skb_clone(list_skb, GFP_ATOMIC);
+			if (unlikely(!nskb))
+				goto err;
+
 			i = 0;
 			nfrags = skb_shinfo(list_skb)->nr_frags;
 			frag = skb_shinfo(list_skb)->frags;
@@ -4230,11 +4240,7 @@ normal:
 				frag++;
 			}
 
-			nskb = skb_clone(list_skb, GFP_ATOMIC);
 			list_skb = list_skb->next;
-
-			if (unlikely(!nskb))
-				goto err;
 
 			if (unlikely(pskb_trim(nskb, len))) {
 				kfree_skb(nskb);
@@ -4312,12 +4318,16 @@ normal:
 		skb_shinfo(nskb)->flags |= skb_shinfo(head_skb)->flags &
 					   SKBFL_SHARED_FRAG;
 
-		if (skb_orphan_frags(frag_skb, GFP_ATOMIC) ||
-		    skb_zerocopy_clone(nskb, frag_skb, GFP_ATOMIC))
+		if (skb_zerocopy_clone(nskb, frag_skb, GFP_ATOMIC))
 			goto err;
 
 		while (pos < offset + len) {
 			if (i >= nfrags) {
+				if (skb_orphan_frags(list_skb, GFP_ATOMIC) ||
+				    skb_zerocopy_clone(nskb, list_skb,
+						       GFP_ATOMIC))
+					goto err;
+
 				i = 0;
 				nfrags = skb_shinfo(list_skb)->nr_frags;
 				frag = skb_shinfo(list_skb)->frags;
@@ -4331,10 +4341,6 @@ normal:
 					i--;
 					frag--;
 				}
-				if (skb_orphan_frags(frag_skb, GFP_ATOMIC) ||
-				    skb_zerocopy_clone(nskb, frag_skb,
-						       GFP_ATOMIC))
-					goto err;
 
 				list_skb = list_skb->next;
 			}

--- a/net/ipv6/ndisc.c
+++ b/net/ipv6/ndisc.c
@@ -414,15 +414,11 @@ static struct sk_buff *ndisc_alloc_skb(struct net_device *dev,
 {
 	int hlen = LL_RESERVED_SPACE(dev);
 	int tlen = dev->needed_tailroom;
-	struct sock *sk = dev_net(dev)->ipv6.ndisc_sk;
 	struct sk_buff *skb;
 
 	skb = alloc_skb(hlen + sizeof(struct ipv6hdr) + len + tlen, GFP_ATOMIC);
-	if (!skb) {
-		ND_PRINTK(0, err, "ndisc: %s failed to allocate an skb\n",
-			  __func__);
+	if (!skb)
 		return NULL;
-	}
 
 	skb->protocol = htons(ETH_P_IPV6);
 	skb->dev = dev;
@@ -433,7 +429,9 @@ static struct sk_buff *ndisc_alloc_skb(struct net_device *dev,
 	/* Manually assign socket ownership as we avoid calling
 	 * sock_alloc_send_pskb() to bypass wmem buffer limits
 	 */
-	skb_set_owner_w(skb, sk);
+	rcu_read_lock();
+	skb_set_owner_w(skb, dev_net_rcu(dev)->ipv6.ndisc_sk);
+	rcu_read_unlock();
 
 	return skb;
 }

--- a/net/tls/tls_strp.c
+++ b/net/tls/tls_strp.c
@@ -396,9 +396,8 @@ static int tls_strp_read_sock(struct tls_strparser *strp)
 	if (inq < strp->stm.full_len)
 		return tls_strp_read_copy(strp, true);
 
+	tls_strp_load_anchor_with_queue(strp, inq);
 	if (!strp->stm.full_len) {
-		tls_strp_load_anchor_with_queue(strp, inq);
-
 		sz = tls_rx_msg_size(strp, strp->anchor);
 		if (sz < 0) {
 			tls_strp_abort_strp(strp, sz);


### PR DESCRIPTION
### Background

Clean cherry-picks except for 8bd67ebb50c0145fd2ca8681ab65eb7e8cde1afc.  The upstream change uses kfree_skb_reason which doesn't exist in this kernel and isn't a simple backport.  So I used the 5.10 LT backport which just calls kfree_ksb.  There were a couple of trivial prerequisites that were backported (2034d90ae41ae93e30d492ebcf1f06f97a9cfba6 and 482ad2a4ace2740ca0ff1cbc8f3c7f862f3ab507) for this change.


### Commits

```
    skbuff: skb_segment, Call zero copy functions before using skbuff frags

    jira VULN-155411
    cve CVE-2023-53354
    commit-author Mohamed Khalfella <mkhalfella@purestorage.com>
    commit 2ea35288c83b3d501a88bc17f2df8f176b5cc96f
```

```
    net: bridge: xmit: make sure we have at least eth header len bytes

    jira VULN-5468
    cve CVE-2024-38538
    commit-author Nikolay Aleksandrov <razor@blackwall.org>
    commit 8bd67ebb50c0145fd2ca8681ab65eb7e8cde1afc
    upstream-diff Use 5.10 LT 82090f94c723dab724b1c32db406091d40448a17
                  because this kernel doesn't have kfree_skb_reason
```

```
    net: treat possible_net_t net pointer as an RCU one and add read_pnet_rcu()

    jira VULN-54026
    cve-pre CVE-2025-21764
    commit-author Jiri Pirko <jiri@nvidia.com>
    commit 2034d90ae41ae93e30d492ebcf1f06f97a9cfba6
```

```
    net: add dev_net_rcu() helper

    jira VULN-54026
    cve-pre CVE-2025-21764
    commit-author Eric Dumazet <edumazet@google.com>
    commit 482ad2a4ace2740ca0ff1cbc8f3c7f862f3ab507
```

```
    ndisc: use RCU protection in ndisc_alloc_skb()

    jira VULN-54026
    cve CVE-2025-21764
    commit-author Eric Dumazet <edumazet@google.com>
    commit 628e6d18930bbd21f2d4562228afe27694f66da9
```

```
    i2c/designware: Fix an initialization issue

    jira VULN-79509
    cve CVE-2025-38380
    commit-author Michael J. Ruhl <michael.j.ruhl@intel.com>
    commit 3d30048958e0d43425f6d4e76565e6249fa71050
```

```
    tls: always refresh the queue when reading sock

    jira VULN-89194
    cve CVE-2025-38471
    commit-author Jakub Kicinski <kuba@kernel.org>
    commit 4ab26bce3969f8fd925fe6f6f551e4d1a508c68b
```

### Build Log

```
/home/brett/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 12s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
--
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] virt/lib/irqbypass.ko
  BTF [M] sound/virtio/virtio_snd.ko
  BTF [M] sound/xen/snd_xen_front.ko
[TIMER]{BUILD}: 944s
Making Modules
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
--
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+/kernel/sound/virtio/virtio_snd.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+
[TIMER]{MODULES}: 7s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 57s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 12s
[TIMER]{BUILD}: 944s
[TIMER]{MODULES}: 7s
[TIMER]{INSTALL}: 57s
[TIMER]{TOTAL} 1040s
Rebooting in 10 seconds

```

### Testing

[selftest-5.14.0-284.30.1.el9_2.92ciq_lts.11.1.x86_64-1.log](https://github.com/user-attachments/files/22641977/selftest-5.14.0-284.30.1.el9_2.92ciq_lts.11.1.x86_64-1.log)

[selftest-5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+-1.log](https://github.com/user-attachments/files/22641980/selftest-5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab%2B-1.log)


```
brett@lycia ~/ciq/many-92-vulns-9-29-25
 % grep ^ok selftest-5.14.0-284.30.1.el9_2.92ciq_lts.11.1.x86_64-1.log | wc -l
343
brett@lycia ~/ciq/many-92-vulns-9-29-25
 % grep ^ok selftest-5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+-1.log | wc -l
344
brett@lycia ~/ciq/many-92-vulns-9-29-25
 % grep ok <(diff -adU0 <(grep ^ok selftest-5.14.0-284.30.1.el9_2.92ciq_lts.11.1.x86_64-1.log | sort -h) <(grep ^ok selftest-5.14.0-bmastbergen_ciqlts9_2_many-vulns-9-29-25-d2412ebce8ab+-1.log | sort -h))
-ok 1 selftests: livepatch: test-livepatch.sh # SKIP
+ok 1 selftests: livepatch: test-livepatch.sh
-ok 1 selftests: vm: run_vmtests.sh # SKIP
-ok 1 selftests: zram: zram.sh # SKIP
+ok 1 selftests: zram: zram.sh
-ok 2 selftests: livepatch: test-callbacks.sh # SKIP
+ok 2 selftests: livepatch: test-callbacks.sh
+ok 32 selftests: net: l2tp.sh
-ok 3 selftests: livepatch: test-shadow-vars.sh # SKIP
+ok 3 selftests: livepatch: test-shadow-vars.sh
+ok 47 selftests: net: drop_monitor_tests.sh
-ok 4 selftests: livepatch: test-state.sh # SKIP
+ok 4 selftests: livepatch: test-state.sh
-ok 58 selftests: kvm: max_guest_memory_test
-ok 5 selftests: livepatch: test-ftrace.sh # SKIP
+ok 5 selftests: livepatch: test-ftrace.sh
+ok 9 selftests: net: test_bpf.sh
brett@lycia ~/ciq/many-92-vulns-9-29-25
 %

```