### PR TITLE
[FIPS 9.2 Compliant] CVE-2025-38471

### DIFF
--- a/net/tls/tls_strp.c
+++ b/net/tls/tls_strp.c
@@ -396,9 +396,8 @@ static int tls_strp_read_sock(struct tls_strparser *strp)
 	if (inq < strp->stm.full_len)
 		return tls_strp_read_copy(strp, true);
 
+	tls_strp_load_anchor_with_queue(strp, inq);
 	if (!strp->stm.full_len) {
-		tls_strp_load_anchor_with_queue(strp, inq);
-
 		sz = tls_rx_msg_size(strp, strp->anchor);
 		if (sz < 0) {
 			tls_strp_abort_strp(strp, sz);


### PR DESCRIPTION
## DESCRIPTION

Commit: 4ab26bce3969f8fd925fe6f6f551e4d1a508c68b ("tls: always refresh the queue when reading sock") was cherry-picked from linux-mainline. It applied cleanly.

Testing was done only for x86_64

## BUILD
```
> egrep -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kernel-build-after* | head -n1)
/home/rnicolescu/ciq/vms/fips-9-compliant_5.14.0-284.30.1/kernel-src-tree-fix
Running make mrproper...
  CLEAN   scripts/basic
  CLEAN   .config
[TIMER]{MRPROPER}: 3s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
--
  BTF [M] sound/virtio/virtio_snd.ko
  BTF [M] sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] sound/xen/snd_xen_front.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1230s
Making Modules
  INSTALL /lib/modules/5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  SIGN    /lib/modules/5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+/kernel/sound/usb/usx2y/snd-usb-usx2y.ko
  SIGN    /lib/modules/5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+/kernel/sound/virtio/virtio_snd.ko
  DEPMOD  /lib/modules/5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+
[TIMER]{MODULES}: 10s
Making Install
sh ./arch/x86/boot/install.sh \
        5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+ arch/x86/boot/bzImage \
        System.map "/boot"
[TIMER]{INSTALL}: 18s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+ and Index to 2
The default is /boot/loader/entries/506c08856ad34062a6658d29211d7b09-5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+
The default is /boot/loader/entries/506c08856ad34062a6658d29211d7b09-5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+.conf with index 2 and kernel /boot/vmlinuz-5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 3s
[TIMER]{BUILD}: 1230s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 18s
[TIMER]{TOTAL} 1266s
Rebooting in 10 seconds
```
[kernel-build-after.log](https://github.com/user-attachments/files/22722398/kernel-build-after.log)
[kernel-build-before.log](https://github.com/user-attachments/files/22722401/kernel-build-before.log)

## Kselftests
Command run
```
> make -j$(nproc) kselftest SKIP_TARGETS="lkdtm pidfd" 2>&1 | tee ../kselftest-after.log
```

```
> grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
306
305

> grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
78
79
Diff:
+ok 11 selftests: proc: proc-uptime-001
```
Note: this test is flaky, multiple reports upstream. At a second run it passed

Note2: I triggered another kselftest run by mistake (Ctr-R mistake) and it override the logs (Another reason to fully automate and name these results properly)
These are the results after a second run:

```
> grep '^ok ' kselftest-before.log | wc -l && grep '^ok ' kselftest-after.log | wc -l
306
320

> grep '^not ok ' kselftest-before.log | wc -l && grep '^not ok ' kselftest-after.log | wc -l
78
82

Diff:
-ok 10 selftests: kvm: hyperv_svm_test # SKIP
-ok 10 selftests: netfilter: nft_queue.sh # SKIP
-ok 10 selftests: net/forwarding: dual_vxlan_bridge.sh # SKIP
-ok 10 selftests: net: netdevice.sh # SKIP
-ok 10 selftests: proc: proc-subset-pid # SKIP
-ok 11 selftests: netfilter: nft_meta.sh # SKIP
-ok 11 selftests: net/forwarding: ethtool_extended_state.sh # SKIP
-ok 11 selftests: net: rtnetlink.sh # SKIP
-ok 11 selftests: proc: proc-uptime-001
-ok 12 selftests: kvm: kvm_pv_test
-ok 12 selftests: netfilter: nf_nat_edemux.sh # SKIP
-ok 12 selftests: net/forwarding: ethtool.sh # SKIP
-ok 12 selftests: net: xfrm_policy.sh # SKIP
-ok 12 selftests: proc: proc-uptime-002
-ok 12 selftests: x86: fsgsbase_restore_64
-ok 13 selftests: kvm: mmio_warning_test # SKIP
-ok 13 selftests: netfilter: ipip-conntrack-mtu.sh # SKIP
-ok 13 selftests: net/forwarding: gre_custom_multipath_hash.sh # SKIP
-ok 13 selftests: proc: read
-ok 13 selftests: x86: sigaltstack_64
-ok 14 selftests: kvm: monitor_mwait_test
-ok 14 selftests: net: fib_tests.sh # SKIP
-ok 14 selftests: netfilter: conntrack_tcp_unreplied.sh # SKIP
-ok 14 selftests: net/forwarding: gre_inner_v4_multipath.sh # SKIP
-ok 14 selftests: proc: self
-ok 14 selftests: x86: fsgsbase_64
-ok 15 selftests: kvm: platform_info_test
-ok 15 selftests: netfilter: conntrack_vrf.sh # SKIP
-ok 15 selftests: net/forwarding: gre_inner_v6_multipath.sh # SKIP
-ok 15 selftests: proc: setns-dcache # SKIP
-ok 15 selftests: x86: sysret_rip_64
-ok 16 selftests: kvm: pmu_event_filter_test # SKIP
-ok 16 selftests: netfilter: rpath.sh # SKIP
-ok 16 selftests: net/forwarding: gre_multipath_nh_res.sh # SKIP
-ok 16 selftests: proc: setns-sysvipc # SKIP
-ok 16 selftests: x86: syscall_numbering_64
-ok 17 selftests: kvm: set_boot_cpu_id
-ok 17 selftests: net/forwarding: gre_multipath_nh.sh # SKIP
-ok 17 selftests: proc: thread-self
-ok 17 selftests: x86: corrupt_xstate_header_64
-ok 18 selftests: kvm: set_sregs_test
-ok 18 selftests: net/forwarding: gre_multipath.sh # SKIP
-ok 19 selftests: net/forwarding: hw_stats_l3.sh # SKIP
-ok 1 selftests: breakpoints: step_after_suspend_test # SKIP
-ok 1 selftests: capabilities: test_execve
-ok 1 selftests: clone3: clone3
-ok 1 selftests: cpufreq: main.sh # SKIP
-ok 1 selftests: cpu-hotplug: cpu-on-off-test.sh # SKIP
-ok 1 selftests: drivers/net/team: dev_addr_lists.sh # SKIP
-ok 1 selftests: efivarfs: efivarfs.sh # SKIP
-ok 1 selftests: filesystems/epoll: epoll_wakeup_test
-ok 1 selftests: firmware: fw_run_tests.sh # SKIP
-ok 1 selftests: fpu: test_fpu
-ok 1 selftests: futex: run.sh
-ok 1 selftests: gpio: gpio-mockup.sh # SKIP
-ok 1 selftests: intel_pstate: run.sh # SKIP
-ok 1 selftests: ipc: msgque # SKIP
-ok 1 selftests: ir: ir_loopback.sh # SKIP
-ok 1 selftests: kcmp: kcmp_test
-ok 1 selftests: kexec: test_kexec_load.sh # SKIP
-ok 1 selftests: kvm: cpuid_test
-ok 1 selftests: lib: printf.sh # SKIP
-ok 1 selftests: livepatch: test-livepatch.sh # SKIP
-ok 1 selftests: membarrier: membarrier_test_single_thread
-ok 1 selftests: memfd: memfd_test
-ok 1 selftests: memory-hotplug: mem-on-off-test.sh # SKIP
-ok 1 selftests: mount: run_unprivileged_remount.sh
-ok 1 selftests: mqueue: mq_open_tests # SKIP
-ok 1 selftests: netfilter: nft_trans_stress.sh # SKIP
-ok 1 selftests: net/forwarding: bridge_igmp.sh # SKIP
-ok 1 selftests: net/mptcp: mptcp_connect.sh # SKIP
-ok 1 selftests: nsfs: owner
-ok 1 selftests: pid_namespace: regression_enomem
-ok 1 selftests: proc: fd-001-lookup
-ok 1 selftests: ptrace: get_syscall_info
-ok 1 selftests: rseq: basic_test
-ok 1 selftests: seccomp: seccomp_bpf
-ok 1 selftests: sigaltstack: sas
-ok 1 selftests: size: get_size
-ok 1 selftests: splice: default_file_splice_read.sh
-ok 1 selftests: static_keys: test_static_keys.sh # SKIP
-ok 1 selftests: sync: sync_test # SKIP
-ok 1 selftests: syscall_user_dispatch: sud_test
-ok 1 selftests: sysctl: sysctl.sh # SKIP
-ok 1 selftests: tc-testing: tdc.sh
-ok 1 selftests: timens: timens # SKIP
-ok 1 selftests: timers: posix_timers
-ok 1 selftests: tmpfs: bug-link-o-tmpfile # SKIP
-ok 1 selftests: tpm2: test_smoke.sh # SKIP
-ok 1 selftests: user: test_user_copy.sh # SKIP
-ok 1 selftests: vDSO: vdso_test_gettimeofday
-ok 1 selftests: vm: run_vmtests.sh # SKIP
-ok 1 selftests: zram: zram.sh # SKIP
-ok 20 selftests: net: fib_rule_tests.sh # SKIP
-ok 20 selftests: net/forwarding: hw_stats_l3_gre.sh # SKIP
-ok 21 selftests: net/forwarding: ip6_forward_instats_vrf.sh # SKIP
-ok 22 selftests: kvm: svm_vmcall_test # SKIP
-ok 22 selftests: net/forwarding: ip6gre_custom_multipath_hash.sh # SKIP
-ok 23 selftests: kvm: svm_int_ctl_test # SKIP
-ok 23 selftests: net/forwarding: ip6gre_flat_key.sh # SKIP
-ok 24 selftests: kvm: svm_nested_soft_inject_test # SKIP
-ok 24 selftests: net/forwarding: ip6gre_flat_keys.sh # SKIP
-ok 25 selftests: kvm: tsc_scaling_sync
-ok 25 selftests: net/forwarding: ip6gre_flat.sh # SKIP
-ok 26 selftests: kvm: sync_regs_test
-ok 26 selftests: net/forwarding: ip6gre_hier_key.sh # SKIP
-ok 27 selftests: kvm: ucna_injection_test
-ok 27 selftests: net/forwarding: ip6gre_hier_keys.sh # SKIP
-ok 28 selftests: kvm: userspace_io_test
-ok 28 selftests: net/forwarding: ip6gre_hier.sh # SKIP
-ok 29 selftests: kvm: userspace_msr_exit_test
-ok 29 selftests: net/forwarding: ip6gre_inner_v4_multipath.sh # SKIP
-ok 2 selftests: breakpoints: breakpoint_test
-ok 2 selftests: clone3: clone3_clear_sighand
-ok 2 selftests: kexec: test_kexec_file_load.sh # SKIP
-ok 2 selftests: kvm: cr4_cpuid_sync_test
-ok 2 selftests: lib: bitmap.sh # SKIP
-ok 2 selftests: livepatch: test-callbacks.sh # SKIP
-ok 2 selftests: membarrier: membarrier_test_multi_thread
-ok 2 selftests: memfd: run_fuse_test.sh
-ok 2 selftests: mount: run_nosymfollow.sh
-ok 2 selftests: mqueue: mq_perf_tests # SKIP
-ok 2 selftests: netfilter: nft_fib.sh # SKIP
-ok 2 selftests: net/forwarding: bridge_locked_port.sh # SKIP
-ok 2 selftests: net/mptcp: pm_netlink.sh # SKIP
-ok 2 selftests: net: reuseport_bpf_cpu
-ok 2 selftests: nsfs: pidns
-ok 2 selftests: openat2: resolve_test # SKIP
-ok 2 selftests: proc: fd-002-posix-eq
-ok 2 selftests: pstore: pstore_post_reboot_tests # SKIP
-ok 2 selftests: ptrace: peeksiginfo
-ok 2 selftests: rseq: basic_percpu_ops_test
-ok 2 selftests: seccomp: seccomp_benchmark
-ok 2 selftests: syscall_user_dispatch: sud_benchmark
-ok 2 selftests: timens: timerfd # SKIP
-ok 2 selftests: timers: nanosleep
-ok 2 selftests: tpm2: test_space.sh # SKIP
-ok 2 selftests: vDSO: vdso_test_getcpu
-ok 2 selftests: x86: sysret_ss_attrs_64
-ok 30 selftests: kvm: vmx_apic_access_test
-ok 30 selftests: net/forwarding: ip6gre_inner_v6_multipath.sh # SKIP
-ok 31 selftests: kvm: vmx_close_while_nested_test
-ok 31 selftests: net/forwarding: ipip_flat_gre_key.sh # SKIP
-ok 32 selftests: kvm: vmx_dirty_log_test
-ok 32 selftests: net/forwarding: ipip_flat_gre_keys.sh # SKIP
-ok 33 selftests: kvm: vmx_exception_with_invalid_guest_state # SKIP
-ok 33 selftests: net/forwarding: ipip_flat_gre.sh # SKIP
-ok 33 selftests: net: traceroute.sh
-ok 34 selftests: net: fin_ack_lat.sh
-ok 34 selftests: net/forwarding: ipip_hier_gre_key.sh # SKIP
-ok 35 selftests: kvm: vmx_invalid_nested_guest_state
-ok 35 selftests: net/forwarding: ipip_hier_gre_keys.sh # SKIP
-ok 36 selftests: kvm: vmx_set_nested_state_test
-ok 36 selftests: net: fib_nexthops.sh # SKIP
-ok 36 selftests: net/forwarding: ipip_hier_gre.sh # SKIP
-ok 37 selftests: kvm: vmx_tsc_adjust_test
-ok 37 selftests: net: altnames.sh # SKIP
-ok 37 selftests: net/forwarding: loopback.sh # SKIP
-ok 38 selftests: kvm: vmx_nested_tsc_scaling_test # SKIP
-ok 38 selftests: net/forwarding: mirror_gre_bound.sh # SKIP
-ok 39 selftests: kvm: xapic_ipi_test
-ok 39 selftests: net/forwarding: mirror_gre_bridge_1d.sh # SKIP
-ok 3 selftests: clone3: clone3_set_tid
-ok 3 selftests: kvm: get_msr_index_features
-ok 3 selftests: lib: prime_numbers.sh # SKIP
-ok 3 selftests: livepatch: test-shadow-vars.sh # SKIP
-ok 3 selftests: memfd: run_hugetlbfs_test.sh # SKIP
-ok 3 selftests: netfilter: nft_nat.sh # SKIP
-ok 3 selftests: net/forwarding: bridge_mld.sh # SKIP
-ok 3 selftests: net/mptcp: mptcp_join.sh # SKIP
-ok 3 selftests: openat2: rename_attack_test
-ok 3 selftests: rseq: param_test
-ok 3 selftests: timens: timer # SKIP
-ok 3 selftests: timers: nsleep-lat
-ok 3 selftests: vDSO: vdso_test_abi
-ok 3 selftests: x86: syscall_nt_64
-ok 40 selftests: kvm: xapic_state_test
-ok 40 selftests: net/forwarding: mirror_gre_bridge_1d_vlan.sh # SKIP
-ok 40 selftests: net: ip6_gre_headroom.sh
-ok 41 selftests: kvm: xss_msr_test
-ok 41 selftests: net/forwarding: mirror_gre_bridge_1q_lag.sh # SKIP
-ok 42 selftests: kvm: debug_regs
-ok 42 selftests: net/forwarding: mirror_gre_bridge_1q.sh # SKIP
-ok 43 selftests: kvm: tsc_msrs_test
-ok 43 selftests: net/forwarding: mirror_gre_changes.sh # SKIP
-ok 44 selftests: kvm: vmx_pmu_caps_test # SKIP
-ok 44 selftests: net/forwarding: mirror_gre_flower.sh # SKIP
-ok 45 selftests: kvm: xen_shinfo_test # SKIP
-ok 45 selftests: net/forwarding: mirror_gre_lag_lacp.sh # SKIP
-ok 46 selftests: kvm: xen_vmcall_test # SKIP
-ok 46 selftests: net: devlink_port_split.py # SKIP
-ok 46 selftests: net/forwarding: mirror_gre_neigh.sh # SKIP
-ok 47 selftests: kvm: sev_migrate_tests # SKIP
-ok 47 selftests: net: drop_monitor_tests.sh # SKIP
-ok 47 selftests: net/forwarding: mirror_gre_nh.sh # SKIP
-ok 48 selftests: kvm: amx_test # SKIP
-ok 48 selftests: net/forwarding: mirror_gre.sh # SKIP
-ok 49 selftests: kvm: max_vcpuid_cap_test
-ok 49 selftests: net: bareudp.sh # SKIP
-ok 49 selftests: net/forwarding: mirror_gre_vlan_bridge_1q.sh # SKIP
-ok 4 selftests: clone3: clone3_cap_checkpoint_restore
-ok 4 selftests: drivers/net/bonding: dev_addr_lists.sh # SKIP
-ok 4 selftests: lib: scanf.sh # SKIP
-ok 4 selftests: livepatch: test-state.sh # SKIP
-ok 4 selftests: netfilter: bridge_brouter.sh # SKIP
-ok 4 selftests: net/forwarding: bridge_port_isolation.sh # SKIP
-ok 4 selftests: net: reuseport_dualstack
-ok 4 selftests: proc: proc-loadavg-001 # SKIP
-ok 4 selftests: rseq: param_test_benchmark
-ok 4 selftests: timens: clock_nanosleep # SKIP
-ok 4 selftests: timers: set-timer-lat
-ok 4 selftests: vDSO: vdso_test_clock_getres
-ok 4 selftests: x86: test_mremap_vdso_64
-ok 50 selftests: kvm: triple_fault_event_test
-ok 50 selftests: net/forwarding: mirror_gre_vlan.sh # SKIP
-ok 51 selftests: kvm: access_tracking_perf_test # SKIP
-ok 51 selftests: net/forwarding: mirror_vlan.sh # SKIP
-ok 52 selftests: kvm: demand_paging_test
-ok 52 selftests: net/forwarding: pedit_dsfield.sh # SKIP
-ok 53 selftests: net/forwarding: pedit_ip.sh # SKIP
-ok 54 selftests: kvm: dirty_log_perf_test
-ok 54 selftests: net/forwarding: pedit_l4port.sh # SKIP
-ok 54 selftests: net: gre_gso.sh # SKIP
-ok 55 selftests: kvm: hardware_disable_test
-ok 55 selftests: net/forwarding: q_in_vni_ipv6.sh # SKIP
-ok 56 selftests: kvm: kvm_create_max_vcpus
-ok 56 selftests: net/forwarding: q_in_vni.sh # SKIP
-ok 56 selftests: net: vrf_strict_mode_test.sh # SKIP
-ok 57 selftests: kvm: kvm_page_table_test
-ok 57 selftests: net/forwarding: router_bridge.sh # SKIP
-ok 58 selftests: kvm: max_guest_memory_test
-ok 58 selftests: net/forwarding: router_bridge_vlan.sh # SKIP
-ok 59 selftests: kvm: memslot_modification_stress_test
-ok 59 selftests: net/forwarding: router_broadcast.sh # SKIP
-ok 5 selftests: drivers/net/bonding: mode-1-recovery-updelay.sh # SKIP
-ok 5 selftests: kvm: emulator_error_test # SKIP
-ok 5 selftests: lib: strscpy.sh # SKIP
-ok 5 selftests: livepatch: test-ftrace.sh # SKIP
-ok 5 selftests: netfilter: conntrack_icmp_related.sh # SKIP
-ok 5 selftests: net/forwarding: bridge_sticky_fdb.sh # SKIP
-ok 5 selftests: net/mptcp: simult_flows.sh # SKIP
-ok 5 selftests: proc: proc-pid-vm # SKIP
-ok 5 selftests: rseq: param_test_compare_twice
-ok 5 selftests: timens: procfs # SKIP
-ok 5 selftests: timers: mqueue-lat
-ok 5 selftests: vDSO: vdso_standalone_test_x86
-ok 5 selftests: x86: check_initial_reg_state_64
-ok 60 selftests: kvm: memslot_perf_test
-ok 60 selftests: net/forwarding: router_mpath_nh_res.sh # SKIP
-ok 61 selftests: kvm: rseq_test
-ok 61 selftests: net/forwarding: router_mpath_nh.sh # SKIP
-ok 62 selftests: kvm: set_memory_region_test
-ok 62 selftests: net/forwarding: router_multicast.sh # SKIP
-ok 63 selftests: kvm: steal_time
-ok 63 selftests: net/forwarding: router_multipath.sh # SKIP
-ok 64 selftests: kvm: kvm_binary_stats_test
-ok 64 selftests: net/forwarding: router_nh.sh # SKIP
-ok 65 selftests: kvm: system_counter_offset_test
-ok 65 selftests: net/forwarding: router.sh # SKIP
-ok 66 selftests: kvm: nx_huge_pages_test.sh
-ok 66 selftests: net/forwarding: router_vid_1.sh # SKIP
-ok 67 selftests: net/forwarding: sch_ets.sh # SKIP
-ok 68 selftests: net/forwarding: sch_red.sh # SKIP
-ok 69 selftests: net/forwarding: sch_tbf_ets.sh # SKIP
-ok 6 selftests: cgroup: test_stress.sh # SKIP
-ok 6 selftests: drivers/net/bonding: mode-2-recovery-updelay.sh # SKIP
-ok 6 selftests: kvm: fix_hypercall_test
-ok 6 selftests: netfilter: nft_flowtable.sh # SKIP
-ok 6 selftests: net/forwarding: bridge_vlan_aware.sh # SKIP
-ok 6 selftests: net/mptcp: mptcp_sockopt.sh # SKIP
-ok 6 selftests: net: tls
-ok 6 selftests: proc: proc-self-map-files-001
-ok 6 selftests: rseq: run_param_test.sh
-ok 6 selftests: timens: exec # SKIP
-ok 6 selftests: timers: inconsistency-check
-ok 6 selftests: vDSO: vdso_test_correctness
-ok 70 selftests: net/forwarding: sch_tbf_prio.sh # SKIP
-ok 71 selftests: net/forwarding: sch_tbf_root.sh # SKIP
-ok 72 selftests: net/forwarding: skbedit_priority.sh # SKIP
-ok 73 selftests: net/forwarding: tc_actions.sh # SKIP
-ok 74 selftests: net/forwarding: tc_chains.sh # SKIP
-ok 75 selftests: net/forwarding: tc_flower_router.sh # SKIP
-ok 76 selftests: net/forwarding: tc_flower.sh # SKIP
-ok 77 selftests: net/forwarding: tc_mpls_l2vpn.sh # SKIP
-ok 78 selftests: net/forwarding: tc_police.sh # SKIP
-ok 79 selftests: net/forwarding: tc_shblocks.sh # SKIP
-ok 7 selftests: cgroup: test_cpuset_prs.sh
-ok 7 selftests: netfilter: ipvs.sh # SKIP
-ok 7 selftests: net/forwarding: bridge_vlan_mcast.sh # SKIP
-ok 7 selftests: net: run_netsocktests
-ok 7 selftests: proc: proc-self-map-files-002
-ok 7 selftests: timens: futex # SKIP
-ok 7 selftests: timers: raw_skew
-ok 7 selftests: x86: iopl_64
-ok 80 selftests: net/forwarding: tc_vlan_modify.sh # SKIP
-ok 81 selftests: net/forwarding: vxlan_asymmetric_ipv6.sh # SKIP
-ok 82 selftests: net/forwarding: vxlan_asymmetric.sh # SKIP
-ok 83 selftests: net/forwarding: vxlan_bridge_1d_ipv6.sh # SKIP
-ok 84 selftests: net/forwarding: vxlan_bridge_1d_port_8472_ipv6.sh # SKIP
-ok 85 selftests: net/forwarding: vxlan_bridge_1d_port_8472.sh # SKIP
-ok 86 selftests: net/forwarding: vxlan_bridge_1d.sh # SKIP
-ok 87 selftests: net/forwarding: vxlan_bridge_1q_ipv6.sh # SKIP
-ok 88 selftests: net/forwarding: vxlan_bridge_1q_port_8472_ipv6.sh # SKIP
-ok 89 selftests: net/forwarding: vxlan_bridge_1q_port_8472.sh # SKIP
-ok 8 selftests: kvm: hyperv_cpuid
-ok 8 selftests: net/forwarding: bridge_vlan_unaware.sh # SKIP
-ok 8 selftests: net: run_afpackettests # SKIP
-ok 8 selftests: proc: proc-self-syscall
-ok 8 selftests: timens: vfork_exec # SKIP
-ok 8 selftests: timers: threadtest
-ok 8 selftests: x86: ioperm_64
-ok 90 selftests: net/forwarding: vxlan_bridge_1q.sh # SKIP
-ok 91 selftests: net/forwarding: vxlan_symmetric_ipv6.sh # SKIP
-ok 92 selftests: net/forwarding: vxlan_symmetric.sh # SKIP
-ok 9 selftests: kvm: hyperv_features
-ok 9 selftests: netfilter: nft_conntrack_helper.sh # SKIP
-ok 9 selftests: net/forwarding: custom_multipath_hash.sh # SKIP
-ok 9 selftests: proc: proc-self-wchan
-ok 9 selftests: timers: rtcpie # SKIP
-ok 9 selftests: x86: test_vsyscall_64
```

tls selftests results:
```
# selftests: net: tls
# #  RUN           global.tls_v6ops ...
# #            OK  global.tls_v6ops
# ok 4 global.tls_v6ops
# #  RUN           tls_basic.base_base ...
# #            OK  tls_basic.base_base
# ok 5 tls_basic.base_base
# #  RUN           tls.12_gcm.sendfile ...
# #            OK  tls.12_gcm.sendfile
# ok 6 tls.12_gcm.sendfile
# #  RUN           tls.12_gcm.send_then_sendfile ...
# #            OK  tls.12_gcm.send_then_sendfile
# ok 7 tls.12_gcm.send_then_sendfile
# #  RUN           tls.12_gcm.multi_chunk_sendfile ...
# #            OK  tls.12_gcm.multi_chunk_sendfile
# ok 8 tls.12_gcm.multi_chunk_sendfile
# #  RUN           tls.12_gcm.recv_max ...
# #            OK  tls.12_gcm.recv_max
# ok 9 tls.12_gcm.recv_max
# #  RUN           tls.12_gcm.recv_small ...
# #            OK  tls.12_gcm.recv_small
# ok 10 tls.12_gcm.recv_small
# #  RUN           tls.12_gcm.msg_more ...
# #            OK  tls.12_gcm.msg_more
...
# ok 455 tls_err.13_aes_gcm.bad_cmsg
# #  RUN           tls_err.13_aes_gcm.timeo ...
# #            OK  tls_err.13_aes_gcm.timeo
# ok 456 tls_err.13_aes_gcm.timeo
ok 6 selftests: net: tls

```
[kselftest-before.log](https://github.com/user-attachments/files/22722472/kselftest-before.log)
[kselftest-after.log](https://github.com/user-attachments/files/22724044/kselftest-after.log)

## KABI -- this was also checked by the build script
```
> ../kernel-dist-git/SOURCES/check-kabi -k ../kernel-dist-git/SOURCES/Module.kabi_x86_64 -s Module.symvers
> echo $?
0
```

## Interdiff
```
> interdiffbkpt 4ab26bce3969f8fd925fe6f6f551e4d1a508c68b 9ee6109a078758f3b2ff02bacc102f8936535874 
```
## Check_kernel_commits

```
> python3 ~/ciq/kernel-src-tree-tools/check_kernel_commits.py --repo . --pr_branch {rnicolescu}_fips-9-compliant/5.14.0-284.30.1 --base_branch fips-9-compliant/5.14.0-284.30.1

All referenced commits exist upstream and have no Fixes: tags.
```
