### PR TITLE
[rlc-8] mm: scrape LRU pages for offlined memcgs

### DIFF
--- a/Documentation/sysctl/vm.txt
+++ b/Documentation/sysctl/vm.txt
@@ -225,6 +225,8 @@ To free reclaimable slab objects (includes dentries and inodes):
 	echo 2 > /proc/sys/vm/drop_caches
 To free slab objects and pagecache:
 	echo 3 > /proc/sys/vm/drop_caches
+To scrape LRU pages from offlined memcgs:
+	echo 8 > /proc/sys/vm/drop_caches
 
 This is a non-destructive operation and will not free any dirty objects.
 To increase the number of objects freed by this operation, the user may run
@@ -248,6 +250,14 @@ used:
 
 These are informational only.  They do not mean that anything is wrong
 with your system.  To disable them, echo 4 (bit 3) into drop_caches.
+
+Note that for offlined memcgs, kmem (slab) is reparented so that it
+does not hold refcnts which would in turn prevent those memcgs from
+being released. However, reparenting does not apply to LRU pages
+(pagecache), and therefore they need to be scraped as well for
+offlined memcgs. "echo 8" was introduced for this reason. And unlike
+"echo 1", it does not have performance impact on online memcgs in
+terms of zapping pagecache.
 
 ==============================================================
 

--- a/include/linux/memcontrol.h
+++ b/include/linux/memcontrol.h
@@ -73,6 +73,8 @@ struct mem_cgroup_reclaim_cookie {
 	unsigned int generation;
 };
 
+#define MEM_CGROUP_RECLAIM_RETRIES	5
+
 #ifdef CONFIG_MEMCG
 
 #define MEM_CGROUP_ID_SHIFT	16
@@ -1150,6 +1152,15 @@ unsigned long mem_cgroup_soft_limit_reclaim(pg_data_t *pgdat, int order,
 						gfp_t gfp_mask,
 						unsigned long *total_scanned);
 
+static inline unsigned long offlined_memcg_nr_pages(void)
+{
+	extern atomic_t nr_offlined_memcgs;
+
+	return atomic_read(&nr_offlined_memcgs) * MEMCG_CHARGE_BATCH;
+}
+
+unsigned long scrape_offlined_memcgs(unsigned long nr_to_reclaim);
+
 #else /* CONFIG_MEMCG */
 
 #define MEM_CGROUP_ID_SHIFT	0
@@ -1526,6 +1537,17 @@ unsigned long mem_cgroup_soft_limit_reclaim(pg_data_t *pgdat, int order,
 {
 	return 0;
 }
+
+static inline unsigned long offlined_memcg_nr_pages(void)
+{
+	return 0;
+}
+
+static inline unsigned long scrape_offlined_memcgs(unsigned long nr_to_reclaim)
+{
+	return 0;
+}
+
 #endif /* CONFIG_MEMCG */
 
 static inline void __inc_lruvec_kmem_state(void *p, enum node_stat_item idx)

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -128,6 +128,7 @@ static int sixty = 60;
 static int __maybe_unused neg_one = -1;
 static int __maybe_unused two = 2;
 static int __maybe_unused four = 4;
+static int __maybe_unused eight = 8;
 static unsigned long zero_ul;
 static unsigned long one_ul = 1;
 static unsigned long long_max = LONG_MAX;
@@ -1483,7 +1484,7 @@ static struct ctl_table vm_table[] = {
 		.mode		= 0644,
 		.proc_handler	= drop_caches_sysctl_handler,
 		.extra1		= SYSCTL_ONE,
-		.extra2		= &four,
+		.extra2		= &eight,
 	},
 #ifdef CONFIG_COMPACTION
 	{

--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -5594,6 +5594,8 @@ static int mem_cgroup_css_online(struct cgroup_subsys_state *css)
 	return 0;
 }
 
+atomic_t nr_offlined_memcgs = ATOMIC_INIT(0);
+
 static void mem_cgroup_css_offline(struct cgroup_subsys_state *css)
 {
 	struct mem_cgroup *memcg = mem_cgroup_from_css(css);
@@ -5621,6 +5623,8 @@ static void mem_cgroup_css_offline(struct cgroup_subsys_state *css)
 	drain_all_stock(memcg);
 
 	memcg_percpu_stats_disable(memcg);
+
+	atomic_inc(&nr_offlined_memcgs);
 }
 
 static void mem_cgroup_css_released(struct cgroup_subsys_state *css)
@@ -5628,6 +5632,8 @@ static void mem_cgroup_css_released(struct cgroup_subsys_state *css)
 	struct mem_cgroup *memcg = mem_cgroup_from_css(css);
 
 	invalidate_reclaim_iterators(memcg);
+
+	atomic_dec(&nr_offlined_memcgs);
 }
 
 static void mem_cgroup_css_free(struct cgroup_subsys_state *css)

--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -123,6 +123,9 @@ struct scan_control {
 	/* The file pages on the current node are dangerously low */
 	unsigned int file_is_tiny:1;
 
+	/* Scrape LRU pages from offlined memcgs */
+	unsigned int scrape_offlined_memcgs:1;
+
 	/* Allocation order */
 	s8 order;
 
@@ -3034,6 +3037,9 @@ static void shrink_node_memcgs(pg_data_t *pgdat, struct scan_control *sc)
 			memcg_memory_event(memcg, MEMCG_LOW);
 		}
 
+		if (sc->scrape_offlined_memcgs && mem_cgroup_online(memcg))
+			continue;
+
 		reclaimed = sc->nr_reclaimed;
 		scanned = sc->nr_scanned;
 
@@ -4736,3 +4742,31 @@ void check_move_unevictable_pages(struct pagevec *pvec)
 	}
 }
 EXPORT_SYMBOL_GPL(check_move_unevictable_pages);
+
+#ifdef CONFIG_MEMCG
+unsigned long scrape_offlined_memcgs(unsigned long nr_to_reclaim)
+{
+	unsigned int flags;
+	unsigned long nr_reclaimed;
+	struct scan_control sc = {
+		.nr_to_reclaim = max(nr_to_reclaim, SWAP_CLUSTER_MAX),
+		.gfp_mask = GFP_KERNEL,
+		.target_mem_cgroup = root_mem_cgroup,
+		.reclaim_idx = MAX_NR_ZONES - 1,
+		.may_writepage = true,
+		.may_unmap = true,
+		.scrape_offlined_memcgs = true,
+	};
+	struct zonelist *zonelist = node_zonelist(numa_node_id(), sc.gfp_mask);
+
+	set_task_reclaim_state(current, &sc.reclaim_state);
+	flags = memalloc_noreclaim_save();
+
+	nr_reclaimed = do_try_to_free_pages(zonelist, &sc);
+
+	memalloc_noreclaim_restore(flags);
+	set_task_reclaim_state(current, NULL);
+
+	return nr_reclaimed;
+}
+#endif


### PR DESCRIPTION
This change came as a patch from Google.  It is not upstream as there is still ongoing work to fix this issue in the upstream https://lore.kernel.org/linux-mm/20250415024532.26632-1-songmuchun@bytedance.com/.  This patch is a stopgap until the upstream solution is ready.  I had to make a few tweaks to the supplied patch, which I have mentioned in the upstream-diff section of the commit message.

Original patch:
[v1-0001-mm-scrape-LRU-pages-for-offlined-memcgs.patch](https://github.com/user-attachments/files/23777710/v1-0001-mm-scrape-LRU-pages-for-offlined-memcgs.patch)


```
mm: scrape LRU pages for offlined memcgs

jira KERNEL-172
feature Add ability to scrape LRU pages from offlined memcgs commit-author Yu Zhao <yuzhao@google.com>
commit-source v1-0001-mm-scrape-LRU-pages-for-offlined-memcgs.patch commit-source-path Provided by Google Engineering
upstream-diff A few tweaks to the original patch were necessary:
              * Removed unused nid variable from scrape_offlined_memcgs
              * Switched extra2 to 8 (otherwise 'echo 8 > /proc/sys/vm/drop_caches'
                would be rejected)
              * Renamed nr_pages_to_scrape to offlined_memcg_nr_pages in the
                !CONFIG_MEMCG case to match the CONFIG_MEMCG case
              * Added 'return 0' to scrape_offlined_memcgs in the
                !CONFIG_MEMCG case

For offlined memcgs, kmem (slab) is reparented so that it does not hold refcnts which would in turn prevent those memcgs from being released.

However, reparenting does not apply to LRU pages (pagecache), and therefore they need to be scraped as well for offlined memcgs. "echo 8 > /proc/sys/vm/drop_caches" was introduced for this reason. And unlike "echo 1", it does not have performance impact on online memcgs in terms of zapping pagecache.
```

### Build Log

```
/home/brett/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 11s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-us122l.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1024s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/cast5-avx-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9+
[TIMER]{MODULES}: 11s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 55s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 11s
[TIMER]{BUILD}: 1024s
[TIMER]{MODULES}: 11s
[TIMER]{INSTALL}: 55s
[TIMER]{TOTAL} 1117s
Rebooting in 10 seconds

```

### Testing

Verified that 8 is now an accepted value to /proc/sys/vm/drop_caches.  Also did a build with some debug to ensure scrape_offlined_memcgs was actually being called.

```
brett@lycia ~/ciq/kernel-172 % cat drop_caches-4.18.0-553.16.1.el8_10.ciqfips.0.14.1.x86_64.log
[brett@kernel-172 ~]$ uname -a
Linux kernel-172 4.18.0-553.16.1.el8_10.ciqfips.0.14.1.x86_64 #1 SMP Thu Oct 2 20:02:44 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
[brett@kernel-172 ~]$ sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches'
[brett@kernel-172 ~]$ sudo sh -c 'echo 2 > /proc/sys/vm/drop_caches'
[brett@kernel-172 ~]$ sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
[brett@kernel-172 ~]$ sudo sh -c 'echo 8 > /proc/sys/vm/drop_caches'
sh: line 0: echo: write error: Invalid argument
[brett@kernel-172 ~]$

brett@lycia ~/ciq/kernel-172 % cat drop_caches-4.18.0-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9+.log
[brett@kernel-172 ~]$ uname -a
Linux kernel-172 4.18.0-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9+ #1 SMP Tue Nov 25 20:23:46 UTC 2025 x86_64 x86_64 x86_64
GNU/Linux
[brett@kernel-172 ~]$ sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches'
[brett@kernel-172 ~]$ sudo sh -c 'echo 2 > /proc/sys/vm/drop_caches'
[brett@kernel-172 ~]$ sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
[brett@kernel-172 ~]$ sudo sh -c 'echo 8 > /proc/sys/vm/drop_caches'
[brett@kernel-172 ~]$
brett@lycia ~/ciq/kernel-172 %

```

Also did normal smoke testing

[selftest-4.18.0-553.16.1.el8_10.ciqfips.0.14.1.x86_64-1.log](https://github.com/user-attachments/files/23777318/selftest-4.18.0-553.16.1.el8_10.ciqfips.0.14.1.x86_64-1.log)

[selftest-4.18.0-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9+-1.log](https://github.com/user-attachments/files/23777733/selftest-4.18.0-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9%2B-1.log)


```
brett@lycia ~/ciq/kernel-172/kselftest-logs
 % grep ^ok selftest-4.18.0-553.16.1.el8_10.ciqfips.0.14.1.x86_64-1.log | wc -l
269
brett@lycia ~/ciq/kernel-172/kselftest-logs
 % grep ^ok selftest-4.18.0-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9+-1.log | wc -l
271
brett@lycia ~/ciq/kernel-172/kselftest-logs
 % grep ok <(diff -adU0 <(grep ^ok selftest-4.18.0-553.16.1.el8_10.ciqfips.0.14.1.x86_64-1.log | sort -h) <(grep ^ok selftest-4.18.0-bmastbergen_rlc-8_4.18.0-553.83.1.el8_10_KERNEL-172-9+-1.log | sort -h))

-ok 1 selftests: livepatch: test-livepatch.sh # SKIP
+ok 1 selftests: livepatch: test-livepatch.sh
-ok 1 selftests: zram: zram.sh # SKIP
+ok 1 selftests: zram: zram.sh
+ok 29 selftests: net: l2tp.sh
-ok 2 selftests: livepatch: test-callbacks.sh # SKIP
+ok 2 selftests: livepatch: test-callbacks.sh
-ok 38 selftests: net: bareudp.sh # SKIP
+ok 38 selftests: net: bareudp.sh
-ok 3 selftests: livepatch: test-shadow-vars.sh # SKIP
+ok 3 selftests: livepatch: test-shadow-vars.sh
-ok 4 selftests: livepatch: test-state.sh # SKIP
+ok 4 selftests: livepatch: test-state.sh
-ok 5 selftests: livepatch: test-ftrace.sh # SKIP
+ok 5 selftests: livepatch: test-ftrace.sh
+ok 9 selftests: net: test_bpf.sh
brett@lycia ~/ciq/kernel-172/kselftest-logs
 %

```