### PR TITLE
[fips-9.2] mm: scrape LRU pages for offlined memcgs

### DIFF
--- a/Documentation/admin-guide/sysctl/vm.rst
+++ b/Documentation/admin-guide/sysctl/vm.rst
@@ -243,6 +243,10 @@ To free slab objects and pagecache::
 
 	echo 3 > /proc/sys/vm/drop_caches
 
+To scrape LRU pages from offlined memcgs:
+
+	echo 8 > /proc/sys/vm/drop_caches
+
 This is a non-destructive operation and will not free any dirty objects.
 To increase the number of objects freed by this operation, the user may run
 `sync` prior to writing to /proc/sys/vm/drop_caches.  This will minimize the
@@ -265,6 +269,14 @@ used::
 
 These are informational only.  They do not mean that anything is wrong
 with your system.  To disable them, echo 4 (bit 2) into drop_caches.
+
+Note that for offlined memcgs, kmem (slab) is reparented so that it
+does not hold refcnts which would in turn prevent those memcgs from
+being released. However, reparenting does not apply to LRU pages
+(pagecache), and therefore they need to be scraped as well for
+offlined memcgs. "echo 8" was introduced for this reason. And unlike
+"echo 1", it does not have performance impact on online memcgs in
+terms of zapping pagecache.
 
 
 extfrag_threshold

--- a/fs/proc/proc_sysctl.c
+++ b/fs/proc/proc_sysctl.c
@@ -26,7 +26,7 @@ static const struct file_operations proc_sys_dir_file_operations;
 static const struct inode_operations proc_sys_dir_operations;
 
 /* shared constants to be used in various sysctls */
-const int sysctl_vals[] = { -1, 0, 1, 2, 4, 100, 200, 1000, 3000, INT_MAX };
+const int sysctl_vals[] = { -1, 0, 1, 2, 4, 8, 100, 200, 1000, 3000, INT_MAX };
 EXPORT_SYMBOL(sysctl_vals);
 
 /* Support for permanently empty directories */

--- a/include/linux/memcontrol.h
+++ b/include/linux/memcontrol.h
@@ -58,6 +58,8 @@ struct mem_cgroup_reclaim_cookie {
 	unsigned int generation;
 };
 
+#define MEM_CGROUP_RECLAIM_RETRIES	5
+
 #ifdef CONFIG_MEMCG
 
 #define MEM_CGROUP_ID_SHIFT	16
@@ -1137,6 +1139,15 @@ unsigned long mem_cgroup_soft_limit_reclaim(pg_data_t *pgdat, int order,
 						gfp_t gfp_mask,
 						unsigned long *total_scanned);
 
+static inline unsigned long offlined_memcg_nr_pages(void)
+{
+	extern atomic_t nr_offlined_memcgs;
+
+	return atomic_read(&nr_offlined_memcgs) * MEMCG_CHARGE_BATCH;
+}
+
+unsigned long scrape_offlined_memcgs(unsigned long nr_to_reclaim);
+
 #else /* CONFIG_MEMCG */
 
 #define MEM_CGROUP_ID_SHIFT	0
@@ -1545,6 +1556,17 @@ unsigned long mem_cgroup_soft_limit_reclaim(pg_data_t *pgdat, int order,
 {
 	return 0;
 }
+
+static inline unsigned long offlined_memcg_nr_pages(void)
+{
+	return 0;
+}
+
+static inline unsigned long scrape_offlined_memcgs(unsigned long nr_to_reclaim)
+{
+	return 0;
+}
+
 #endif /* CONFIG_MEMCG */
 
 static inline void __inc_lruvec_kmem_state(void *p, enum node_stat_item idx)

--- a/include/linux/sysctl.h
+++ b/include/linux/sysctl.h
@@ -43,11 +43,12 @@ struct ctl_dir;
 #define SYSCTL_ONE			((void *)&sysctl_vals[2])
 #define SYSCTL_TWO			((void *)&sysctl_vals[3])
 #define SYSCTL_FOUR			((void *)&sysctl_vals[4])
-#define SYSCTL_ONE_HUNDRED		((void *)&sysctl_vals[5])
-#define SYSCTL_TWO_HUNDRED		((void *)&sysctl_vals[6])
-#define SYSCTL_ONE_THOUSAND		((void *)&sysctl_vals[7])
-#define SYSCTL_THREE_THOUSAND		((void *)&sysctl_vals[8])
-#define SYSCTL_INT_MAX			((void *)&sysctl_vals[9])
+#define SYSCTL_EIGHT			((void *)&sysctl_vals[5])
+#define SYSCTL_ONE_HUNDRED		((void *)&sysctl_vals[6])
+#define SYSCTL_TWO_HUNDRED		((void *)&sysctl_vals[7])
+#define SYSCTL_ONE_THOUSAND		((void *)&sysctl_vals[8])
+#define SYSCTL_THREE_THOUSAND		((void *)&sysctl_vals[9])
+#define SYSCTL_INT_MAX			((void *)&sysctl_vals[10])
 
 extern const int sysctl_vals[];
 

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -2627,7 +2627,7 @@ static struct ctl_table vm_table[] = {
 		.mode		= 0200,
 		.proc_handler	= drop_caches_sysctl_handler,
 		.extra1		= SYSCTL_ONE,
-		.extra2		= SYSCTL_FOUR,
+		.extra2		= SYSCTL_EIGHT,
 	},
 #ifdef CONFIG_COMPACTION
 	{

--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -5350,6 +5350,8 @@ remove_id:
 	return -ENOMEM;
 }
 
+atomic_t nr_offlined_memcgs = ATOMIC_INIT(0);
+
 static void mem_cgroup_css_offline(struct cgroup_subsys_state *css)
 {
 	struct mem_cgroup *memcg = mem_cgroup_from_css(css);
@@ -5377,6 +5379,8 @@ static void mem_cgroup_css_offline(struct cgroup_subsys_state *css)
 	drain_all_stock(memcg);
 
 	mem_cgroup_id_put(memcg);
+
+	atomic_inc(&nr_offlined_memcgs);
 }
 
 static void mem_cgroup_css_released(struct cgroup_subsys_state *css)
@@ -5384,6 +5388,8 @@ static void mem_cgroup_css_released(struct cgroup_subsys_state *css)
 	struct mem_cgroup *memcg = mem_cgroup_from_css(css);
 
 	invalidate_reclaim_iterators(memcg);
+
+	atomic_dec(&nr_offlined_memcgs);
 }
 
 static void mem_cgroup_css_free(struct cgroup_subsys_state *css)


### PR DESCRIPTION
This change came as a patch from Google. It is not upstream as there is still ongoing work to fix this issue in the upstream https://lore.kernel.org/linux-mm/20250415024532.26632-1-songmuchun@bytedance.com/. This patch is a stopgap until the upstream solution is ready. I had to make a few tweaks to the supplied patch, which I have mentioned in the upstream-diff section of the commit message.

Original patch:
[v1-0001-mm-scrape-LRU-pages-for-offlined-memcgs.patch](https://github.com/user-attachments/files/23887264/v1-0001-mm-scrape-LRU-pages-for-offlined-memcgs.patch)


```
jira KERNEL-173
feature Add ability to scrape LRU pages from offlined memcgs
commit-author: Yu Zhao <yuzhao@google.com>
commit-source v1-0001-mm-scrape-LRU-pages-for-offlined-memcgs.patch commit-source-path Provided by Google Engineering
upstream-diff A few tweaks to the original patch were necessary:
              * Format changes because Documentation/sysctl/vm.txt has
                been changed to Documentation/admin-guide/sysctl/vm.rst
              * Removed unused nid variable from scrape_offlined_memcgs
              * Switched drop_caches_sysctl_handler to use SYSCTL_EIGHT
                (otherwise 'echo 8 > /proc/sys/vm/drop_caches' would be
                rejected)
              * Renamed nr_pages_to_scrape to offlined_memcg_nr_pages in the
                !CONFIG_MEMCG case to match the CONFIG_MEMCG case
              * Added 'return 0' to scrape_offlined_memcgs in the
                !CONFIG_MEMCG case

For offlined memcgs, kmem (slab) is reparented so that it does not hold refcnts which would in turn prevent those memcgs from being released.

However, reparenting does not apply to LRU pages (pagecache), and therefore they need to be scraped as well for offlined memcgs. "echo 8 > /proc/sys/vm/drop_caches" was introduced for this reason. And unlike "echo 1", it does not have performance impact on online memcgs in terms of zapping pagecache.
```

### Build Log

```
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old certs/signing_key.pem certs/signing_key.x509 certs/x509.genkey
[TIMER]{MRPROPER}: 16s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
--
  BTF [M] sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] virt/lib/irqbypass.ko
  BTF [M] sound/xen/snd_xen_front.ko
  BTF [M] sound/virtio/virtio_snd.ko
[TIMER]{BUILD}: 939s
Making Modules
  INSTALL /lib/modules/5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+/kernel/arch/x86/crypto/blake2s-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+/kernel/arch/x86/crypto/blowfish-x86_64.ko
  INSTALL /lib/modules/5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+/kernel/arch/x86/crypto/camellia-aesni-avx2.ko
--
  SIGN    /lib/modules/5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+/kernel/sound/x86/snd-hdmi-lpe-audio.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+/kernel/sound/xen/snd_xen_front.ko
  SIGN    /lib/modules/5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+/kernel/sound/virtio/virtio_snd.ko
  DEPMOD  /lib/modules/5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+
[TIMER]{MODULES}: 10s
Making Install
sh ./arch/x86/boot/install.sh \
	5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 61s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+ and Index to 1
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 16s
[TIMER]{BUILD}: 939s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 61s
[TIMER]{TOTAL} 1045s
Rebooting in 10 seconds

```

### Testing

Verified that 8 is now an accepted value to /proc/sys/vm/drop_caches. Also did a build with some debug to ensure scrape_offlined_memcgs was actually being called.

```
brett@lycia ~/ciq/kernel-173 % cat drop_caches-5.14.0-284.30.1.el9_2.92ciq_lts.14.2.x86_64.log
[brett@kernel-173 ~]$ uname -a
Linux kernel-173 5.14.0-284.30.1.el9_2.92ciq_lts.14.2.x86_64 #1 SMP PREEMPT_DYNAMIC Mon Nov 24 18:30:16 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
[brett@kernel-173 ~]$ sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches'
[brett@kernel-173 ~]$ sudo sh -c 'echo 2 > /proc/sys/vm/drop_caches'
[brett@kernel-173 ~]$ sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
[brett@kernel-173 ~]$ sudo sh -c 'echo 8 > /proc/sys/vm/drop_caches'
sh: line 1: echo: write error: Invalid argument
[brett@kernel-173 ~]$

brett@lycia ~/ciq/kernel-173 % cat drop_caches-5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+.log
[brett@kernel-173 ~]$ uname -a
Linux kernel-173 5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+ #1 SMP PREEMPT_DYNAMIC Mon Dec 1 21:19:05 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
[brett@kernel-173 ~]$ sudo sh -c 'echo 1 > /proc/sys/vm/drop_caches'
[brett@kernel-173 ~]$ sudo sh -c 'echo 2 > /proc/sys/vm/drop_caches'
[brett@kernel-173 ~]$ sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
[brett@kernel-173 ~]$ sudo sh -c 'echo 8 > /proc/sys/vm/drop_caches'
[brett@kernel-173 ~]$

brett@lycia ~/ciq/kernel-173 %

```

Also did normal smoke testing

[selftest-5.14.0-284.30.1.el9_2.92ciq_lts.14.2.x86_64-1.log](https://github.com/user-attachments/files/23887299/selftest-5.14.0-284.30.1.el9_2.92ciq_lts.14.2.x86_64-1.log)

[drop_caches-5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+.log](https://github.com/user-attachments/files/23887306/drop_caches-5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1%2B.log)

```
brett@lycia ~/ciq/kernel-173/kselftest-logs
 % grep ^ok selftest-5.14.0-284.30.1.el9_2.92ciq_lts.14.2.x86_64-1.log | wc -l
332
brett@lycia ~/ciq/kernel-173/kselftest-logs
 % grep ^ok selftest-5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+-1.log | wc -l
332
brett@lycia ~/ciq/kernel-173/kselftest-logs
 % grep ok <(diff -adU0 <(grep ^ok selftest-5.14.0-284.30.1.el9_2.92ciq_lts.14.2.x86_64-1.log | sort -h) <(grep ^ok selftest-5.14.0-bmastbergen_fips-9-compliant_5.14.0-284.30.1_KERNEL-1+-1.log | sort -h))

-ok 1 selftests: livepatch: test-livepatch.sh # SKIP
+ok 1 selftests: livepatch: test-livepatch.sh
-ok 1 selftests: zram: zram.sh # SKIP
+ok 1 selftests: zram: zram.sh
-ok 2 selftests: livepatch: test-callbacks.sh # SKIP
+ok 2 selftests: livepatch: test-callbacks.sh
+ok 32 selftests: net: l2tp.sh
-ok 3 selftests: livepatch: test-shadow-vars.sh # SKIP
+ok 3 selftests: livepatch: test-shadow-vars.sh
-ok 4 selftests: livepatch: test-state.sh # SKIP
+ok 4 selftests: livepatch: test-state.sh
-ok 58 selftests: kvm: max_guest_memory_test
-ok 5 selftests: livepatch: test-ftrace.sh # SKIP
+ok 5 selftests: livepatch: test-ftrace.sh
-ok 6 selftests: net: tls
+ok 9 selftests: net: test_bpf.sh
brett@lycia ~/ciq/kernel-173/kselftest-logs
 %

```