### PR TITLE
[rlc-10] dcache: export shrink_dentry_list() and add new helper d_dispose_if_u…

### DIFF
--- a/fs/dcache.c
+++ b/fs/dcache.c
@@ -1032,6 +1032,15 @@ struct dentry *d_find_alias_rcu(struct inode *inode)
 	return de;
 }
 
+void d_dispose_if_unused(struct dentry *dentry, struct list_head *dispose)
+{
+	spin_lock(&dentry->d_lock);
+	if (!dentry->d_lockref.count)
+		to_shrink_list(dentry, dispose);
+	spin_unlock(&dentry->d_lock);
+}
+EXPORT_SYMBOL(d_dispose_if_unused);
+
 /*
  *	Try to kill dentries associated with this inode.
  * WARNING: you must own a reference to inode.
@@ -1042,12 +1051,8 @@ void d_prune_aliases(struct inode *inode)
 	struct dentry *dentry;
 
 	spin_lock(&inode->i_lock);
-	hlist_for_each_entry(dentry, &inode->i_dentry, d_u.d_alias) {
-		spin_lock(&dentry->d_lock);
-		if (!dentry->d_lockref.count)
-			to_shrink_list(dentry, &dispose);
-		spin_unlock(&dentry->d_lock);
-	}
+	hlist_for_each_entry(dentry, &inode->i_dentry, d_u.d_alias)
+		d_dispose_if_unused(dentry, &dispose);
 	spin_unlock(&inode->i_lock);
 	shrink_dentry_list(&dispose);
 }
@@ -1087,6 +1092,7 @@ void shrink_dentry_list(struct list_head *list)
 		shrink_kill(dentry);
 	}
 }
+EXPORT_SYMBOL(shrink_dentry_list);
 
 static enum lru_status dentry_lru_isolate(struct list_head *item,
 		struct list_lru_one *lru, void *arg)

--- a/include/linux/dcache.h
+++ b/include/linux/dcache.h
@@ -256,6 +256,8 @@ extern void d_tmpfile(struct file *, struct inode *);
 
 extern struct dentry *d_find_alias(struct inode *);
 extern void d_prune_aliases(struct inode *);
+extern void d_dispose_if_unused(struct dentry *, struct list_head *);
+extern void shrink_dentry_list(struct list_head *);
 
 extern struct dentry *d_find_alias_rcu(struct inode *);
 


### PR DESCRIPTION
https://ciqinc.atlassian.net/browse/SECO-468


## Description
Customer request to backport [this](https://github.com/torvalds/linux/commit/395b95530343) to rlc-10.
The commit is a clean cherry pick and it has no impact on the current kernel.
The main impact is that it exposes a function that is probably used in an external kernel module by the customer.

## Note
It was introduced upstream in preparation for a change to invalidate expired dentries in fuse. https://lore.kernel.org/all/20250916135310.51177-1-luis@igalia.com/
But we are not picking the rest of the changes since that is not of interest. 
This commit has barely any impact since the rest of the changes from this submission are not cherry picked.

## Build

```
> grep -E -B 5 -A 5 '\[TIMER\]|^Starting Build' /home/rnicolescu/ciq/kernels/rlc-10/kernel-build-after.log
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/x509.genkey
[TIMER]{MRPROPER}: 17s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  GEN     arch/x86/include/generated/asm/orc_hash.h
  UPD     include/generated/uapi/linux/version.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
--
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] net/hsr/hsr.ko
  BTF [M] net/qrtr/qrtr-mhi.ko
  BTF [M] net/qrtr/qrtr.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 6228s
Making Modules
  INSTALL /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+/modules.order
  SYMLINK /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+/build
  INSTALL /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+/modules.builtin
  INSTALL /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+/modules.builtin.modinfo
--
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+/kernel/net/hsr/hsr.ko
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+/kernel/net/qrtr/qrtr-mhi.ko
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+/kernel/net/qrtr/qrtr.ko
  DEPMOD  /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+
[TIMER]{MODULES}: 32s
Making Install
  INSTALL /boot
[TIMER]{INSTALL}: 33s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+ and Index to 3
The default is /boot/loader/entries/2adeea37d6d145f09ba612fce6891624-6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+.conf with index 3 and kernel /boot/vmlinuz-6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+
The default is /boot/loader/entries/2adeea37d6d145f09ba612fce6891624-6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+.conf with index 3 and kernel /boot/vmlinuz-6.12.0-rnicolescu_rlc-10_6.12.0-124.31.1.el10_1-4dec50d33010+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 17s
[TIMER]{BUILD}: 6228s
[TIMER]{MODULES}: 32s
[TIMER]{INSTALL}: 33s
[TIMER]{TOTAL} 6319s
Rebooting in 10 seconds
```

## Kselftests

```
> /home/rnicolescu/ciq/kernel-tools/kselftest-diff.sh /home/rnicolescu/ciq/kernels/rlc-10
/home/rnicolescu/ciq/kernels/rlc-10/kselftest-before.log
483
/home/rnicolescu/ciq/kernels/rlc-10/kselftest-after.log
484
Before: /home/rnicolescu/ciq/kernels/rlc-10/kselftest-before.log
After: /home/rnicolescu/ciq/kernels/rlc-10/kselftest-after.log
Diff:
+ok 2 selftests: seccomp: seccomp_benchmark
```