### PR TITLE
[rlc-10] dcache: export shrink_dentry_list() and add new helper d_dispose_if_u…

### DIFF
--- a/fs/dcache.c
+++ b/fs/dcache.c
@@ -1032,6 +1032,15 @@ struct dentry *d_find_alias_rcu(struct inode *inode)
 	return de;
 }
 
+void d_dispose_if_unused(struct dentry *dentry, struct list_head *dispose)
+{
+	spin_lock(&dentry->d_lock);
+	if (!dentry->d_lockref.count)
+		to_shrink_list(dentry, dispose);
+	spin_unlock(&dentry->d_lock);
+}
+EXPORT_SYMBOL(d_dispose_if_unused);
+
 /*
  *	Try to kill dentries associated with this inode.
  * WARNING: you must own a reference to inode.
@@ -1042,12 +1051,8 @@ void d_prune_aliases(struct inode *inode)
 	struct dentry *dentry;
 
 	spin_lock(&inode->i_lock);
-	hlist_for_each_entry(dentry, &inode->i_dentry, d_u.d_alias) {
-		spin_lock(&dentry->d_lock);
-		if (!dentry->d_lockref.count)
-			to_shrink_list(dentry, &dispose);
-		spin_unlock(&dentry->d_lock);
-	}
+	hlist_for_each_entry(dentry, &inode->i_dentry, d_u.d_alias)
+		d_dispose_if_unused(dentry, &dispose);
 	spin_unlock(&inode->i_lock);
 	shrink_dentry_list(&dispose);
 }
@@ -1087,6 +1092,7 @@ void shrink_dentry_list(struct list_head *list)
 		shrink_kill(dentry);
 	}
 }
+EXPORT_SYMBOL(shrink_dentry_list);
 
 static enum lru_status dentry_lru_isolate(struct list_head *item,
 		struct list_lru_one *lru, void *arg)

--- a/include/linux/dcache.h
+++ b/include/linux/dcache.h
@@ -256,6 +256,8 @@ extern void d_tmpfile(struct file *, struct inode *);
 
 extern struct dentry *d_find_alias(struct inode *);
 extern void d_prune_aliases(struct inode *);
+extern void d_dispose_if_unused(struct dentry *, struct list_head *);
+extern void shrink_dentry_list(struct list_head *);
 
 extern struct dentry *d_find_alias_rcu(struct inode *);
 


### PR DESCRIPTION
https://ciqinc.atlassian.net/browse/SECO-468

## Description
Customer request to backport [this](https://github.com/torvalds/linux/commit/395b95530343) to rlc-10.
The commit is a clean cherry pick and it has no impact on the current kernel.
The main impact is that it exposes a function that is probably used in an external kernel module by the customer.

## Note
It was introduced upstream in preparation for a change to invalidate expired dentries in fuse. https://lore.kernel.org/all/20250916135310.51177-1-luis@igalia.com/
But we are not picking the rest of the changes since that is not of interest. 
This commit has barely any impact since the rest of the changes from this submission are not cherry picked.

## Build

```
> grep -E -B 5 -A 5 '\[TIMER\]|^Starting Build' /home/rnicolescu/ciq/kernels/rlc-10/kernel-build-after.log
  CLEAN   scripts/mod
  CLEAN   scripts/selinux/genheaders
  CLEAN   scripts/selinux/mdp
  CLEAN   scripts
  CLEAN   include/config include/generated arch/x86/include/generated .config .config.old .version Module.symvers certs/signing_key.pem certs/x509.genkey
[TIMER]{MRPROPER}: 9s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  GEN     arch/x86/include/generated/asm/orc_hash.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
--
  BTF [M] net/hsr/hsr.ko
  BTF [M] net/qrtr/qrtr-mhi.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] net/qrtr/qrtr.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 2160s
Making Modules
  SYMLINK /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+/build
  INSTALL /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+/modules.order
  INSTALL /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+/modules.builtin
  INSTALL /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+/modules.builtin.modinfo
--
  STRIP   /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+/kernel/net/qrtr/qrtr.ko
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+/kernel/net/qrtr/qrtr-mhi.ko
  DEPMOD  /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+
[TIMER]{MODULES}: 10s
Making Install
  INSTALL /boot
[TIMER]{INSTALL}: 14s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+ and Index to 2
The default is /boot/loader/entries/2adeea37d6d145f09ba612fce6891624-6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+.conf with index 2 and kernel /boot/vmlinuz-6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+
The default is /boot/loader/entries/2adeea37d6d145f09ba612fce6891624-6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+.conf with index 2 and kernel /boot/vmlinuz-6.12.0-rnicolescu_rlc-10_6.12.0-124.35.1.el10_1-72ea64896adc+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 9s
[TIMER]{BUILD}: 2160s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 14s
[TIMER]{TOTAL} 2197s
Rebooting in 10 seconds
```

## Kselftests

```
> /home/rnicolescu/ciq/kernel-tools/kselftest-diff.sh /home/rnicolescu/ciq/kernels/rlc-10
/home/rnicolescu/ciq/kernels/rlc-10/kselftest-before.log
483
/home/rnicolescu/ciq/kernels/rlc-10/kselftest-after.log
481
Before: /home/rnicolescu/ciq/kernels/rlc-10/kselftest-before.log
After: /home/rnicolescu/ciq/kernels/rlc-10/kselftest-after.log
Diff:
-ok 100 selftests: net: test_vxlan_nolocalbypass.sh # SKIP
-ok 101 selftests: net: test_bridge_backup_port.sh # SKIP
+ok 100 selftests: net: test_vxlan_nolocalbypass.sh
+ok 101 selftests: net: test_bridge_backup_port.sh
-ok 14 selftests: net: bind_wildcard
-ok 2 selftests: syscall_user_dispatch: sud_benchmark
-ok 44 selftests: net: fib_nexthops.sh # SKIP
+ok 44 selftests: net: fib_nexthops.sh
-ok 46 selftests: net: altnames.sh # SKIP
+ok 46 selftests: net: altnames.sh
-ok 7 selftests: timers: raw_skew # SKIP
+ok 7 selftests: timers: raw_skew
-ok 98 selftests: net: test_vxlan_mdb.sh # SKIP
+ok 98 selftests: net: test_vxlan_mdb.sh
```

