### PR TITLE
[rlc-10] Fix idpf tx timeout issue

### DIFF
--- a/drivers/net/ethernet/intel/idpf/idpf_singleq_txrx.c
+++ b/drivers/net/ethernet/intel/idpf/idpf_singleq_txrx.c
@@ -415,11 +415,11 @@ netdev_tx_t idpf_tx_singleq_frame(struct sk_buff *skb,
 {
 	struct idpf_tx_offload_params offload = { };
 	struct idpf_tx_buf *first;
+	u32 count, buf_count = 1;
 	int csum, tso, needed;
-	unsigned int count;
 	__be16 protocol;
 
-	count = idpf_tx_desc_count_required(tx_q, skb);
+	count = idpf_tx_res_count_required(tx_q, skb, &buf_count);
 	if (unlikely(!count))
 		return idpf_tx_drop_skb(tx_q, skb);
 

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.c
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
@@ -2132,6 +2132,19 @@ void idpf_tx_splitq_build_flow_desc(union idpf_tx_flex_desc *desc,
 	desc->flow.qw1.compl_tag = cpu_to_le16(params->compl_tag);
 }
 
+/* Global conditions to tell whether the txq (and related resources)
+ * has room to allow the use of "size" descriptors.
+ */
+static int idpf_txq_has_room(struct idpf_tx_queue *tx_q, u32 size)
+{
+	if (IDPF_DESC_UNUSED(tx_q) < size ||
+	    IDPF_TX_COMPLQ_PENDING(tx_q->txq_grp) >
+		IDPF_TX_COMPLQ_OVERFLOW_THRESH(tx_q->txq_grp->complq) ||
+	    IDPF_TX_BUF_RSV_LOW(tx_q))
+		return 0;
+	return 1;
+}
+
 /**
  * idpf_tx_maybe_stop_splitq - 1st level check for Tx splitq stop conditions
  * @tx_q: the queue to be checked
@@ -2142,29 +2155,11 @@ void idpf_tx_splitq_build_flow_desc(union idpf_tx_flex_desc *desc,
 static int idpf_tx_maybe_stop_splitq(struct idpf_tx_queue *tx_q,
 				     unsigned int descs_needed)
 {
-	if (idpf_tx_maybe_stop_common(tx_q, descs_needed))
-		goto out;
+	if (netif_subqueue_maybe_stop(tx_q->netdev, tx_q->idx,
+				      idpf_txq_has_room(tx_q, descs_needed),
+				      1, 1))
+		return 0;
 
-	/* If there are too many outstanding completions expected on the
-	 * completion queue, stop the TX queue to give the device some time to
-	 * catch up
-	 */
-	if (unlikely(IDPF_TX_COMPLQ_PENDING(tx_q->txq_grp) >
-		     IDPF_TX_COMPLQ_OVERFLOW_THRESH(tx_q->txq_grp->complq)))
-		goto splitq_stop;
-
-	/* Also check for available book keeping buffers; if we are low, stop
-	 * the queue to wait for more completions
-	 */
-	if (unlikely(IDPF_TX_BUF_RSV_LOW(tx_q)))
-		goto splitq_stop;
-
-	return 0;
-
-splitq_stop:
-	netif_stop_subqueue(tx_q->netdev, tx_q->idx);
-
-out:
 	u64_stats_update_begin(&tx_q->stats_sync);
 	u64_stats_inc(&tx_q->q_stats.q_busy);
 	u64_stats_update_end(&tx_q->stats_sync);
@@ -2189,12 +2184,6 @@ void idpf_tx_buf_hw_update(struct idpf_tx_queue *tx_q, u32 val,
 
 	nq = netdev_get_tx_queue(tx_q->netdev, tx_q->idx);
 	tx_q->next_to_use = val;
-
-	if (idpf_tx_maybe_stop_common(tx_q, IDPF_TX_DESC_NEEDED)) {
-		u64_stats_update_begin(&tx_q->stats_sync);
-		u64_stats_inc(&tx_q->q_stats.q_busy);
-		u64_stats_update_end(&tx_q->stats_sync);
-	}
 
 	/* Force memory writes to complete before letting h/w
 	 * know there are new descriptors to fetch.  (Only

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.c
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
@@ -7,47 +7,11 @@
 #include "idpf.h"
 #include "idpf_virtchnl.h"
 
-struct idpf_tx_stash {
-	struct hlist_node hlist;
-	struct libeth_sqe buf;
-};
-
 #define idpf_tx_buf_next(buf)		(*(u32 *)&(buf)->priv)
-#define idpf_tx_buf_compl_tag(buf)	(*(u32 *)&(buf)->priv)
 LIBETH_SQE_CHECK_PRIV(u32);
 
 static bool idpf_chk_linearize(struct sk_buff *skb, unsigned int max_bufs,
 			       unsigned int count);
-
-/**
- * idpf_buf_lifo_push - push a buffer pointer onto stack
- * @stack: pointer to stack struct
- * @buf: pointer to buf to push
- *
- * Returns 0 on success, negative on failure
- **/
-static int idpf_buf_lifo_push(struct idpf_buf_lifo *stack,
-			      struct idpf_tx_stash *buf)
-{
-	if (unlikely(stack->top == stack->size))
-		return -ENOSPC;
-
-	stack->bufs[stack->top++] = buf;
-
-	return 0;
-}
-
-/**
- * idpf_buf_lifo_pop - pop a buffer pointer from stack
- * @stack: pointer to stack struct
- **/
-static struct idpf_tx_stash *idpf_buf_lifo_pop(struct idpf_buf_lifo *stack)
-{
-	if (unlikely(!stack->top))
-		return NULL;
-
-	return stack->bufs[--stack->top];
-}
 
 /**
  * idpf_tx_timeout - Respond to a Tx Hang
@@ -77,14 +41,11 @@ void idpf_tx_timeout(struct net_device *netdev, unsigned int txqueue)
 static void idpf_tx_buf_rel_all(struct idpf_tx_queue *txq)
 {
 	struct libeth_sq_napi_stats ss = { };
-	struct idpf_buf_lifo *buf_stack;
-	struct idpf_tx_stash *stash;
 	struct libeth_cq_pp cp = {
 		.dev	= txq->dev,
 		.ss	= &ss,
 	};
-	struct hlist_node *tmp;
-	u32 i, tag;
+	u32 i;
 
 	/* Buffers already cleared, nothing to do */
 	if (!txq->tx_buf)
@@ -96,33 +57,6 @@ static void idpf_tx_buf_rel_all(struct idpf_tx_queue *txq)
 
 	kfree(txq->tx_buf);
 	txq->tx_buf = NULL;
-
-	if (!idpf_queue_has(FLOW_SCH_EN, txq))
-		return;
-
-	buf_stack = &txq->stash->buf_stack;
-	if (!buf_stack->bufs)
-		return;
-
-	/*
-	 * If a Tx timeout occurred, there are potentially still bufs in the
-	 * hash table, free them here.
-	 */
-	hash_for_each_safe(txq->stash->sched_buf_hash, tag, tmp, stash,
-			   hlist) {
-		if (!stash)
-			continue;
-
-		libeth_tx_complete(&stash->buf, &cp);
-		hash_del(&stash->hlist);
-		idpf_buf_lifo_push(buf_stack, stash);
-	}
-
-	for (i = 0; i < buf_stack->size; i++)
-		kfree(buf_stack->bufs[i]);
-
-	kfree(buf_stack->bufs);
-	buf_stack->bufs = NULL;
 }
 
 /**
@@ -198,9 +132,6 @@ static void idpf_tx_desc_rel_all(struct idpf_vport *vport)
  */
 static int idpf_tx_buf_alloc_all(struct idpf_tx_queue *tx_q)
 {
-	struct idpf_buf_lifo *buf_stack;
-	int i;
-
 	/* Allocate book keeping buffers only. Buffers to be supplied to HW
 	 * are allocated by kernel network stack and received as part of skb
 	 */
@@ -212,29 +143,6 @@ static int idpf_tx_buf_alloc_all(struct idpf_tx_queue *tx_q)
 			       GFP_KERNEL);
 	if (!tx_q->tx_buf)
 		return -ENOMEM;
-
-	if (!idpf_queue_has(FLOW_SCH_EN, tx_q))
-		return 0;
-
-	buf_stack = &tx_q->stash->buf_stack;
-
-	/* Initialize tx buf stack for out-of-order completions if
-	 * flow scheduling offload is enabled
-	 */
-	buf_stack->bufs = kcalloc(tx_q->desc_count, sizeof(*buf_stack->bufs),
-				  GFP_KERNEL);
-	if (!buf_stack->bufs)
-		return -ENOMEM;
-
-	buf_stack->size = tx_q->desc_count;
-	buf_stack->top = tx_q->desc_count;
-
-	for (i = 0; i < tx_q->desc_count; i++) {
-		buf_stack->bufs[i] = kzalloc(sizeof(*buf_stack->bufs[i]),
-					     GFP_KERNEL);
-		if (!buf_stack->bufs[i])
-			return -ENOMEM;
-	}
 
 	return 0;
 }
@@ -349,8 +257,6 @@ static int idpf_tx_desc_alloc_all(struct idpf_vport *vport)
 	for (i = 0; i < vport->num_txq_grp; i++) {
 		for (j = 0; j < vport->txq_grps[i].num_txq; j++) {
 			struct idpf_tx_queue *txq = vport->txq_grps[i].txqs[j];
-			u8 gen_bits = 0;
-			u16 bufidx_mask;
 
 			err = idpf_tx_desc_alloc(vport, txq);
 			if (err) {
@@ -359,34 +265,6 @@ static int idpf_tx_desc_alloc_all(struct idpf_vport *vport)
 					i);
 				goto err_out;
 			}
-
-			if (!idpf_is_queue_model_split(vport->txq_model))
-				continue;
-
-			txq->compl_tag_cur_gen = 0;
-
-			/* Determine the number of bits in the bufid
-			 * mask and add one to get the start of the
-			 * generation bits
-			 */
-			bufidx_mask = txq->desc_count - 1;
-			while (bufidx_mask >> 1) {
-				txq->compl_tag_gen_s++;
-				bufidx_mask = bufidx_mask >> 1;
-			}
-			txq->compl_tag_gen_s++;
-
-			gen_bits = IDPF_TX_SPLITQ_COMPL_TAG_WIDTH -
-							txq->compl_tag_gen_s;
-			txq->compl_tag_gen_max = GETMAXVAL(gen_bits);
-
-			/* Set bufid mask based on location of first
-			 * gen bit; it cannot simply be the descriptor
-			 * ring size-1 since we can have size values
-			 * where not all of those bits are set.
-			 */
-			txq->compl_tag_bufid_m =
-				GETMAXVAL(txq->compl_tag_gen_s);
 		}
 
 		if (!idpf_is_queue_model_split(vport->txq_model))
@@ -1041,9 +919,6 @@ static void idpf_txq_group_rel(struct idpf_vport *vport)
 
 		kfree(txq_grp->complq);
 		txq_grp->complq = NULL;
-
-		if (flow_sch_en)
-			kfree(txq_grp->stashes);
 	}
 	kfree(vport->txq_grps);
 	vport->txq_grps = NULL;
@@ -1396,7 +1271,6 @@ static int idpf_txq_group_alloc(struct idpf_vport *vport, u16 num_txq)
 	for (i = 0; i < vport->num_txq_grp; i++) {
 		struct idpf_txq_group *tx_qgrp = &vport->txq_grps[i];
 		struct idpf_adapter *adapter = vport->adapter;
-		struct idpf_txq_stash *stashes;
 		int j;
 
 		tx_qgrp->vport = vport;
@@ -1407,15 +1281,6 @@ static int idpf_txq_group_alloc(struct idpf_vport *vport, u16 num_txq)
 						   GFP_KERNEL);
 			if (!tx_qgrp->txqs[j])
 				goto err_alloc;
-		}
-
-		if (split && flow_sch_en) {
-			stashes = kcalloc(num_txq, sizeof(*stashes),
-					  GFP_KERNEL);
-			if (!stashes)
-				goto err_alloc;
-
-			tx_qgrp->stashes = stashes;
 		}
 
 		for (j = 0; j < tx_qgrp->num_txq; j++) {
@@ -1436,11 +1301,6 @@ static int idpf_txq_group_alloc(struct idpf_vport *vport, u16 num_txq)
 
 			if (!flow_sch_en)
 				continue;
-
-			if (split) {
-				q->stash = &stashes[j];
-				hash_init(q->stash->sched_buf_hash);
-			}
 
 			idpf_queue_set(FLOW_SCH_EN, q);
 
@@ -1699,82 +1559,6 @@ static void idpf_tx_handle_sw_marker(struct idpf_tx_queue *tx_q)
 	wake_up(&vport->sw_marker_wq);
 }
 
-/**
- * idpf_tx_clean_stashed_bufs - clean bufs that were stored for
- * out of order completions
- * @txq: queue to clean
- * @compl_tag: completion tag of packet to clean (from completion descriptor)
- * @cleaned: pointer to stats struct to track cleaned packets/bytes
- * @budget: Used to determine if we are in netpoll
- */
-static void idpf_tx_clean_stashed_bufs(struct idpf_tx_queue *txq,
-				       u16 compl_tag,
-				       struct libeth_sq_napi_stats *cleaned,
-				       int budget)
-{
-	struct idpf_tx_stash *stash;
-	struct hlist_node *tmp_buf;
-	struct libeth_cq_pp cp = {
-		.dev	= txq->dev,
-		.ss	= cleaned,
-		.napi	= budget,
-	};
-
-	/* Buffer completion */
-	hash_for_each_possible_safe(txq->stash->sched_buf_hash, stash, tmp_buf,
-				    hlist, compl_tag) {
-		if (unlikely(idpf_tx_buf_compl_tag(&stash->buf) != compl_tag))
-			continue;
-
-		hash_del(&stash->hlist);
-		libeth_tx_complete(&stash->buf, &cp);
-
-		/* Push shadow buf back onto stack */
-		idpf_buf_lifo_push(&txq->stash->buf_stack, stash);
-	}
-}
-
-/**
- * idpf_stash_flow_sch_buffers - store buffer parameters info to be freed at a
- * later time (only relevant for flow scheduling mode)
- * @txq: Tx queue to clean
- * @tx_buf: buffer to store
- */
-static int idpf_stash_flow_sch_buffers(struct idpf_tx_queue *txq,
-				       struct idpf_tx_buf *tx_buf)
-{
-	struct idpf_tx_stash *stash;
-
-	if (unlikely(tx_buf->type <= LIBETH_SQE_CTX))
-		return 0;
-
-	stash = idpf_buf_lifo_pop(&txq->stash->buf_stack);
-	if (unlikely(!stash)) {
-		net_err_ratelimited("%s: No out-of-order TX buffers left!\n",
-				    netdev_name(txq->netdev));
-
-		return -ENOMEM;
-	}
-
-	/* Store buffer params in shadow buffer */
-	stash->buf.skb = tx_buf->skb;
-	stash->buf.bytes = tx_buf->bytes;
-	stash->buf.packets = tx_buf->packets;
-	stash->buf.type = tx_buf->type;
-	stash->buf.nr_frags = tx_buf->nr_frags;
-	dma_unmap_addr_set(&stash->buf, dma, dma_unmap_addr(tx_buf, dma));
-	dma_unmap_len_set(&stash->buf, len, dma_unmap_len(tx_buf, len));
-	idpf_tx_buf_compl_tag(&stash->buf) = idpf_tx_buf_compl_tag(tx_buf);
-
-	/* Add buffer to buf_hash table to be freed later */
-	hash_add(txq->stash->sched_buf_hash, &stash->hlist,
-		 idpf_tx_buf_compl_tag(&stash->buf));
-
-	tx_buf->type = LIBETH_SQE_EMPTY;
-
-	return 0;
-}
-
 #define idpf_tx_splitq_clean_bump_ntc(txq, ntc, desc, buf)	\
 do {								\
 	if (unlikely(++(ntc) == (txq)->desc_count)) {		\
@@ -1802,14 +1586,8 @@ do {								\
  * Separate packet completion events will be reported on the completion queue,
  * and the buffers will be cleaned separately. The stats are not updated from
  * this function when using flow-based scheduling.
- *
- * Furthermore, in flow scheduling mode, check to make sure there are enough
- * reserve buffers to stash the packet. If there are not, return early, which
- * will leave next_to_clean pointing to the packet that failed to be stashed.
- *
- * Return: false in the scenario above, true otherwise.
  */
-static bool idpf_tx_splitq_clean(struct idpf_tx_queue *tx_q, u16 end,
+static void idpf_tx_splitq_clean(struct idpf_tx_queue *tx_q, u16 end,
 				 int napi_budget,
 				 struct libeth_sq_napi_stats *cleaned,
 				 bool descs_only)
@@ -1823,12 +1601,11 @@ static bool idpf_tx_splitq_clean(struct idpf_tx_queue *tx_q, u16 end,
 		.napi	= napi_budget,
 	};
 	struct idpf_tx_buf *tx_buf;
-	bool clean_complete = true;
 
 	if (descs_only) {
 		/* Bump ring index to mark as cleaned. */
 		tx_q->next_to_clean = end;
-		return true;
+		return;
 	}
 
 	tx_desc = &tx_q->flex_tx[ntc];
@@ -1849,52 +1626,23 @@ static bool idpf_tx_splitq_clean(struct idpf_tx_queue *tx_q, u16 end,
 			break;
 
 		eop_idx = tx_buf->rs_idx;
+		libeth_tx_complete(tx_buf, &cp);
 
-		if (descs_only) {
-			if (IDPF_TX_BUF_RSV_UNUSED(tx_q) < tx_buf->nr_frags) {
-				clean_complete = false;
-				goto tx_splitq_clean_out;
-			}
+		/* unmap remaining buffers */
+		while (ntc != eop_idx) {
+			idpf_tx_splitq_clean_bump_ntc(tx_q, ntc,
+						      tx_desc, tx_buf);
 
-			idpf_stash_flow_sch_buffers(tx_q, tx_buf);
-
-			while (ntc != eop_idx) {
-				idpf_tx_splitq_clean_bump_ntc(tx_q, ntc,
-							      tx_desc, tx_buf);
-				idpf_stash_flow_sch_buffers(tx_q, tx_buf);
-			}
-		} else {
+			/* unmap any remaining paged data */
 			libeth_tx_complete(tx_buf, &cp);
-
-			/* unmap remaining buffers */
-			while (ntc != eop_idx) {
-				idpf_tx_splitq_clean_bump_ntc(tx_q, ntc,
-							      tx_desc, tx_buf);
-
-				/* unmap any remaining paged data */
-				libeth_tx_complete(tx_buf, &cp);
-			}
 		}
 
 fetch_next_txq_desc:
 		idpf_tx_splitq_clean_bump_ntc(tx_q, ntc, tx_desc, tx_buf);
 	}
 
-tx_splitq_clean_out:
 	tx_q->next_to_clean = ntc;
-
-	return clean_complete;
 }
-
-#define idpf_tx_clean_buf_ring_bump_ntc(txq, ntc, buf)	\
-do {							\
-	(buf)++;					\
-	(ntc)++;					\
-	if (unlikely((ntc) == (txq)->desc_count)) {	\
-		buf = (txq)->tx_buf;			\
-		ntc = 0;				\
-	}						\
-} while (0)
 
 /**
  * idpf_tx_clean_bufs - clean flow scheduling TX queue buffers
@@ -1906,7 +1654,7 @@ do {							\
  * Clean all buffers associated with the packet starting at buf_id. Returns the
  * byte/segment count for the cleaned packet.
  */
-static bool idpf_tx_clean_bufs(struct idpf_tx_queue *txq, u32 buf_id,
+static void idpf_tx_clean_bufs(struct idpf_tx_queue *txq, u32 buf_id,
 			       struct libeth_sq_napi_stats *cleaned,
 			       int budget)
 {
@@ -1930,8 +1678,6 @@ static bool idpf_tx_clean_bufs(struct idpf_tx_queue *txq, u32 buf_id,
 		libeth_tx_complete(tx_buf, &cp);
 		idpf_post_buf_refill(txq->refillq, buf_id);
 	}
-
-	return true;
 }
 
 /**
@@ -1950,22 +1696,17 @@ static void idpf_tx_handle_rs_completion(struct idpf_tx_queue *txq,
 					 struct libeth_sq_napi_stats *cleaned,
 					 int budget)
 {
-	u16 compl_tag;
+	/* RS completion contains queue head for queue based scheduling or
+	 * completion tag for flow based scheduling.
+	 */
+	u16 rs_compl_val = le16_to_cpu(desc->q_head_compl_tag.q_head);
 
 	if (!idpf_queue_has(FLOW_SCH_EN, txq)) {
-		u16 head = le16_to_cpu(desc->q_head_compl_tag.q_head);
-
-		idpf_tx_splitq_clean(txq, head, budget, cleaned, false);
+		idpf_tx_splitq_clean(txq, rs_compl_val, budget, cleaned, false);
 		return;
 	}
 
-	compl_tag = le16_to_cpu(desc->q_head_compl_tag.compl_tag);
-
-	/* If we didn't clean anything on the ring, this packet must be
-	 * in the hash table. Go clean it there.
-	 */
-	if (!idpf_tx_clean_bufs(txq, compl_tag, cleaned, budget))
-		idpf_tx_clean_stashed_bufs(txq, compl_tag, cleaned, budget);
+	idpf_tx_clean_bufs(txq, rs_compl_val, cleaned, budget);
 }
 
 /**
@@ -2082,8 +1823,7 @@ fetch_next_desc:
 		/* Update BQL */
 		nq = netdev_get_tx_queue(tx_q->netdev, tx_q->idx);
 
-		dont_wake = !complq_ok || IDPF_TX_BUF_RSV_LOW(tx_q) ||
-			    np->state != __IDPF_VPORT_UP ||
+		dont_wake = !complq_ok || np->state != __IDPF_VPORT_UP ||
 			    !netif_carrier_ok(tx_q->netdev);
 		/* Check if the TXQ needs to and can be restarted */
 		__netif_txq_completed_wake(nq, tx_q->cleaned_pkts, tx_q->cleaned_bytes,
@@ -2154,7 +1894,6 @@ static int idpf_txq_has_room(struct idpf_tx_queue *tx_q, u32 descs_needed,
 	if (IDPF_DESC_UNUSED(tx_q) < descs_needed ||
 	    IDPF_TX_COMPLQ_PENDING(tx_q->txq_grp) >
 		IDPF_TX_COMPLQ_OVERFLOW_THRESH(tx_q->txq_grp->complq) ||
-	    IDPF_TX_BUF_RSV_LOW(tx_q) ||
 	    idpf_tx_splitq_get_free_bufs(tx_q->refillq) < bufs_needed)
 		return 0;
 	return 1;
@@ -2278,10 +2017,8 @@ static unsigned int idpf_tx_splitq_bump_ntu(struct idpf_tx_queue *txq, u16 ntu)
 {
 	ntu++;
 
-	if (ntu == txq->desc_count) {
+	if (ntu == txq->desc_count)
 		ntu = 0;
-		txq->compl_tag_cur_gen = IDPF_TX_ADJ_COMPL_TAG_GEN(txq);
-	}
 
 	return ntu;
 }
@@ -2463,8 +2200,6 @@ static void idpf_tx_splitq_map(struct idpf_tx_queue *tx_q,
 			if (unlikely(++i == tx_q->desc_count)) {
 				tx_desc = &tx_q->flex_tx[0];
 				i = 0;
-				tx_q->compl_tag_cur_gen =
-					IDPF_TX_ADJ_COMPL_TAG_GEN(tx_q);
 			} else {
 				tx_desc++;
 			}
@@ -2495,7 +2230,6 @@ static void idpf_tx_splitq_map(struct idpf_tx_queue *tx_q,
 		if (unlikely(++i == tx_q->desc_count)) {
 			tx_desc = &tx_q->flex_tx[0];
 			i = 0;
-			tx_q->compl_tag_cur_gen = IDPF_TX_ADJ_COMPL_TAG_GEN(tx_q);
 		} else {
 			tx_desc++;
 		}
@@ -2856,10 +2590,9 @@ static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
 
 		tx_params.dtype = IDPF_TX_DESC_DTYPE_FLEX_FLOW_SCHE;
 		tx_params.eop_cmd = IDPF_TXD_FLEX_FLOW_CMD_EOP;
-		/* Set the RE bit to catch any packets that may have not been
-		 * stashed during RS completion cleaning. MIN_GAP is set to
-		 * MIN_RING size to ensure it will be set at least once each
-		 * time around the ring.
+		/* Set the RE bit to periodically "clean" the descriptor ring.
+		 * MIN_GAP is set to MIN_RING size to ensure it will be set at
+		 * least once each time around the ring.
 		 */
 		if (idpf_tx_splitq_need_re(tx_q)) {
 			tx_params.eop_cmd |= IDPF_TXD_FLEX_FLOW_CMD_RE;

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.c
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
@@ -2140,15 +2140,22 @@ void idpf_tx_splitq_build_flow_desc(union idpf_tx_flex_desc *desc,
 	desc->flow.qw1.compl_tag = cpu_to_le16(params->compl_tag);
 }
 
-/* Global conditions to tell whether the txq (and related resources)
- * has room to allow the use of "size" descriptors.
+/**
+ * idpf_tx_splitq_has_room - check if enough Tx splitq resources are available
+ * @tx_q: the queue to be checked
+ * @descs_needed: number of descriptors required for this packet
+ * @bufs_needed: number of Tx buffers required for this packet
+ *
+ * Return: 0 if no room available, 1 otherwise
  */
-static int idpf_txq_has_room(struct idpf_tx_queue *tx_q, u32 size)
+static int idpf_txq_has_room(struct idpf_tx_queue *tx_q, u32 descs_needed,
+			     u32 bufs_needed)
 {
-	if (IDPF_DESC_UNUSED(tx_q) < size ||
+	if (IDPF_DESC_UNUSED(tx_q) < descs_needed ||
 	    IDPF_TX_COMPLQ_PENDING(tx_q->txq_grp) >
 		IDPF_TX_COMPLQ_OVERFLOW_THRESH(tx_q->txq_grp->complq) ||
-	    IDPF_TX_BUF_RSV_LOW(tx_q))
+	    IDPF_TX_BUF_RSV_LOW(tx_q) ||
+	    idpf_tx_splitq_get_free_bufs(tx_q->refillq) < bufs_needed)
 		return 0;
 	return 1;
 }
@@ -2157,14 +2164,21 @@ static int idpf_txq_has_room(struct idpf_tx_queue *tx_q, u32 size)
  * idpf_tx_maybe_stop_splitq - 1st level check for Tx splitq stop conditions
  * @tx_q: the queue to be checked
  * @descs_needed: number of descriptors required for this packet
+ * @bufs_needed: number of buffers needed for this packet
  *
- * Returns 0 if stop is not needed
+ * Return: 0 if stop is not needed
  */
 static int idpf_tx_maybe_stop_splitq(struct idpf_tx_queue *tx_q,
-				     unsigned int descs_needed)
+				     u32 descs_needed,
+				     u32 bufs_needed)
 {
+	/* Since we have multiple resources to check for splitq, our
+	 * start,stop_thrs becomes a boolean check instead of a count
+	 * threshold.
+	 */
 	if (netif_subqueue_maybe_stop(tx_q->netdev, tx_q->idx,
-				      idpf_txq_has_room(tx_q, descs_needed),
+				      idpf_txq_has_room(tx_q, descs_needed,
+							bufs_needed),
 				      1, 1))
 		return 0;
 
@@ -2206,14 +2220,16 @@ void idpf_tx_buf_hw_update(struct idpf_tx_queue *tx_q, u32 val,
 }
 
 /**
- * idpf_tx_desc_count_required - calculate number of Tx descriptors needed
+ * idpf_tx_res_count_required - get number of Tx resources needed for this pkt
  * @txq: queue to send buffer on
  * @skb: send buffer
+ * @bufs_needed: (output) number of buffers needed for this skb.
  *
- * Returns number of data descriptors needed for this skb.
+ * Return: number of data descriptors and buffers needed for this skb.
  */
-unsigned int idpf_tx_desc_count_required(struct idpf_tx_queue *txq,
-					 struct sk_buff *skb)
+unsigned int idpf_tx_res_count_required(struct idpf_tx_queue *txq,
+					struct sk_buff *skb,
+					u32 *bufs_needed)
 {
 	const struct skb_shared_info *shinfo;
 	unsigned int count = 0, i;
@@ -2224,6 +2240,7 @@ unsigned int idpf_tx_desc_count_required(struct idpf_tx_queue *txq,
 		return count;
 
 	shinfo = skb_shinfo(skb);
+	*bufs_needed += shinfo->nr_frags;
 	for (i = 0; i < shinfo->nr_frags; i++) {
 		unsigned int size;
 
@@ -2773,11 +2790,11 @@ static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
 		.prev_ntu = tx_q->next_to_use,
 	};
 	struct idpf_tx_buf *first;
-	unsigned int count;
+	u32 count, buf_count = 1;
 	int tso;
 	u32 buf_id;
 
-	count = idpf_tx_desc_count_required(tx_q, skb);
+	count = idpf_tx_res_count_required(tx_q, skb, &buf_count);
 	if (unlikely(!count))
 		return idpf_tx_drop_skb(tx_q, skb);
 
@@ -2787,7 +2804,7 @@ static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
 
 	/* Check for splitq specific TX resources */
 	count += (IDPF_TX_DESCS_PER_CACHE_LINE + tso);
-	if (idpf_tx_maybe_stop_splitq(tx_q, count)) {
+	if (idpf_tx_maybe_stop_splitq(tx_q, count, buf_count)) {
 		idpf_tx_buf_hw_update(tx_q, tx_q->next_to_use, false);
 
 		return NETDEV_TX_BUSY;

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.c
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
@@ -2288,57 +2288,6 @@ unsigned int idpf_tx_desc_count_required(struct idpf_tx_queue *txq,
 }
 
 /**
- * idpf_tx_dma_map_error - handle TX DMA map errors
- * @txq: queue to send buffer on
- * @skb: send buffer
- * @first: original first buffer info buffer for packet
- * @idx: starting point on ring to unwind
- */
-void idpf_tx_dma_map_error(struct idpf_tx_queue *txq, struct sk_buff *skb,
-			   struct idpf_tx_buf *first, u16 idx)
-{
-	struct libeth_sq_napi_stats ss = { };
-	struct libeth_cq_pp cp = {
-		.dev	= txq->dev,
-		.ss	= &ss,
-	};
-
-	u64_stats_update_begin(&txq->stats_sync);
-	u64_stats_inc(&txq->q_stats.dma_map_errs);
-	u64_stats_update_end(&txq->stats_sync);
-
-	/* clear dma mappings for failed tx_buf map */
-	for (;;) {
-		struct idpf_tx_buf *tx_buf;
-
-		tx_buf = &txq->tx_buf[idx];
-		libeth_tx_complete(tx_buf, &cp);
-		if (tx_buf == first)
-			break;
-		if (idx == 0)
-			idx = txq->desc_count;
-		idx--;
-	}
-
-	if (skb_is_gso(skb)) {
-		union idpf_tx_flex_desc *tx_desc;
-
-		/* If we failed a DMA mapping for a TSO packet, we will have
-		 * used one additional descriptor for a context
-		 * descriptor. Reset that here.
-		 */
-		tx_desc = &txq->flex_tx[idx];
-		memset(tx_desc, 0, sizeof(struct idpf_flex_tx_ctx_desc));
-		if (idx == 0)
-			idx = txq->desc_count;
-		idx--;
-	}
-
-	/* Update tail in case netdev_xmit_more was previously true */
-	idpf_tx_buf_hw_update(txq, idx, false);
-}
-
-/**
  * idpf_tx_splitq_bump_ntu - adjust NTU and generation
  * @txq: the tx ring to wrap
  * @ntu: ring index to bump
@@ -2387,6 +2336,37 @@ static bool idpf_tx_get_free_buf_id(struct idpf_sw_queue *refillq,
 }
 
 /**
+ * idpf_tx_splitq_pkt_err_unmap - Unmap buffers and bump tail in case of error
+ * @txq: Tx queue to unwind
+ * @params: pointer to splitq params struct
+ * @first: starting buffer for packet to unmap
+ */
+static void idpf_tx_splitq_pkt_err_unmap(struct idpf_tx_queue *txq,
+					 struct idpf_tx_splitq_params *params,
+					 struct idpf_tx_buf *first)
+{
+	struct libeth_sq_napi_stats ss = { };
+	struct idpf_tx_buf *tx_buf = first;
+	struct libeth_cq_pp cp = {
+		.dev    = txq->dev,
+		.ss     = &ss,
+	};
+	u32 idx = 0;
+
+	u64_stats_update_begin(&txq->stats_sync);
+	u64_stats_inc(&txq->q_stats.dma_map_errs);
+	u64_stats_update_end(&txq->stats_sync);
+
+	do {
+		libeth_tx_complete(tx_buf, &cp);
+		idpf_tx_clean_buf_ring_bump_ntc(txq, idx, tx_buf);
+	} while (idpf_tx_buf_compl_tag(tx_buf) == params->compl_tag);
+
+	/* Update tail in case netdev_xmit_more was previously true. */
+	idpf_tx_buf_hw_update(txq, params->prev_ntu, false);
+}
+
+/**
  * idpf_tx_splitq_map - Build the Tx flex descriptor
  * @tx_q: queue to send buffer on
  * @params: pointer to splitq params struct
@@ -2430,8 +2410,9 @@ static void idpf_tx_splitq_map(struct idpf_tx_queue *tx_q,
 	for (frag = &skb_shinfo(skb)->frags[0];; frag++) {
 		unsigned int max_data = IDPF_TX_MAX_DESC_DATA_ALIGNED;
 
-		if (dma_mapping_error(tx_q->dev, dma))
-			return idpf_tx_dma_map_error(tx_q, skb, first, i);
+		if (unlikely(dma_mapping_error(tx_q->dev, dma)))
+			return idpf_tx_splitq_pkt_err_unmap(tx_q, params,
+							    first);
 
 		first->nr_frags++;
 		idpf_tx_buf_compl_tag(tx_buf) = params->compl_tag;
@@ -2820,7 +2801,9 @@ static bool idpf_tx_splitq_need_re(struct idpf_tx_queue *tx_q)
 static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
 					struct idpf_tx_queue *tx_q)
 {
-	struct idpf_tx_splitq_params tx_params = { };
+	struct idpf_tx_splitq_params tx_params = {
+		.prev_ntu = tx_q->next_to_use,
+	};
 	struct idpf_tx_buf *first;
 	unsigned int count;
 	int tso;

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.c
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
@@ -293,6 +293,8 @@ static int idpf_tx_desc_alloc(const struct idpf_vport *vport,
 	 */
 	idpf_queue_change(GEN_CHK, refillq);
 
+	tx_q->last_re = tx_q->desc_count - IDPF_TX_SPLITQ_RE_MIN_GAP;
+
 	return 0;
 
 err_alloc:
@@ -2794,6 +2796,21 @@ netdev_tx_t idpf_tx_drop_skb(struct idpf_tx_queue *tx_q, struct sk_buff *skb)
 }
 
 /**
+ * idpf_tx_splitq_need_re - check whether RE bit needs to be set
+ * @tx_q: pointer to Tx queue
+ *
+ * Return: true if RE bit needs to be set, false otherwise
+ */
+static bool idpf_tx_splitq_need_re(struct idpf_tx_queue *tx_q)
+{
+	int gap = tx_q->next_to_use - tx_q->last_re;
+
+	gap += (gap < 0) ? tx_q->desc_count : 0;
+
+	return gap >= IDPF_TX_SPLITQ_RE_MIN_GAP;
+}
+
+/**
  * idpf_tx_splitq_frame - Sends buffer on Tx ring using flex descriptors
  * @skb: send buffer
  * @tx_q: queue to send buffer on
@@ -2873,9 +2890,10 @@ static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
 		 * MIN_RING size to ensure it will be set at least once each
 		 * time around the ring.
 		 */
-		if (!(tx_q->next_to_use % IDPF_TX_SPLITQ_RE_MIN_GAP)) {
+		if (idpf_tx_splitq_need_re(tx_q)) {
 			tx_params.eop_cmd |= IDPF_TXD_FLEX_FLOW_CMD_RE;
 			tx_q->txq_grp->num_completions_pending++;
+			tx_q->last_re = tx_q->next_to_use;
 		}
 
 		if (skb->ip_summed == CHECKSUM_PARTIAL)

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.c
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
@@ -12,6 +12,7 @@ struct idpf_tx_stash {
 	struct libeth_sqe buf;
 };
 
+#define idpf_tx_buf_next(buf)		(*(u32 *)&(buf)->priv)
 #define idpf_tx_buf_compl_tag(buf)	(*(u32 *)&(buf)->priv)
 LIBETH_SQE_CHECK_PRIV(u32);
 
@@ -90,7 +91,7 @@ static void idpf_tx_buf_rel_all(struct idpf_tx_queue *txq)
 		return;
 
 	/* Free all the Tx buffer sk_buffs */
-	for (i = 0; i < txq->desc_count; i++)
+	for (i = 0; i < txq->buf_pool_size; i++)
 		libeth_tx_complete(&txq->tx_buf[i], &cp);
 
 	kfree(txq->tx_buf);
@@ -198,14 +199,17 @@ static void idpf_tx_desc_rel_all(struct idpf_vport *vport)
 static int idpf_tx_buf_alloc_all(struct idpf_tx_queue *tx_q)
 {
 	struct idpf_buf_lifo *buf_stack;
-	int buf_size;
 	int i;
 
 	/* Allocate book keeping buffers only. Buffers to be supplied to HW
 	 * are allocated by kernel network stack and received as part of skb
 	 */
-	buf_size = sizeof(struct idpf_tx_buf) * tx_q->desc_count;
-	tx_q->tx_buf = kzalloc(buf_size, GFP_KERNEL);
+	if (idpf_queue_has(FLOW_SCH_EN, tx_q))
+		tx_q->buf_pool_size = U16_MAX;
+	else
+		tx_q->buf_pool_size = tx_q->desc_count;
+	tx_q->tx_buf = kcalloc(tx_q->buf_pool_size, sizeof(*tx_q->tx_buf),
+			       GFP_KERNEL);
 	if (!tx_q->tx_buf)
 		return -ENOMEM;
 
@@ -274,7 +278,7 @@ static int idpf_tx_desc_alloc(const struct idpf_vport *vport,
 		return 0;
 
 	refillq = tx_q->refillq;
-	refillq->desc_count = tx_q->desc_count;
+	refillq->desc_count = tx_q->buf_pool_size;
 	refillq->ring = kcalloc(refillq->desc_count, sizeof(u32),
 				GFP_KERNEL);
 	if (!refillq->ring) {
@@ -1821,6 +1825,12 @@ static bool idpf_tx_splitq_clean(struct idpf_tx_queue *tx_q, u16 end,
 	struct idpf_tx_buf *tx_buf;
 	bool clean_complete = true;
 
+	if (descs_only) {
+		/* Bump ring index to mark as cleaned. */
+		tx_q->next_to_clean = end;
+		return true;
+	}
+
 	tx_desc = &tx_q->flex_tx[ntc];
 	next_pending_desc = &tx_q->flex_tx[end];
 	tx_buf = &tx_q->tx_buf[ntc];
@@ -1887,82 +1897,39 @@ do {							\
 } while (0)
 
 /**
- * idpf_tx_clean_buf_ring - clean flow scheduling TX queue buffers
+ * idpf_tx_clean_bufs - clean flow scheduling TX queue buffers
  * @txq: queue to clean
- * @compl_tag: completion tag of packet to clean (from completion descriptor)
+ * @buf_id: packet's starting buffer ID, from completion descriptor
  * @cleaned: pointer to stats struct to track cleaned packets/bytes
  * @budget: Used to determine if we are in netpoll
  *
- * Cleans all buffers associated with the input completion tag either from the
- * TX buffer ring or from the hash table if the buffers were previously
- * stashed. Returns the byte/segment count for the cleaned packet associated
- * this completion tag.
+ * Clean all buffers associated with the packet starting at buf_id. Returns the
+ * byte/segment count for the cleaned packet.
  */
-static bool idpf_tx_clean_buf_ring(struct idpf_tx_queue *txq, u16 compl_tag,
-				   struct libeth_sq_napi_stats *cleaned,
-				   int budget)
+static bool idpf_tx_clean_bufs(struct idpf_tx_queue *txq, u32 buf_id,
+			       struct libeth_sq_napi_stats *cleaned,
+			       int budget)
 {
-	u16 idx = compl_tag & txq->compl_tag_bufid_m;
 	struct idpf_tx_buf *tx_buf = NULL;
 	struct libeth_cq_pp cp = {
 		.dev	= txq->dev,
 		.ss	= cleaned,
 		.napi	= budget,
 	};
-	u16 ntc, orig_idx = idx;
 
-	tx_buf = &txq->tx_buf[idx];
-
-	if (unlikely(tx_buf->type <= LIBETH_SQE_CTX ||
-		     idpf_tx_buf_compl_tag(tx_buf) != compl_tag))
-		return false;
-
-	if (tx_buf->type == LIBETH_SQE_SKB)
+	tx_buf = &txq->tx_buf[buf_id];
+	if (tx_buf->type == LIBETH_SQE_SKB) {
 		libeth_tx_complete(tx_buf, &cp);
-
-	idpf_tx_clean_buf_ring_bump_ntc(txq, idx, tx_buf);
-
-	while (idpf_tx_buf_compl_tag(tx_buf) == compl_tag) {
-		libeth_tx_complete(tx_buf, &cp);
-		idpf_tx_clean_buf_ring_bump_ntc(txq, idx, tx_buf);
+		idpf_post_buf_refill(txq->refillq, buf_id);
 	}
 
-	/*
-	 * It's possible the packet we just cleaned was an out of order
-	 * completion, which means we can stash the buffers starting from
-	 * the original next_to_clean and reuse the descriptors. We need
-	 * to compare the descriptor ring next_to_clean packet's "first" buffer
-	 * to the "first" buffer of the packet we just cleaned to determine if
-	 * this is the case. Howevever, next_to_clean can point to either a
-	 * reserved buffer that corresponds to a context descriptor used for the
-	 * next_to_clean packet (TSO packet) or the "first" buffer (single
-	 * packet). The orig_idx from the packet we just cleaned will always
-	 * point to the "first" buffer. If next_to_clean points to a reserved
-	 * buffer, let's bump ntc once and start the comparison from there.
-	 */
-	ntc = txq->next_to_clean;
-	tx_buf = &txq->tx_buf[ntc];
+	while (idpf_tx_buf_next(tx_buf) != IDPF_TXBUF_NULL) {
+		buf_id = idpf_tx_buf_next(tx_buf);
 
-	if (tx_buf->type == LIBETH_SQE_CTX)
-		idpf_tx_clean_buf_ring_bump_ntc(txq, ntc, tx_buf);
-
-	/*
-	 * If ntc still points to a different "first" buffer, clean the
-	 * descriptor ring and stash all of the buffers for later cleaning. If
-	 * we cannot stash all of the buffers, next_to_clean will point to the
-	 * "first" buffer of the packet that could not be stashed and cleaning
-	 * will start there next time.
-	 */
-	if (unlikely(tx_buf != &txq->tx_buf[orig_idx] &&
-		     !idpf_tx_splitq_clean(txq, orig_idx, budget, cleaned,
-					   true)))
-		return true;
-
-	/*
-	 * Otherwise, update next_to_clean to reflect the cleaning that was
-	 * done above.
-	 */
-	txq->next_to_clean = idx;
+		tx_buf = &txq->tx_buf[buf_id];
+		libeth_tx_complete(tx_buf, &cp);
+		idpf_post_buf_refill(txq->refillq, buf_id);
+	}
 
 	return true;
 }
@@ -1994,12 +1961,10 @@ static void idpf_tx_handle_rs_completion(struct idpf_tx_queue *txq,
 
 	compl_tag = le16_to_cpu(desc->q_head_compl_tag.compl_tag);
 
-	idpf_post_buf_refill(txq->refillq, compl_tag);
-
 	/* If we didn't clean anything on the ring, this packet must be
 	 * in the hash table. Go clean it there.
 	 */
-	if (!idpf_tx_clean_buf_ring(txq, compl_tag, cleaned, budget))
+	if (!idpf_tx_clean_bufs(txq, compl_tag, cleaned, budget))
 		idpf_tx_clean_stashed_bufs(txq, compl_tag, cleaned, budget);
 }
 
@@ -2312,7 +2277,7 @@ static unsigned int idpf_tx_splitq_bump_ntu(struct idpf_tx_queue *txq, u16 ntu)
  * Return: true if a buffer ID was found, false if not
  */
 static bool idpf_tx_get_free_buf_id(struct idpf_sw_queue *refillq,
-				    u16 *buf_id)
+				    u32 *buf_id)
 {
 	u32 ntc = refillq->next_to_clean;
 	u32 refill_desc;
@@ -2345,25 +2310,34 @@ static void idpf_tx_splitq_pkt_err_unmap(struct idpf_tx_queue *txq,
 					 struct idpf_tx_splitq_params *params,
 					 struct idpf_tx_buf *first)
 {
+	struct idpf_sw_queue *refillq = txq->refillq;
 	struct libeth_sq_napi_stats ss = { };
 	struct idpf_tx_buf *tx_buf = first;
 	struct libeth_cq_pp cp = {
 		.dev    = txq->dev,
 		.ss     = &ss,
 	};
-	u32 idx = 0;
 
 	u64_stats_update_begin(&txq->stats_sync);
 	u64_stats_inc(&txq->q_stats.dma_map_errs);
 	u64_stats_update_end(&txq->stats_sync);
 
-	do {
+	libeth_tx_complete(tx_buf, &cp);
+	while (idpf_tx_buf_next(tx_buf) != IDPF_TXBUF_NULL) {
+		tx_buf = &txq->tx_buf[idpf_tx_buf_next(tx_buf)];
 		libeth_tx_complete(tx_buf, &cp);
-		idpf_tx_clean_buf_ring_bump_ntc(txq, idx, tx_buf);
-	} while (idpf_tx_buf_compl_tag(tx_buf) == params->compl_tag);
+	}
 
 	/* Update tail in case netdev_xmit_more was previously true. */
 	idpf_tx_buf_hw_update(txq, params->prev_ntu, false);
+
+	if (!refillq)
+		return;
+
+	/* Restore refillq state to avoid leaking tags. */
+	if (params->prev_refill_gen != idpf_queue_has(RFL_GEN_CHK, refillq))
+		idpf_queue_change(RFL_GEN_CHK, refillq);
+	refillq->next_to_clean = params->prev_refill_ntc;
 }
 
 /**
@@ -2387,6 +2361,7 @@ static void idpf_tx_splitq_map(struct idpf_tx_queue *tx_q,
 	struct netdev_queue *nq;
 	struct sk_buff *skb;
 	skb_frag_t *frag;
+	u32 next_buf_id;
 	u16 td_cmd = 0;
 	dma_addr_t dma;
 
@@ -2404,18 +2379,16 @@ static void idpf_tx_splitq_map(struct idpf_tx_queue *tx_q,
 	tx_buf = first;
 	first->nr_frags = 0;
 
-	params->compl_tag =
-		(tx_q->compl_tag_cur_gen << tx_q->compl_tag_gen_s) | i;
-
 	for (frag = &skb_shinfo(skb)->frags[0];; frag++) {
 		unsigned int max_data = IDPF_TX_MAX_DESC_DATA_ALIGNED;
 
-		if (unlikely(dma_mapping_error(tx_q->dev, dma)))
+		if (unlikely(dma_mapping_error(tx_q->dev, dma))) {
+			idpf_tx_buf_next(tx_buf) = IDPF_TXBUF_NULL;
 			return idpf_tx_splitq_pkt_err_unmap(tx_q, params,
 							    first);
+		}
 
 		first->nr_frags++;
-		idpf_tx_buf_compl_tag(tx_buf) = params->compl_tag;
 		tx_buf->type = LIBETH_SQE_FRAG;
 
 		/* record length, and DMA address */
@@ -2471,28 +2444,13 @@ static void idpf_tx_splitq_map(struct idpf_tx_queue *tx_q,
 						  max_data);
 
 			if (unlikely(++i == tx_q->desc_count)) {
-				tx_buf = tx_q->tx_buf;
 				tx_desc = &tx_q->flex_tx[0];
 				i = 0;
 				tx_q->compl_tag_cur_gen =
 					IDPF_TX_ADJ_COMPL_TAG_GEN(tx_q);
 			} else {
-				tx_buf++;
 				tx_desc++;
 			}
-
-			/* Since this packet has a buffer that is going to span
-			 * multiple descriptors, it's going to leave holes in
-			 * to the TX buffer ring. To ensure these holes do not
-			 * cause issues in the cleaning routines, we will clear
-			 * them of any stale data and assign them the same
-			 * completion tag as the current packet. Then when the
-			 * packet is being cleaned, the cleaning routines will
-			 * simply pass over these holes and finish cleaning the
-			 * rest of the packet.
-			 */
-			tx_buf->type = LIBETH_SQE_EMPTY;
-			idpf_tx_buf_compl_tag(tx_buf) = params->compl_tag;
 
 			/* Adjust the DMA offset and the remaining size of the
 			 * fragment.  On the first iteration of this loop,
@@ -2518,14 +2476,25 @@ static void idpf_tx_splitq_map(struct idpf_tx_queue *tx_q,
 		idpf_tx_splitq_build_desc(tx_desc, params, td_cmd, size);
 
 		if (unlikely(++i == tx_q->desc_count)) {
-			tx_buf = tx_q->tx_buf;
 			tx_desc = &tx_q->flex_tx[0];
 			i = 0;
 			tx_q->compl_tag_cur_gen = IDPF_TX_ADJ_COMPL_TAG_GEN(tx_q);
 		} else {
-			tx_buf++;
 			tx_desc++;
 		}
+
+		if (idpf_queue_has(FLOW_SCH_EN, tx_q)) {
+			if (unlikely(!idpf_tx_get_free_buf_id(tx_q->refillq,
+							      &next_buf_id))) {
+				idpf_tx_buf_next(tx_buf) = IDPF_TXBUF_NULL;
+				return idpf_tx_splitq_pkt_err_unmap(tx_q, params,
+								    first);
+			}
+		} else {
+			next_buf_id = i;
+		}
+		idpf_tx_buf_next(tx_buf) = next_buf_id;
+		tx_buf = &tx_q->tx_buf[next_buf_id];
 
 		size = skb_frag_size(frag);
 		data_len -= size;
@@ -2541,6 +2510,7 @@ static void idpf_tx_splitq_map(struct idpf_tx_queue *tx_q,
 
 	/* write last descriptor with RS and EOP bits */
 	first->rs_idx = i;
+	idpf_tx_buf_next(tx_buf) = IDPF_TXBUF_NULL;
 	td_cmd |= params->eop_cmd;
 	idpf_tx_splitq_build_desc(tx_desc, params, td_cmd, size);
 	i = idpf_tx_splitq_bump_ntu(tx_q, i);
@@ -2749,8 +2719,6 @@ idpf_tx_splitq_get_ctx_desc(struct idpf_tx_queue *txq)
 	struct idpf_flex_tx_ctx_desc *desc;
 	int i = txq->next_to_use;
 
-	txq->tx_buf[i].type = LIBETH_SQE_CTX;
-
 	/* grab the next descriptor */
 	desc = &txq->flex_ctx[i];
 	txq->next_to_use = idpf_tx_splitq_bump_ntu(txq, i);
@@ -2807,6 +2775,7 @@ static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
 	struct idpf_tx_buf *first;
 	unsigned int count;
 	int tso;
+	u32 buf_id;
 
 	count = idpf_tx_desc_count_required(tx_q, skb);
 	if (unlikely(!count))
@@ -2845,26 +2814,28 @@ static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
 		u64_stats_update_end(&tx_q->stats_sync);
 	}
 
-	/* record the location of the first descriptor for this packet */
-	first = &tx_q->tx_buf[tx_q->next_to_use];
-	first->skb = skb;
-
-	if (tso) {
-		first->packets = tx_params.offload.tso_segs;
-		first->bytes = skb->len +
-			((first->packets - 1) * tx_params.offload.tso_hdr_len);
-	} else {
-		first->packets = 1;
-		first->bytes = max_t(unsigned int, skb->len, ETH_ZLEN);
-	}
-
 	if (idpf_queue_has(FLOW_SCH_EN, tx_q)) {
+		struct idpf_sw_queue *refillq = tx_q->refillq;
+
+		/* Save refillq state in case of a packet rollback.  Otherwise,
+		 * the tags will be leaked since they will be popped from the
+		 * refillq but never reposted during cleaning.
+		 */
+		tx_params.prev_refill_gen =
+			idpf_queue_has(RFL_GEN_CHK, refillq);
+		tx_params.prev_refill_ntc = refillq->next_to_clean;
+
 		if (unlikely(!idpf_tx_get_free_buf_id(tx_q->refillq,
-						      &tx_params.compl_tag))) {
-			u64_stats_update_begin(&tx_q->stats_sync);
-			u64_stats_inc(&tx_q->q_stats.q_busy);
-			u64_stats_update_end(&tx_q->stats_sync);
+						      &buf_id))) {
+			if (tx_params.prev_refill_gen !=
+			    idpf_queue_has(RFL_GEN_CHK, refillq))
+				idpf_queue_change(RFL_GEN_CHK, refillq);
+			refillq->next_to_clean = tx_params.prev_refill_ntc;
+
+			tx_q->next_to_use = tx_params.prev_ntu;
+			return idpf_tx_drop_skb(tx_q, skb);
 		}
+		tx_params.compl_tag = buf_id;
 
 		tx_params.dtype = IDPF_TX_DESC_DTYPE_FLEX_FLOW_SCHE;
 		tx_params.eop_cmd = IDPF_TXD_FLEX_FLOW_CMD_EOP;
@@ -2883,11 +2854,25 @@ static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
 			tx_params.offload.td_cmd |= IDPF_TXD_FLEX_FLOW_CMD_CS_EN;
 
 	} else {
+		buf_id = tx_q->next_to_use;
+
 		tx_params.dtype = IDPF_TX_DESC_DTYPE_FLEX_L2TAG1_L2TAG2;
 		tx_params.eop_cmd = IDPF_TXD_LAST_DESC_CMD;
 
 		if (skb->ip_summed == CHECKSUM_PARTIAL)
 			tx_params.offload.td_cmd |= IDPF_TX_FLEX_DESC_CMD_CS_EN;
+	}
+
+	first = &tx_q->tx_buf[buf_id];
+	first->skb = skb;
+
+	if (tso) {
+		first->packets = tx_params.offload.tso_segs;
+		first->bytes = skb->len +
+			((first->packets - 1) * tx_params.offload.tso_hdr_len);
+	} else {
+		first->packets = 1;
+		first->bytes = max_t(unsigned int, skb->len, ETH_ZLEN);
 	}
 
 	idpf_tx_splitq_map(tx_q, &tx_params, first);

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.c
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
@@ -138,6 +138,9 @@ static void idpf_tx_desc_rel(struct idpf_tx_queue *txq)
 	if (!txq->desc_ring)
 		return;
 
+	if (txq->refillq)
+		kfree(txq->refillq->ring);
+
 	dmam_free_coherent(txq->dev, txq->size, txq->desc_ring, txq->dma);
 	txq->desc_ring = NULL;
 	txq->next_to_use = 0;
@@ -243,6 +246,7 @@ static int idpf_tx_desc_alloc(const struct idpf_vport *vport,
 			      struct idpf_tx_queue *tx_q)
 {
 	struct device *dev = tx_q->dev;
+	struct idpf_sw_queue *refillq;
 	int err;
 
 	err = idpf_tx_buf_alloc_all(tx_q);
@@ -265,6 +269,29 @@ static int idpf_tx_desc_alloc(const struct idpf_vport *vport,
 	tx_q->next_to_use = 0;
 	tx_q->next_to_clean = 0;
 	idpf_queue_set(GEN_CHK, tx_q);
+
+	if (!idpf_queue_has(FLOW_SCH_EN, tx_q))
+		return 0;
+
+	refillq = tx_q->refillq;
+	refillq->desc_count = tx_q->desc_count;
+	refillq->ring = kcalloc(refillq->desc_count, sizeof(u32),
+				GFP_KERNEL);
+	if (!refillq->ring) {
+		err = -ENOMEM;
+		goto err_alloc;
+	}
+
+	for (unsigned int i = 0; i < refillq->desc_count; i++)
+		refillq->ring[i] =
+			FIELD_PREP(IDPF_RFL_BI_BUFID_M, i) |
+			FIELD_PREP(IDPF_RFL_BI_GEN_M,
+				   idpf_queue_has(GEN_CHK, refillq));
+
+	/* Go ahead and flip the GEN bit since this counts as filling
+	 * up the ring, i.e. we already ring wrapped.
+	 */
+	idpf_queue_change(GEN_CHK, refillq);
 
 	return 0;
 
@@ -602,18 +629,18 @@ static int idpf_rx_hdr_buf_alloc_all(struct idpf_buf_queue *bufq)
 }
 
 /**
- * idpf_rx_post_buf_refill - Post buffer id to refill queue
+ * idpf_post_buf_refill - Post buffer id to refill queue
  * @refillq: refill queue to post to
  * @buf_id: buffer id to post
  */
-static void idpf_rx_post_buf_refill(struct idpf_sw_queue *refillq, u16 buf_id)
+static void idpf_post_buf_refill(struct idpf_sw_queue *refillq, u16 buf_id)
 {
 	u32 nta = refillq->next_to_use;
 
 	/* store the buffer ID and the SW maintained GEN bit to the refillq */
 	refillq->ring[nta] =
-		FIELD_PREP(IDPF_RX_BI_BUFID_M, buf_id) |
-		FIELD_PREP(IDPF_RX_BI_GEN_M,
+		FIELD_PREP(IDPF_RFL_BI_BUFID_M, buf_id) |
+		FIELD_PREP(IDPF_RFL_BI_GEN_M,
 			   idpf_queue_has(GEN_CHK, refillq));
 
 	if (unlikely(++nta == refillq->desc_count)) {
@@ -994,6 +1021,11 @@ static void idpf_txq_group_rel(struct idpf_vport *vport)
 		struct idpf_txq_group *txq_grp = &vport->txq_grps[i];
 
 		for (j = 0; j < txq_grp->num_txq; j++) {
+			if (flow_sch_en) {
+				kfree(txq_grp->txqs[j]->refillq);
+				txq_grp->txqs[j]->refillq = NULL;
+			}
+
 			kfree(txq_grp->txqs[j]);
 			txq_grp->txqs[j] = NULL;
 		}
@@ -1405,6 +1437,13 @@ static int idpf_txq_group_alloc(struct idpf_vport *vport, u16 num_txq)
 			}
 
 			idpf_queue_set(FLOW_SCH_EN, q);
+
+			q->refillq = kzalloc(sizeof(*q->refillq), GFP_KERNEL);
+			if (!q->refillq)
+				goto err_alloc;
+
+			idpf_queue_set(GEN_CHK, q->refillq);
+			idpf_queue_set(RFL_GEN_CHK, q->refillq);
 		}
 
 		if (!split)
@@ -1953,6 +1992,8 @@ static void idpf_tx_handle_rs_completion(struct idpf_tx_queue *txq,
 
 	compl_tag = le16_to_cpu(desc->q_head_compl_tag.compl_tag);
 
+	idpf_post_buf_refill(txq->refillq, compl_tag);
+
 	/* If we didn't clean anything on the ring, this packet must be
 	 * in the hash table. Go clean it there.
 	 */
@@ -2310,6 +2351,37 @@ static unsigned int idpf_tx_splitq_bump_ntu(struct idpf_tx_queue *txq, u16 ntu)
 	}
 
 	return ntu;
+}
+
+/**
+ * idpf_tx_get_free_buf_id - get a free buffer ID from the refill queue
+ * @refillq: refill queue to get buffer ID from
+ * @buf_id: return buffer ID
+ *
+ * Return: true if a buffer ID was found, false if not
+ */
+static bool idpf_tx_get_free_buf_id(struct idpf_sw_queue *refillq,
+				    u16 *buf_id)
+{
+	u32 ntc = refillq->next_to_clean;
+	u32 refill_desc;
+
+	refill_desc = refillq->ring[ntc];
+
+	if (unlikely(idpf_queue_has(RFL_GEN_CHK, refillq) !=
+		     !!(refill_desc & IDPF_RFL_BI_GEN_M)))
+		return false;
+
+	*buf_id = FIELD_GET(IDPF_RFL_BI_BUFID_M, refill_desc);
+
+	if (unlikely(++ntc == refillq->desc_count)) {
+		idpf_queue_change(RFL_GEN_CHK, refillq);
+		ntc = 0;
+	}
+
+	refillq->next_to_clean = ntc;
+
+	return true;
 }
 
 /**
@@ -2787,6 +2859,13 @@ static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
 	}
 
 	if (idpf_queue_has(FLOW_SCH_EN, tx_q)) {
+		if (unlikely(!idpf_tx_get_free_buf_id(tx_q->refillq,
+						      &tx_params.compl_tag))) {
+			u64_stats_update_begin(&tx_q->stats_sync);
+			u64_stats_inc(&tx_q->q_stats.q_busy);
+			u64_stats_update_end(&tx_q->stats_sync);
+		}
+
 		tx_params.dtype = IDPF_TX_DESC_DTYPE_FLEX_FLOW_SCHE;
 		tx_params.eop_cmd = IDPF_TXD_FLEX_FLOW_CMD_EOP;
 		/* Set the RE bit to catch any packets that may have not been
@@ -3309,7 +3388,7 @@ payload:
 skip_data:
 		rx_buf->page = NULL;
 
-		idpf_rx_post_buf_refill(refillq, buf_id);
+		idpf_post_buf_refill(refillq, buf_id);
 		IDPF_RX_BUMP_NTC(rxq, ntc);
 
 		/* skip if it is non EOP desc */
@@ -3417,10 +3496,10 @@ static void idpf_rx_clean_refillq(struct idpf_buf_queue *bufq,
 		bool failure;
 
 		if (idpf_queue_has(RFL_GEN_CHK, refillq) !=
-		    !!(refill_desc & IDPF_RX_BI_GEN_M))
+		    !!(refill_desc & IDPF_RFL_BI_GEN_M))
 			break;
 
-		buf_id = FIELD_GET(IDPF_RX_BI_BUFID_M, refill_desc);
+		buf_id = FIELD_GET(IDPF_RFL_BI_BUFID_M, refill_desc);
 		failure = idpf_rx_update_bufq_desc(bufq, buf_id, buf_desc);
 		if (failure)
 			break;

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.h
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
@@ -1015,6 +1015,17 @@ static inline void idpf_vport_intr_set_wb_on_itr(struct idpf_q_vector *q_vector)
 	       reg->dyn_ctl);
 }
 
+/**
+ * idpf_tx_splitq_get_free_bufs - get number of free buf_ids in refillq
+ * @refillq: pointer to refillq containing buf_ids
+ */
+static inline u32 idpf_tx_splitq_get_free_bufs(struct idpf_sw_queue *refillq)
+{
+	return (refillq->next_to_use > refillq->next_to_clean ?
+		0 : refillq->desc_count) +
+	       refillq->next_to_use - refillq->next_to_clean - 1;
+}
+
 int idpf_vport_singleq_napi_poll(struct napi_struct *napi, int budget);
 void idpf_vport_init_num_qs(struct idpf_vport *vport,
 			    struct virtchnl2_create_vport *vport_msg);
@@ -1042,8 +1053,8 @@ void idpf_tx_buf_hw_update(struct idpf_tx_queue *tx_q, u32 val,
 			   bool xmit_more);
 unsigned int idpf_size_to_txd_count(unsigned int size);
 netdev_tx_t idpf_tx_drop_skb(struct idpf_tx_queue *tx_q, struct sk_buff *skb);
-unsigned int idpf_tx_desc_count_required(struct idpf_tx_queue *txq,
-					 struct sk_buff *skb);
+unsigned int idpf_tx_res_count_required(struct idpf_tx_queue *txq,
+					struct sk_buff *skb, u32 *buf_count);
 void idpf_tx_timeout(struct net_device *netdev, unsigned int txqueue);
 netdev_tx_t idpf_tx_singleq_frame(struct sk_buff *skb,
 				  struct idpf_tx_queue *tx_q);

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.h
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
@@ -117,10 +117,6 @@ do {								\
 	((((txq)->next_to_clean > (txq)->next_to_use) ? 0 : (txq)->desc_count) + \
 	(txq)->next_to_clean - (txq)->next_to_use - 1)
 
-#define IDPF_TX_BUF_RSV_UNUSED(txq)	((txq)->stash->buf_stack.top)
-#define IDPF_TX_BUF_RSV_LOW(txq)	(IDPF_TX_BUF_RSV_UNUSED(txq) < \
-					 (txq)->desc_count >> 2)
-
 #define IDPF_TX_COMPLQ_OVERFLOW_THRESH(txcq)	((txcq)->desc_count >> 1)
 /* Determine the absolute number of completions pending, i.e. the number of
  * completions that are expected to arrive on the TX completion queue.
@@ -129,12 +125,6 @@ do {								\
 	(((txq)->num_completions_pending >= (txq)->complq->num_completions ? \
 	0 : U32_MAX) + \
 	(txq)->num_completions_pending - (txq)->complq->num_completions)
-
-#define IDPF_TX_SPLITQ_COMPL_TAG_WIDTH	16
-/* Adjust the generation for the completion tag and wrap if necessary */
-#define IDPF_TX_ADJ_COMPL_TAG_GEN(txq) \
-	((++(txq)->compl_tag_cur_gen) >= (txq)->compl_tag_gen_max ? \
-	0 : (txq)->compl_tag_cur_gen)
 
 #define IDPF_TXBUF_NULL			U32_MAX
 
@@ -151,18 +141,6 @@ union idpf_tx_flex_desc {
 };
 
 #define idpf_tx_buf libeth_sqe
-
-/**
- * struct idpf_buf_lifo - LIFO for managing OOO completions
- * @top: Used to know how many buffers are left
- * @size: Total size of LIFO
- * @bufs: Backing array
- */
-struct idpf_buf_lifo {
-	u16 top;
-	u16 size;
-	struct idpf_tx_stash **bufs;
-};
 
 /**
  * struct idpf_tx_offload_params - Offload parameters for a given packet
@@ -473,17 +451,6 @@ struct idpf_tx_queue_stats {
 #define IDPF_DIM_DEFAULT_PROFILE_IX		1
 
 /**
- * struct idpf_txq_stash - Tx buffer stash for Flow-based scheduling mode
- * @buf_stack: Stack of empty buffers to store buffer info for out of order
- *	       buffer completions. See struct idpf_buf_lifo
- * @sched_buf_hash: Hash table to store buffers
- */
-struct idpf_txq_stash {
-	struct idpf_buf_lifo buf_stack;
-	DECLARE_HASHTABLE(sched_buf_hash, 12);
-} ____cacheline_aligned;
-
-/**
  * struct idpf_rx_queue - software structure representing a receive queue
  * @rx: universal receive descriptor array
  * @single_buf: buffer descriptor array in singleq
@@ -625,11 +592,7 @@ libeth_cacheline_set_assert(struct idpf_rx_queue, 64,
  *		   only once at the end of the cleaning routine.
  * @clean_budget: singleq only, queue cleaning budget
  * @cleaned_pkts: Number of packets cleaned for the above said case
- * @stash: Tx buffer stash for Flow-based scheduling mode
  * @refillq: Pointer to refill queue
- * @compl_tag_bufid_m: Completion tag buffer id mask
- * @compl_tag_cur_gen: Used to keep track of current completion tag generation
- * @compl_tag_gen_max: To determine when compl_tag_cur_gen should be reset
  * @stats_sync: See struct u64_stats_sync
  * @q_stats: See union idpf_tx_queue_stats
  * @q_id: Queue id
@@ -658,7 +621,6 @@ struct idpf_tx_queue {
 	u16 desc_count;
 
 	u16 tx_min_pkt_len;
-	u16 compl_tag_gen_s;
 
 	struct net_device *netdev;
 	__cacheline_group_end_aligned(read_mostly);
@@ -675,12 +637,7 @@ struct idpf_tx_queue {
 	};
 	u16 cleaned_pkts;
 
-	struct idpf_txq_stash *stash;
 	struct idpf_sw_queue *refillq;
-
-	u16 compl_tag_bufid_m;
-	u16 compl_tag_cur_gen;
-	u16 compl_tag_gen_max;
 
 	struct u64_stats_sync stats_sync;
 	struct idpf_tx_queue_stats q_stats;
@@ -696,7 +653,7 @@ struct idpf_tx_queue {
 	__cacheline_group_end_aligned(cold);
 };
 libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
-			    96 + sizeof(struct u64_stats_sync),
+			    80 + sizeof(struct u64_stats_sync),
 			    32);
 
 /**
@@ -907,7 +864,6 @@ struct idpf_rxq_group {
  * @vport: Vport back pointer
  * @num_txq: Number of TX queues associated
  * @txqs: Array of TX queue pointers
- * @stashes: array of OOO stashes for the queues
  * @complq: Associated completion queue pointer, split queue only
  * @num_completions_pending: Total number of completions pending for the
  *			     completion queue, acculumated for all TX queues
@@ -922,7 +878,6 @@ struct idpf_txq_group {
 
 	u16 num_txq;
 	struct idpf_tx_queue *txqs[IDPF_LARGE_MAX_Q];
-	struct idpf_txq_stash *stashes;
 
 	struct idpf_compl_queue *complq;
 

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.h
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
@@ -107,8 +107,8 @@ do {								\
  */
 #define IDPF_TX_SPLITQ_RE_MIN_GAP	64
 
-#define IDPF_RX_BI_GEN_M		BIT(16)
-#define IDPF_RX_BI_BUFID_M		GENMASK(15, 0)
+#define IDPF_RFL_BI_GEN_M		BIT(16)
+#define IDPF_RFL_BI_BUFID_M		GENMASK(15, 0)
 
 #define IDPF_RXD_EOF_SPLITQ		VIRTCHNL2_RX_FLEX_DESC_ADV_STATUS0_EOF_M
 #define IDPF_RXD_EOF_SINGLEQ		VIRTCHNL2_RX_BASE_DESC_STATUS_EOF_M
@@ -616,6 +616,7 @@ libeth_cacheline_set_assert(struct idpf_rx_queue, 64,
  * @cleaned_pkts: Number of packets cleaned for the above said case
  * @tx_max_bufs: Max buffers that can be transmitted with scatter-gather
  * @stash: Tx buffer stash for Flow-based scheduling mode
+ * @refillq: Pointer to refill queue
  * @compl_tag_bufid_m: Completion tag buffer id mask
  * @compl_tag_cur_gen: Used to keep track of current completion tag generation
  * @compl_tag_gen_max: To determine when compl_tag_cur_gen should be reset
@@ -663,6 +664,7 @@ struct idpf_tx_queue {
 
 	u16 tx_max_bufs;
 	struct idpf_txq_stash *stash;
+	struct idpf_sw_queue *refillq;
 
 	u16 compl_tag_bufid_m;
 	u16 compl_tag_cur_gen;
@@ -681,7 +683,7 @@ struct idpf_tx_queue {
 	__cacheline_group_end_aligned(cold);
 };
 libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
-			    88 + sizeof(struct u64_stats_sync),
+			    96 + sizeof(struct u64_stats_sync),
 			    24);
 
 /**

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.h
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
@@ -1039,12 +1039,4 @@ bool idpf_rx_singleq_buf_hw_alloc_all(struct idpf_rx_queue *rxq,
 				      u16 cleaned_count);
 int idpf_tso(struct sk_buff *skb, struct idpf_tx_offload_params *off);
 
-static inline bool idpf_tx_maybe_stop_common(struct idpf_tx_queue *tx_q,
-					     u32 needed)
-{
-	return !netif_subqueue_maybe_stop(tx_q->netdev, tx_q->idx,
-					  IDPF_DESC_UNUSED(tx_q),
-					  needed, needed);
-}
-
 #endif /* !_IDPF_TXRX_H_ */

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.h
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
@@ -194,6 +194,7 @@ struct idpf_tx_offload_params {
  * @compl_tag: Associated tag for completion
  * @td_tag: Descriptor tunneling tag
  * @offload: Offload parameters
+ * @prev_ntu: stored TxQ next_to_use in case of rollback
  */
 struct idpf_tx_splitq_params {
 	enum idpf_tx_desc_dtype_value dtype;
@@ -204,6 +205,8 @@ struct idpf_tx_splitq_params {
 	};
 
 	struct idpf_tx_offload_params offload;
+
+	u16 prev_ntu;
 };
 
 enum idpf_tx_ctx_desc_eipt_offload {
@@ -1031,8 +1034,6 @@ void idpf_tx_buf_hw_update(struct idpf_tx_queue *tx_q, u32 val,
 			   bool xmit_more);
 unsigned int idpf_size_to_txd_count(unsigned int size);
 netdev_tx_t idpf_tx_drop_skb(struct idpf_tx_queue *tx_q, struct sk_buff *skb);
-void idpf_tx_dma_map_error(struct idpf_tx_queue *txq, struct sk_buff *skb,
-			   struct idpf_tx_buf *first, u16 ring_idx);
 unsigned int idpf_tx_desc_count_required(struct idpf_tx_queue *txq,
 					 struct sk_buff *skb);
 void idpf_tx_timeout(struct net_device *netdev, unsigned int txqueue);

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.h
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
@@ -604,6 +604,8 @@ libeth_cacheline_set_assert(struct idpf_rx_queue, 64,
  * @netdev: &net_device corresponding to this queue
  * @next_to_use: Next descriptor to use
  * @next_to_clean: Next descriptor to clean
+ * @last_re: last descriptor index that RE bit was set
+ * @tx_max_bufs: Max buffers that can be transmitted with scatter-gather
  * @cleaned_bytes: Splitq only, TXQ only: When a TX completion is received on
  *		   the TX completion queue, it can be for any TXQ associated
  *		   with that completion queue. This means we can clean up to
@@ -614,7 +616,6 @@ libeth_cacheline_set_assert(struct idpf_rx_queue, 64,
  *		   only once at the end of the cleaning routine.
  * @clean_budget: singleq only, queue cleaning budget
  * @cleaned_pkts: Number of packets cleaned for the above said case
- * @tx_max_bufs: Max buffers that can be transmitted with scatter-gather
  * @stash: Tx buffer stash for Flow-based scheduling mode
  * @refillq: Pointer to refill queue
  * @compl_tag_bufid_m: Completion tag buffer id mask
@@ -655,6 +656,8 @@ struct idpf_tx_queue {
 	__cacheline_group_begin_aligned(read_write);
 	u16 next_to_use;
 	u16 next_to_clean;
+	u16 last_re;
+	u16 tx_max_bufs;
 
 	union {
 		u32 cleaned_bytes;
@@ -662,7 +665,6 @@ struct idpf_tx_queue {
 	};
 	u16 cleaned_pkts;
 
-	u16 tx_max_bufs;
 	struct idpf_txq_stash *stash;
 	struct idpf_sw_queue *refillq;
 

--- a/drivers/net/ethernet/intel/idpf/idpf_txrx.h
+++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
@@ -136,6 +136,8 @@ do {								\
 	((++(txq)->compl_tag_cur_gen) >= (txq)->compl_tag_gen_max ? \
 	0 : (txq)->compl_tag_cur_gen)
 
+#define IDPF_TXBUF_NULL			U32_MAX
+
 #define IDPF_TXD_LAST_DESC_CMD (IDPF_TX_DESC_CMD_EOP | IDPF_TX_DESC_CMD_RS)
 
 #define IDPF_TX_FLAGS_TSO		BIT(0)
@@ -195,6 +197,8 @@ struct idpf_tx_offload_params {
  * @td_tag: Descriptor tunneling tag
  * @offload: Offload parameters
  * @prev_ntu: stored TxQ next_to_use in case of rollback
+ * @prev_refill_ntc: stored refillq next_to_clean in case of packet rollback
+ * @prev_refill_gen: stored refillq generation bit in case of packet rollback
  */
 struct idpf_tx_splitq_params {
 	enum idpf_tx_desc_dtype_value dtype;
@@ -207,6 +211,8 @@ struct idpf_tx_splitq_params {
 	struct idpf_tx_offload_params offload;
 
 	u16 prev_ntu;
+	u16 prev_refill_ntc;
+	bool prev_refill_gen;
 };
 
 enum idpf_tx_ctx_desc_eipt_offload {
@@ -630,6 +636,7 @@ libeth_cacheline_set_assert(struct idpf_rx_queue, 64,
  * @size: Length of descriptor ring in bytes
  * @dma: Physical address of ring
  * @q_vector: Backreference to associated vector
+ * @buf_pool_size: Total number of idpf_tx_buf
  */
 struct idpf_tx_queue {
 	__cacheline_group_begin_aligned(read_mostly);
@@ -685,11 +692,12 @@ struct idpf_tx_queue {
 	dma_addr_t dma;
 
 	struct idpf_q_vector *q_vector;
+	u32 buf_pool_size;
 	__cacheline_group_end_aligned(cold);
 };
 libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
 			    96 + sizeof(struct u64_stats_sync),
-			    24);
+			    32);
 
 /**
  * struct idpf_buf_queue - software structure representing a buffer queue


### PR DESCRIPTION
## Description
Customer request to fix a tx timeout issue in c4a metal instances in
google cloud.

From mainline submission explanation:

This series fixes a stability issue in the flow scheduling Tx send/clean
path that results in a Tx timeout.

The existing guardrails in the Tx path were not sufficient to prevent
the driver from reusing completion tags that were still in flight (held
by the HW).  This collision would cause the driver to erroneously clean
the wrong packet thus leaving the descriptor ring in a bad state.

The main point of this fix is to replace the flow scheduling buffer ring
with a large pool/array of buffers.  The completion tag then simply is
the index into this array.  The driver tracks the free tags and pulls
the next free one from a refillq.  The cleaning routines simply use the
completion tag from the completion descriptor to index into the array to
quickly find the buffers to clean.

All of the code to support this is added first to ensure traffic still
passes with each patch.  The final patch then removes all of the
obsolete stashing code.

## COMMITS

The majority are not not clean cherry picks due to missing
1a49cf814fe1e ("idpf: add Tx timestamp flows").
I did not backport this one as well because it was part of a bigger submission
https://lore.kernel.org/all/20250425215227.3170837-1-anthony.l.nguyen@intel.com/
After checking the code, the tx timestamp does not interfere with the new
large pool/aaray of buffers instead of one buffer ring.

```
idpf: fix a race in txq wakeup

jira KERNEL-170
commit-author Brian Vazquez <brianvv@google.com>
commit 7292af042bcf22e2c18b96ed250f78498a5b28ab
```

```
idpf: add support for Tx refillqs in flow scheduling mode

jira KERNEL-170
commit-author Joshua Hay <joshua.a.hay@intel.com>
commit cb83b559bea39f207ee214ee2972657e8576ed18
upstream-diff |
	adjusted the number of bytes expected in
	libeth_cacheline_set_assert for struct idpf_tx_queue due to missing
	of some elements in the struct introduced in commit
	1a49cf814fe1e ("idpf: add Tx timestamp flows").
```

```
idpf: improve when to set RE bit logic

jira KERNEL-170
commit-author Joshua Hay <joshua.a.hay@intel.com>
commit f2d18e16479cac7a708d77cbfb4220a9114a71fc
```

```
idpf: simplify and fix splitq Tx packet rollback error path

jira KERNEL-170
commit-author Joshua Hay <joshua.a.hay@intel.com>
commit b61dfa9bc4430ad82b96d3a7c1c485350f91b467
upstream-diff |
	adjusted context in 2 places:
	- when removing func idpf_tx_dma_map_error due to different memset
	call that uses the hardcoded struct type;
	- in func idpf_tx_splitq_frame due to missing expected
	union idpf_flex_tx_ctx_desc *ctx_desc;
	both differences were introduced in commit
	1a49cf814fe1e ("idpf: add Tx timestamp flows").
```

```
idpf: replace flow scheduling buffer ring with buffer pool

jira KERNEL-170
commit-author Joshua Hay <joshua.a.hay@intel.com>
commit 5f417d551324d2894168b362f2429d120ab06243
upstream-diff |
	adjusted context in:
	- ifpf_tx_splitq_frame and idpf_tx_clean_bufs;
	- libeth_cacheline_set_assert for struct idpf_tx_queue due to missing
	of some elements in the struct;
	all cases are due to missing commit
	1a49cf814fe1e ("idpf: add Tx timestamp flows").
```

```
idpf: stop Tx if there are insufficient buffer resources

jira KERNEL-170
commit-author Joshua Hay <joshua.a.hay@intel.com>
commit 0c3f135e840d4a2ba4253e15d530ec61bc30718e
upstream-diff |
	adjusted conflict in idpf_tx_splitq_frame func due to missing
	1a49cf814fe1e ("idpf: add Tx timestamp flows").
```

```
idpf: remove obsolete stashing code

jira KERNEL-170
commit-author Joshua Hay <joshua.a.hay@intel.com>
commit 6c4e68480238274f84aa50d54da0d9e262df6284
upstream-diff |
	- adjusted context due to missing idpf_tx_read_tstamp func;
	- adjusted the number of bytes expected in
	libeth_cacheline_set_assert for struct idpf_tx_queue due to missing
	of some elements in the struct;
	both are due to missing commit
	1a49cf814fe1e ("idpf: add Tx timestamp flows").
```

## BUILD
```
/home/rnicolescu/ciq/kernels/rlc-10-latest/kernel-src-tree
Running make mrproper...
[TIMER]{MRPROPER}: 5s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96"
Making olddefconfig
--
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  GEN     arch/x86/include/generated/asm/orc_hash.h
  WRAP    arch/x86/include/generated/uapi/asm/bpf_perf_event.h
  WRAP    arch/x86/include/generated/uapi/asm/errno.h
  WRAP    arch/x86/include/generated/uapi/asm/fcntl.h
  WRAP    arch/x86/include/generated/uapi/asm/ioctl.h
--
  LD [M]  net/qrtr/qrtr-mhi.ko
  LD [M]  virt/lib/irqbypass.ko
  BTF [M] net/qrtr/qrtr.ko
  BTF [M] net/qrtr/qrtr-mhi.ko
  BTF [M] virt/lib/irqbypass.ko
[TIMER]{BUILD}: 4091s
Making Modules
  SYMLINK /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+/build
  INSTALL /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+/modules.order
  INSTALL /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+/modules.builtin
  INSTALL /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+/modules.builtin.modinfo
--
  STRIP   /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+/kernel/virt/lib/irqbypass.ko
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+/kernel/net/qrtr/qrtr.ko
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+/kernel/net/qrtr/qrtr-mhi.ko
  SIGN    /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+
[TIMER]{MODULES}: 10s
Making Install
  INSTALL /boot
[TIMER]{INSTALL}: 15s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+ and Index to 2
The default is /boot/loader/entries/2adeea37d6d145f09ba612fce6891624-6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+.conf with index 2 and kernel /boot/vmlinuz-6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+
The default is /boot/loader/entries/2adeea37d6d145f09ba612fce6891624-6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+.conf with index 2 and kernel /boot/vmlinuz-6.12.0-rnicolescu_rlc-10_6.12.0-124.38.1.el10_1-044a3252be96+
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 4091s
[TIMER]{MODULES}: 10s
[TIMER]{INSTALL}: 15s
[TIMER]{TOTAL} 4126s
Rebooting in 10 seconds
```
[kernel-build-after.log](https://github.com/user-attachments/files/25549407/kernel-build-after.log)

## Kselftests
```
./kselftest-after.log
480
./kselftest-before.log
481
Before: ./kselftest-after.log
After: ./kselftest-before.log
Diff:
-ok 2 selftests: syscall_user_dispatch: sud_benchmark
+ok 4 selftests: cgroup: test_freezer
+ok 66 selftests: net: gre_gso.sh
```
[kselftest-after.log](https://github.com/user-attachments/files/25549399/kselftest-after.log)
[kselftest-before.log](https://github.com/user-attachments/files/25549402/kselftest-before.log)

## Check_kernel_commits
```
> python3 ~/ciq/kernel-src-tree-tools/check_kernel_commits.py --repo . --pr_branch {rnicolescu}/rlc-10/6.12.0-124.38.1.el10_1 --base_branch origin/rlc-10/6.12.0-124.38.1.el10_1
All referenced commits exist upstream and have no Fixes: tags.
```

## Run interdiff
```
[DIFF] PR commit 37f70602c1f2 (idpf: add support for Tx refillqs in flow scheduling mode) → upstream cb83b559bea3
Differences found:

  ================================================================================
  *    DELTA DIFFERENCES - code changes that differ between the patches          *
  ================================================================================

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  @@ -683,7 +683,7 @@
   	__cacheline_group_end_aligned(cold);
   };
   libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
  -			    96 + sizeof(struct u64_stats_sync),
  +			    88 + sizeof(struct u64_stats_sync),
   			    24);

   /**
83b559bea3################################################################################
  !    REJECTED PATCH2 HUNKS - could not be compared; manual review needed       !
  ################################################################################

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  @@ -694,7 +696,7 @@
   	__cacheline_group_end_aligned(cold);
   };
   libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
  -			    112 + sizeof(struct u64_stats_sync),
  +			    120 + sizeof(struct u64_stats_sync),
   			    24);

   /**

  ================================================================================
  *    CONTEXT DIFFERENCES - surrounding code differences between the patches    *
  ================================================================================

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -3306,5 +3431,5 @@
   skip_data:
  -		rx_buf->page = NULL;
  +		rx_buf->netmem = 0;

   		idpf_rx_post_buf_refill(refillq, buf_id);
   		IDPF_RX_BUMP_NTC(rxq, ntc);
  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  @@ -678,7 +686,7 @@
   	__cacheline_group_end_aligned(cold);
   };
   libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
  -			    88 + sizeof(struct u64_stats_sync),
  +			    112 + sizeof(struct u64_stats_sync),
   			    24);

   /**

```
As explained in the comment.
<img width="1715" height="233" alt="Screenshot From 2026-02-25 14-24-30" src="https://github.com/user-attachments/assets/0718fa75-3806-4885-a14e-4a25f0140a83" />
Check colordiff log as well 
[37f70602c1f2_colordiff.log](https://github.com/user-attachments/files/25547075/37f70602c1f2_colordiff.log)


```
[DIFF] PR commit 49bb62933e77 (idpf: simplify and fix splitq Tx packet rollback error path) → upstream b61dfa9bc443
Differences found:

  ================================================================================
  *    DELTA DIFFERENCES - code changes that differ between the patches          *
  ================================================================================

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -2289,4 +2289,55 @@

   /**
  + * idpf_tx_dma_map_error - handle TX DMA map errors
  + * @txq: queue to send buffer on
  + * @skb: send buffer
  + * @first: original first buffer info buffer for packet
  + * @idx: starting point on ring to unwind
  + */
  +void idpf_tx_dma_map_error(struct idpf_tx_queue *txq, struct sk_buff *skb,
  +			   struct idpf_tx_buf *first, u16 idx)
  +{
  +	struct libeth_sq_napi_stats ss = { };
  +	struct libeth_cq_pp cp = {
  +		.dev	= txq->dev,
  +		.ss	= &ss,
  +	};
  +
  +	u64_stats_update_begin(&txq->stats_sync);
  +	u64_stats_inc(&txq->q_stats.dma_map_errs);
  +	u64_stats_update_end(&txq->stats_sync);
  +
  +	/* clear dma mappings for failed tx_buf map */
  +	for (;;) {
  +		struct idpf_tx_buf *tx_buf;
  +
  +		tx_buf = &txq->tx_buf[idx];
  +		libeth_tx_complete(tx_buf, &cp);
  +		if (tx_buf == first)
  +			break;
  +		if (idx == 0)
  +			idx = txq->desc_count;
  +		idx--;
  +	}
  +
  +	if (skb_is_gso(skb)) {
  +		union idpf_tx_flex_desc *tx_desc;
  +
  +		/* If we failed a DMA mapping for a TSO packet, we will have
  +		 * used one additional descriptor for a context
  +		 * descriptor. Reset that here.
  +		 */
  +		tx_desc = &txq->flex_tx[idx];
  +		memset(tx_desc, 0, sizeof(struct idpf_flex_tx_ctx_desc));
  +		if (idx == 0)
  +			idx = txq->desc_count;
  +		idx--;
  +	}
  +
  +	/* Update tail in case netdev_xmit_more was previously true */
  +	idpf_tx_buf_hw_update(txq, idx, false);
  +}
  +
  +/**
    * idpf_tx_splitq_bump_ntu - adjust NTU and generation
    * @txq: the tx ring to wrap
  @@ -2337,35 +2388,4 @@

   /**
  - * idpf_tx_splitq_pkt_err_unmap - Unmap buffers and bump tail in case of error
  - * @txq: Tx queue to unwind
  - * @params: pointer to splitq params struct
  - * @first: starting buffer for packet to unmap
  - */
  -static void idpf_tx_splitq_pkt_err_unmap(struct idpf_tx_queue *txq,
  -					 struct idpf_tx_splitq_params *params,
  -					 struct idpf_tx_buf *first)
  -{
  -	struct libeth_sq_napi_stats ss = { };
  -	struct idpf_tx_buf *tx_buf = first;
  -	struct libeth_cq_pp cp = {
  -		.dev    = txq->dev,
  -		.ss     = &ss,
  -	};
  -	u32 idx = 0;
  -
  -	u64_stats_update_begin(&txq->stats_sync);
  -	u64_stats_inc(&txq->q_stats.dma_map_errs);
  -	u64_stats_update_end(&txq->stats_sync);
  -
  -	do {
  -		libeth_tx_complete(tx_buf, &cp);
  -		idpf_tx_clean_buf_ring_bump_ntc(txq, idx, tx_buf);
  -	} while (idpf_tx_buf_compl_tag(tx_buf) == params->compl_tag);
  -
  -	/* Update tail in case netdev_xmit_more was previously true. */
  -	idpf_tx_buf_hw_update(txq, params->prev_ntu, false);
  -}
  -
  -/**
    * idpf_tx_splitq_map - Build the Tx flex descriptor
    * @tx_q: queue to send buffer on

  ################################################################################
  !    REJECTED PATCH2 HUNKS - could not be compared; manual review needed       !
  ################################################################################

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -2339,57 +2339,6 @@
   	return count;
   }

  -/**
  - * idpf_tx_dma_map_error - handle TX DMA map errors
  - * @txq: queue to send buffer on
  - * @skb: send buffer
  - * @first: original first buffer info buffer for packet
  - * @idx: starting point on ring to unwind
  - */
  -void idpf_tx_dma_map_error(struct idpf_tx_queue *txq, struct sk_buff *skb,
  -			   struct idpf_tx_buf *first, u16 idx)
  -{
  -	struct libeth_sq_napi_stats ss = { };
  -	struct libeth_cq_pp cp = {
  -		.dev	= txq->dev,
  -		.ss	= &ss,
  -	};
  -
  -	u64_stats_update_begin(&txq->stats_sync);
  -	u64_stats_inc(&txq->q_stats.dma_map_errs);
  -	u64_stats_update_end(&txq->stats_sync);
  -
  -	/* clear dma mappings for failed tx_buf map */
  -	for (;;) {
  -		struct idpf_tx_buf *tx_buf;
  -
  -		tx_buf = &txq->tx_buf[idx];
  -		libeth_tx_complete(tx_buf, &cp);
  -		if (tx_buf == first)
  -			break;
  -		if (idx == 0)
  -			idx = txq->desc_count;
  -		idx--;
  -	}
  -
  -	if (skb_is_gso(skb)) {
  -		union idpf_tx_flex_desc *tx_desc;
  -
  -		/* If we failed a DMA mapping for a TSO packet, we will have
  -		 * used one additional descriptor for a context
  -		 * descriptor. Reset that here.
  -		 */
  -		tx_desc = &txq->flex_tx[idx];
  -		memset(tx_desc, 0, sizeof(*tx_desc));
  -		if (idx == 0)
  -			idx = txq->desc_count;
  -		idx--;
  -	}
  -
  -	/* Update tail in case netdev_xmit_more was previously true */
  -	idpf_tx_buf_hw_update(txq, idx, false);
  -}
  -
   /**
    * idpf_tx_splitq_bump_ntu - adjust NTU and generation
    * @txq: the tx ring to wrap
  @@ -2438,6 +2387,37 @@
   	return true;
   }

  +/**
  + * idpf_tx_splitq_pkt_err_unmap - Unmap buffers and bump tail in case of error
  + * @txq: Tx queue to unwind
  + * @params: pointer to splitq params struct
  + * @first: starting buffer for packet to unmap
  + */
  +static void idpf_tx_splitq_pkt_err_unmap(struct idpf_tx_queue *txq,
  +					 struct idpf_tx_splitq_params *params,
  +					 struct idpf_tx_buf *first)
  +{
  +	struct libeth_sq_napi_stats ss = { };
  +	struct idpf_tx_buf *tx_buf = first;
  +	struct libeth_cq_pp cp = {
  +		.dev    = txq->dev,
  +		.ss     = &ss,
  +	};
  +	u32 idx = 0;
  +
  +	u64_stats_update_begin(&txq->stats_sync);
  +	u64_stats_inc(&txq->q_stats.dma_map_errs);
  +	u64_stats_update_end(&txq->stats_sync);
  +
  +	do {
  +		libeth_tx_complete(tx_buf, &cp);
  +		idpf_tx_clean_buf_ring_bump_ntc(txq, idx, tx_buf);
  +	} while (idpf_tx_buf_compl_tag(tx_buf) == params->compl_tag);
  +
  +	/* Update tail in case netdev_xmit_more was previously true. */
  +	idpf_tx_buf_hw_update(txq, params->prev_ntu, false);
  +}
  +
   /**
    * idpf_tx_splitq_map - Build the Tx flex descriptor
    * @tx_q: queue to send buffer on
  @@ -2482,8 +2462,9 @@
   	for (frag = &skb_shinfo(skb)->frags[0];; frag++) {
   		unsigned int max_data = IDPF_TX_MAX_DESC_DATA_ALIGNED;

  -		if (dma_mapping_error(tx_q->dev, dma))
  -			return idpf_tx_dma_map_error(tx_q, skb, first, i);
  +		if (unlikely(dma_mapping_error(tx_q->dev, dma)))
  +			return idpf_tx_splitq_pkt_err_unmap(tx_q, params,
  +							    first);

   		first->nr_frags++;
   		idpf_tx_buf_compl_tag(tx_buf) = params->compl_tag;
  @@ -2939,7 +2920,9 @@
   static netdev_tx_t idpf_tx_splitq_frame(struct sk_buff *skb,
   					struct idpf_tx_queue *tx_q)
   {
  -	struct idpf_tx_splitq_params tx_params = { };
  +	struct idpf_tx_splitq_params tx_params = {
  +		.prev_ntu = tx_q->next_to_use,
  +	};
   	union idpf_flex_tx_ctx_desc *ctx_desc;
   	struct idpf_tx_buf *first;
   	unsigned int count;

  ================================================================================
  *    CONTEXT DIFFERENCES - surrounding code differences between the patches    *
  ================================================================================

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -2328,7 +2380,7 @@
   		 * descriptor. Reset that here.
   		 */
   		tx_desc = &txq->flex_tx[idx];
  -		memset(tx_desc, 0, sizeof(struct idpf_flex_tx_ctx_desc));
  +		memset(tx_desc, 0, sizeof(*tx_desc));
   		if (idx == 0)
   			idx = txq->desc_count;
   		idx--;
  @@ -2819,4 +2871,5 @@
   {
   	struct idpf_tx_splitq_params tx_params = { };
  +	union idpf_flex_tx_ctx_desc *ctx_desc;
   	struct idpf_tx_buf *first;
   	unsigned int count;
```
Last chunk is relevant here, as explained in the commit message.
The rest I am not sure why it complains.
Check colordiff as well
[49bb62933e77_colordiff.log](https://github.com/user-attachments/files/25547082/49bb62933e77_colordiff.log)

```
[DIFF] PR commit 9c1f0f3ca76a (idpf: replace flow scheduling buffer ring with buffer pool) → upstream 5f417d551324
Differences found:

  ================================================================================
  *    DELTA DIFFERENCES - code changes that differ between the patches          *
  ================================================================================

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -1917,11 +1917,8 @@
   		.napi	= budget,
   	};

  -	tx_buf = &txq->tx_buf[buf_id];
  -	if (tx_buf->type == LIBETH_SQE_SKB) {
  +	if (tx_buf->type == LIBETH_SQE_SKB)
   		libeth_tx_complete(tx_buf, &cp);
  -		idpf_post_buf_refill(txq->refillq, buf_id);
  -	}

   	while (idpf_tx_buf_next(tx_buf) != IDPF_TXBUF_NULL) {
   		buf_id = idpf_tx_buf_next(tx_buf);

  ################################################################################
  !    REJECTED PATCH2 HUNKS - could not be compared; manual review needed       !
  ################################################################################

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -1962,6 +1962,7 @@
   		     idpf_tx_buf_compl_tag(tx_buf) != compl_tag))
   		return false;

  +	tx_buf = &txq->tx_buf[buf_id];
   	if (tx_buf->type == LIBETH_SQE_SKB) {
   		if (skb_shinfo(tx_buf->skb)->tx_flags & SKBTX_IN_PROGRESS)
   			idpf_tx_read_tstamp(txq, tx_buf->skb);
  @@ -1965,6 +1966,7 @@
   			idpf_tx_read_tstamp(txq, tx_buf->skb);

   		libeth_tx_complete(tx_buf, &cp);
  +		idpf_post_buf_refill(txq->refillq, buf_id);
   	}

   	idpf_tx_clean_buf_ring_bump_ntc(txq, idx, tx_buf);
  @@ -2892,6 +2859,7 @@
   	struct idpf_tx_buf *first;
   	unsigned int count;
   	int tso, idx;
  +	u32 buf_id;

   	count = idpf_tx_desc_count_required(tx_q, skb);
   	if (unlikely(!count))
  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  @@ -707,7 +715,7 @@
   };
   libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
   			    120 + sizeof(struct u64_stats_sync),
  -			    24);
  +			    32);

   /**
    * struct idpf_buf_queue - software structure representing a buffer queue

  ================================================================================
  *    CONTEXT DIFFERENCES - surrounding code differences between the patches    *
  ================================================================================

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -1917,8 +1965,12 @@
   		     idpf_tx_buf_compl_tag(tx_buf) != compl_tag))
   		return false;

  -	if (tx_buf->type == LIBETH_SQE_SKB)
  +	if (tx_buf->type == LIBETH_SQE_SKB) {
  +		if (skb_shinfo(tx_buf->skb)->tx_flags & SKBTX_IN_PROGRESS)
  +			idpf_tx_read_tstamp(txq, tx_buf->skb);
  +
   		libeth_tx_complete(tx_buf, &cp);
  +	}

   	idpf_tx_clean_buf_ring_bump_ntc(txq, idx, tx_buf);

  @@ -2746,4 +2798,4 @@
  -	struct idpf_flex_tx_ctx_desc *desc;
  +	union idpf_flex_tx_ctx_desc *desc;
   	int i = txq->next_to_use;

   	txq->tx_buf[i].type = LIBETH_SQE_CTX;
  @@ -2804,6 +2856,6 @@
   	struct idpf_tx_buf *first;
   	unsigned int count;
  -	int tso;
  +	int tso, idx;

   	count = idpf_tx_desc_count_required(tx_q, skb);
   	if (unlikely(!count))
  @@ -2842,4 +2962,4 @@
  -		u64_stats_update_end(&tx_q->stats_sync);
  +		idpf_tx_set_tstamp_desc(ctx_desc, idx);
   	}

   	/* record the location of the first descriptor for this packet */
  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  @@ -685,7 +693,7 @@
   	__cacheline_group_end_aligned(cold);
   };
   libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
  -			    96 + sizeof(struct u64_stats_sync),
  +			    120 + sizeof(struct u64_stats_sync),
   			    24);

   /**
```

<img width="1708" height="265" alt="Screenshot From 2026-02-25 14-46-40" src="https://github.com/user-attachments/assets/21ffb01f-871c-4366-ab0b-9342b49cc8bc" />
This is due to missing 1a49cf814fe1e ("idpf: add Tx timestamp flows")
Same for here
<img width="1714" height="279" alt="Screenshot From 2026-02-25 14-48-06" src="https://github.com/user-attachments/assets/7c0e462e-5ec5-4841-82e3-4788038b4aba" />

[9c1f0f3ca76a_colordiff.log](https://github.com/user-attachments/files/25547505/9c1f0f3ca76a_colordiff.log)

```
[DIFF] PR commit 0facc01c7a6a (idpf: stop Tx if there are insufficient buffer resources) → upstream 0c3f135e840d
Differences found:

  ################################################################################
  !    REJECTED PATCH2 HUNKS - could not be compared; manual review needed       !
  ################################################################################

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -2909,7 +2926,7 @@
   	};
   	union idpf_flex_tx_ctx_desc *ctx_desc;
   	struct idpf_tx_buf *first;
  -	unsigned int count;
  +	u32 count, buf_count = 1;
   	int tso, idx;
   	u32 buf_id;


  ================================================================================
  *    CONTEXT DIFFERENCES - surrounding code differences between the patches    *
  ================================================================================

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -2770,7 +2821,8 @@
   	};
  +	union idpf_flex_tx_ctx_desc *ctx_desc;
   	struct idpf_tx_buf *first;
   	unsigned int count;
  -	int tso;
  +	int tso, idx;
   	u32 buf_id;

   	count = idpf_tx_desc_count_required(tx_q, skb);
```
Second is due to missing the same commit. All good.

[0facc01c7a6a_colordiff.log](https://github.com/user-attachments/files/25547566/0facc01c7a6a_colordiff.log)

```
[DIFF] PR commit 044a3252be96 (idpf: remove obsolete stashing code) → upstream 6c4e68480238
Differences found:

  ================================================================================
  *    DELTA DIFFERENCES - code changes that differ between the patches          *
  ================================================================================

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -1559,6 +1559,82 @@
   	wake_up(&vport->sw_marker_wq);
   }

  +/**
  + * idpf_tx_clean_stashed_bufs - clean bufs that were stored for
  + * out of order completions
  + * @txq: queue to clean
  + * @compl_tag: completion tag of packet to clean (from completion descriptor)
  + * @cleaned: pointer to stats struct to track cleaned packets/bytes
  + * @budget: Used to determine if we are in netpoll
  + */
  +static void idpf_tx_clean_stashed_bufs(struct idpf_tx_queue *txq,
  +				       u16 compl_tag,
  +				       struct libeth_sq_napi_stats *cleaned,
  +				       int budget)
  +{
  +	struct idpf_tx_stash *stash;
  +	struct hlist_node *tmp_buf;
  +	struct libeth_cq_pp cp = {
  +		.dev	= txq->dev,
  +		.ss	= cleaned,
  +		.napi	= budget,
  +	};
  +
  +	/* Buffer completion */
  +	hash_for_each_possible_safe(txq->stash->sched_buf_hash, stash, tmp_buf,
  +				    hlist, compl_tag) {
  +		if (unlikely(idpf_tx_buf_compl_tag(&stash->buf) != compl_tag))
  +			continue;
  +
  +		hash_del(&stash->hlist);
  +		libeth_tx_complete(&stash->buf, &cp);
  +
  +		/* Push shadow buf back onto stack */
  +		idpf_buf_lifo_push(&txq->stash->buf_stack, stash);
  +	}
  +}
  +
  +/**
  + * idpf_stash_flow_sch_buffers - store buffer parameters info to be freed at a
  + * later time (only relevant for flow scheduling mode)
  + * @txq: Tx queue to clean
  + * @tx_buf: buffer to store
  + */
  +static int idpf_stash_flow_sch_buffers(struct idpf_tx_queue *txq,
  +				       struct idpf_tx_buf *tx_buf)
  +{
  +	struct idpf_tx_stash *stash;
  +
  +	if (unlikely(tx_buf->type <= LIBETH_SQE_CTX))
  +		return 0;
  +
  +	stash = idpf_buf_lifo_pop(&txq->stash->buf_stack);
  +	if (unlikely(!stash)) {
  +		net_err_ratelimited("%s: No out-of-order TX buffers left!\n",
  +				    netdev_name(txq->netdev));
  +
  +		return -ENOMEM;
  +	}
  +
  +	/* Store buffer params in shadow buffer */
  +	stash->buf.skb = tx_buf->skb;
  +	stash->buf.bytes = tx_buf->bytes;
  +	stash->buf.packets = tx_buf->packets;
  +	stash->buf.type = tx_buf->type;
  +	stash->buf.nr_frags = tx_buf->nr_frags;
  +	dma_unmap_addr_set(&stash->buf, dma, dma_unmap_addr(tx_buf, dma));
  +	dma_unmap_len_set(&stash->buf, len, dma_unmap_len(tx_buf, len));
  +	idpf_tx_buf_compl_tag(&stash->buf) = idpf_tx_buf_compl_tag(tx_buf);
  +
  +	/* Add buffer to buf_hash table to be freed later */
  +	hash_add(txq->stash->sched_buf_hash, &stash->hlist,
  +		 idpf_tx_buf_compl_tag(&stash->buf));
  +
  +	tx_buf->type = LIBETH_SQE_EMPTY;
  +
  +	return 0;
  +}
  +
   #define idpf_tx_splitq_clean_bump_ntc(txq, ntc, desc, buf)	\
   do {								\
   	if (unlikely(++(ntc) == (txq)->desc_count)) {		\
  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  @@ -653,7 +660,7 @@
   	__cacheline_group_end_aligned(cold);
   };
   libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
  -			    80 + sizeof(struct u64_stats_sync),
  +			    96 + sizeof(struct u64_stats_sync),
   			    32);

   /**

  ################################################################################
  !    REJECTED PATCH2 HUNKS - could not be compared; manual review needed       !
  ################################################################################

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -1602,87 +1462,6 @@
   	spin_unlock_bh(&tx_tstamp_caps->status_lock);
   }

  -/**
  - * idpf_tx_clean_stashed_bufs - clean bufs that were stored for
  - * out of order completions
  - * @txq: queue to clean
  - * @compl_tag: completion tag of packet to clean (from completion descriptor)
  - * @cleaned: pointer to stats struct to track cleaned packets/bytes
  - * @budget: Used to determine if we are in netpoll
  - */
  -static void idpf_tx_clean_stashed_bufs(struct idpf_tx_queue *txq,
  -				       u16 compl_tag,
  -				       struct libeth_sq_napi_stats *cleaned,
  -				       int budget)
  -{
  -	struct idpf_tx_stash *stash;
  -	struct hlist_node *tmp_buf;
  -	struct libeth_cq_pp cp = {
  -		.dev	= txq->dev,
  -		.ss	= cleaned,
  -		.napi	= budget,
  -	};
  -
  -	/* Buffer completion */
  -	hash_for_each_possible_safe(txq->stash->sched_buf_hash, stash, tmp_buf,
  -				    hlist, compl_tag) {
  -		if (unlikely(idpf_tx_buf_compl_tag(&stash->buf) != compl_tag))
  -			continue;
  -
  -		hash_del(&stash->hlist);
  -
  -		if (stash->buf.type == LIBETH_SQE_SKB &&
  -		    (skb_shinfo(stash->buf.skb)->tx_flags & SKBTX_IN_PROGRESS))
  -			idpf_tx_read_tsta044a3252be96mp(txq, stash->buf.skb);
  -
  -		libeth_tx_complete(&stash->buf, &cp);
  -
  -		/* Push shadow buf back onto stack */
  -		idpf_buf_lifo_push(&txq->stash->buf_stack, stash);
  -	}
  -}
  -
  -/**
  - * idpf_stash_flow_sch_buffers - store buffer parameters info to be freed at a
  - * later time (only relevant for flow scheduling mode)
  - * @txq: Tx queue to clean
  - * @tx_buf: buffer to store
  - */
  -static int idpf_stash_flow_sch_buffers(struct idpf_tx_queue *txq,
  -				       struct idpf_tx_buf *tx_buf)
  -{
  -	struct idpf_tx_stash *stash;
  -
  -	if (unlikely(tx_buf->type <= LIBETH_SQE_CTX))
  -		return 0;
  -
  -	stash = idpf_buf_lifo_pop(&txq->stash->buf_stack);
  -	if (unlikely(!stash)) {
  -		net_err_ratelimited("%s: No out-of-order TX buffers left!\n",
  -				    netdev_name(txq->netdev));
  -
  -		return -ENOMEM;
  -	}
  -
  -	/* Store buffer params in shadow buffer */
  -	stash->buf.skb = tx_buf->skb;
  -	stash->buf.bytes = tx_buf->bytes;
  -	stash->buf.packets = tx_buf->packets;
  -	stash->buf.type = tx_buf->type;
  -	stash->buf.nr_frags = tx_buf->nr_frags;
  -	dma_unmap_addr_set(&stash->buf, dma, dma_unmap_addr(tx_buf, dma));
  -	dma_unmap_len_set(&stash->buf, len, dma_unmap_len(tx_buf, len));
  -	idpf_tx_buf_compl_tag(&stash->buf) = idpf_tx_buf_compl_tag(tx_buf);
  -
  -	/* Add buffer to buf_hash table to be freed later */
  -	hash_add(txq->stash->sched_buf_hash, &stash->hlist,
  -		 idpf_tx_buf_compl_tag(&stash->buf));
  -
  -	tx_buf->type = LIBETH_SQE_EMPTY;
  -
  -	return 0;
  -}
  -
   #define idpf_tx_splitq_clean_bump_ntc(txq, ntc, desc, buf)	\
   do {								\
   	if (unlikely(++(ntc) == (txq)->desc_count)) {		\
  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  @@ -599,9 +565,6 @@
    * @cleaned_pkts: Number of packets cleaned for the above said case
    * @stash: Tx buffer stash for Flow-based scheduling mode
    * @refillq: Pointer to refill queue
  - * @compl_tag_bufid_m: Completion tag buffer id mask
  - * @compl_tag_cur_gen: Used to keep track of current completion tag generation
  - * @compl_tag_gen_max: To determine when compl_tag_cur_gen should be reset
    * @cached_tstamp_caps: Tx timestamp capabilities negotiated with the CP
    * @tstamp_task: Work that handles Tx timestamp read
    * @stats_sync: See struct u64_stats_sync
  @@ -650,10 +611,6 @@
   	struct idpf_txq_stash *stash;
   	struct idpf_sw_queue *refillq;

  -	u16 compl_tag_bufid_m;
  -	u16 compl_tag_cur_gen;
  -	u16 compl_tag_gen_max;
  -
   	struct idpf_ptp_vport_tx_tstamp_caps *cached_tstamp_caps;
   	struct work_struct *tstamp_task;

  @@ -671,7 +628,7 @@
   	__cacheline_group_end_aligned(cold);
   };
   libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
  -			    120 + sizeof(struct u64_stats_sync),
  +			    104 + sizeof(struct u64_stats_sync),
   			    32);

   /**

  ================================================================================
  *    CONTEXT DIFFERENCES - surrounding code differences between the patches    *
  ================================================================================

  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.c
  @@ -4,4 +4,4 @@
  -#include "idpf.h"
  +#include "idpf_ptp.h"
   #include "idpf_virtchnl.h"

   struct idpf_tx_stash {
  @@ -1727,6 +1770,11 @@
   			continue;

   		hash_del(&stash->hlist);
  +
  +		if (stash->buf.type == LIBETH_SQE_SKB &&
  +		    (skb_shinfo(stash->buf.skb)->tx_flags & SKBTX_IN_PROGRESS))
  +			idpf_tx_read_tstamp(txq, stash->buf.skb);
  +
   		libeth_tx_complete(&stash->buf, &cp);

   		/* Push shadow buf back onto stack */
  --- b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  +++ b/drivers/net/ethernet/intel/idpf/idpf_txrx.h
  @@ -632,2 +638,4 @@
    * @compl_tag_gen_max: To determine when compl_tag_cur_gen should be reset
  + * @cached_tstamp_caps: Tx timestamp capabilities negotiated with the CP
  + * @tstamp_task: Work that handles Tx timestamp read
    * @stats_sync: See struct u64_stats_sync
  @@ -682,6 +690,6 @@
   	u16 compl_tag_cur_gen;
   	u16 compl_tag_gen_max;

  -	struct u64_stats_sync stats_sync;
  -	struct idpf_tx_queue_stats q_stats;
  -	__cacheline_group_end_aligned(read_write);
  +	struct idpf_ptp_vport_tx_tstamp_caps *cached_tstamp_caps;
  +	struct work_struct *tstamp_task;
  +
  @@ -696,7 +707,7 @@
   	__cacheline_group_end_aligned(cold);
   };
   libeth_cacheline_set_assert(struct idpf_tx_queue, 64,
  -			    96 + sizeof(struct u64_stats_sync),
  +			    120 + sizeof(struct u64_stats_sync),
   			    32);

   /**
```
Not sure why it complains so much here.
[044a3252be96_colordiff.log](https://github.com/user-attachments/files/25547587/044a3252be96_colordiff.log)
<img width="1714" height="279" alt="Screenshot From 2026-02-25 14-55-16" src="https://github.com/user-attachments/assets/928266ff-f074-4cc8-842c-ad766c59628b" />

The only relevant change is this as explained in the commit message. 