### PR TITLE
[LTS 8.6] CVE-2024-58002, CVE-2025-40248, CVE-2022-48786, CVE-2025-22026

### DIFF
--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1557,7 +1557,7 @@ static int uvc_ctrl_find_ctrl_idx(struct uvc_entity *entity,
 				  struct uvc_control *uvc_control)
 {
 	struct uvc_control_mapping *mapping = NULL;
-	struct uvc_control *ctrl_found;
+	struct uvc_control *ctrl_found = NULL;
 	unsigned int i;
 
 	if (!entity)

--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1556,7 +1556,7 @@ static int uvc_ctrl_find_ctrl_idx(struct uvc_entity *entity,
 				  struct v4l2_ext_controls *ctrls,
 				  struct uvc_control *uvc_control)
 {
-	struct uvc_control_mapping *mapping;
+	struct uvc_control_mapping *mapping = NULL;
 	struct uvc_control *ctrl_found;
 	unsigned int i;
 

--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1500,7 +1500,7 @@ int uvc_ctrl_begin(struct uvc_video_chain *chain)
 }
 
 static int uvc_ctrl_commit_entity(struct uvc_device *dev,
-	struct uvc_entity *entity, int rollback)
+	struct uvc_entity *entity, int rollback, struct uvc_control **err_ctrl)
 {
 	struct uvc_control *ctrl;
 	unsigned int i;
@@ -1542,31 +1542,59 @@ static int uvc_ctrl_commit_entity(struct uvc_device *dev,
 
 		ctrl->dirty = 0;
 
-		if (ret < 0)
+		if (ret < 0) {
+			if (err_ctrl)
+				*err_ctrl = ctrl;
 			return ret;
+		}
 	}
 
 	return 0;
 }
 
+static int uvc_ctrl_find_ctrl_idx(struct uvc_entity *entity,
+				  struct v4l2_ext_controls *ctrls,
+				  struct uvc_control *uvc_control)
+{
+	struct uvc_control_mapping *mapping;
+	struct uvc_control *ctrl_found;
+	unsigned int i;
+
+	if (!entity)
+		return ctrls->count;
+
+	for (i = 0; i < ctrls->count; i++) {
+		__uvc_find_control(entity, ctrls->controls[i].id, &mapping,
+				   &ctrl_found, 0);
+		if (uvc_control == ctrl_found)
+			return i;
+	}
+
+	return ctrls->count;
+}
+
 int __uvc_ctrl_commit(struct uvc_fh *handle, int rollback,
-		      const struct v4l2_ext_control *xctrls,
-		      unsigned int xctrls_count)
+		      struct v4l2_ext_controls *ctrls)
 {
 	struct uvc_video_chain *chain = handle->chain;
+	struct uvc_control *err_ctrl;
 	struct uvc_entity *entity;
 	int ret = 0;
 
 	/* Find the control. */
 	list_for_each_entry(entity, &chain->entities, chain) {
-		ret = uvc_ctrl_commit_entity(chain->dev, entity, rollback);
+		ret = uvc_ctrl_commit_entity(chain->dev, entity, rollback,
+					     &err_ctrl);
 		if (ret < 0)
 			goto done;
 	}
 
 	if (!rollback)
-		uvc_ctrl_send_events(handle, xctrls, xctrls_count);
+		uvc_ctrl_send_events(handle, ctrls->controls, ctrls->count);
 done:
+	if (ret < 0 && ctrls)
+		ctrls->error_idx = uvc_ctrl_find_ctrl_idx(entity, ctrls,
+							  err_ctrl);
 	mutex_unlock(&chain->ctrl_mutex);
 	return ret;
 }
@@ -2018,7 +2046,7 @@ int uvc_ctrl_restore_values(struct uvc_device *dev)
 			ctrl->dirty = 1;
 		}
 
-		ret = uvc_ctrl_commit_entity(dev, entity, 0);
+		ret = uvc_ctrl_commit_entity(dev, entity, 0, NULL);
 		if (ret < 0)
 			return ret;
 	}

--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1282,6 +1282,40 @@ static void uvc_ctrl_send_slave_event(struct uvc_video_chain *chain,
 	uvc_ctrl_send_event(chain, handle, ctrl, mapping, val, changes);
 }
 
+static void uvc_ctrl_set_handle(struct uvc_fh *handle, struct uvc_control *ctrl,
+				struct uvc_fh *new_handle)
+{
+	lockdep_assert_held(&handle->chain->ctrl_mutex);
+
+	if (new_handle) {
+		if (ctrl->handle)
+			dev_warn_ratelimited(&handle->stream->dev->udev->dev,
+					     "UVC non compliance: Setting an async control with a pending operation.");
+
+		if (new_handle == ctrl->handle)
+			return;
+
+		if (ctrl->handle) {
+			WARN_ON(!ctrl->handle->pending_async_ctrls);
+			if (ctrl->handle->pending_async_ctrls)
+				ctrl->handle->pending_async_ctrls--;
+		}
+
+		ctrl->handle = new_handle;
+		handle->pending_async_ctrls++;
+		return;
+	}
+
+	/* Cannot clear the handle for a control not owned by us.*/
+	if (WARN_ON(ctrl->handle != handle))
+		return;
+
+	ctrl->handle = NULL;
+	if (WARN_ON(!handle->pending_async_ctrls))
+		return;
+	handle->pending_async_ctrls--;
+}
+
 void uvc_ctrl_status_event(struct uvc_video_chain *chain,
 			   struct uvc_control *ctrl, const u8 *data)
 {
@@ -1292,7 +1326,8 @@ void uvc_ctrl_status_event(struct uvc_video_chain *chain,
 	mutex_lock(&chain->ctrl_mutex);
 
 	handle = ctrl->handle;
-	ctrl->handle = NULL;
+	if (handle)
+		uvc_ctrl_set_handle(handle, ctrl, NULL);
 
 	list_for_each_entry(mapping, &ctrl->info.mappings, list) {
 		s32 value = __uvc_ctrl_get_value(mapping, data);
@@ -1553,7 +1588,7 @@ static int uvc_ctrl_commit_entity(struct uvc_device *dev,
 
 		if (!rollback && handle &&
 		    ctrl->info.flags & UVC_CTRL_FLAG_ASYNCHRONOUS)
-			ctrl->handle = handle;
+			uvc_ctrl_set_handle(handle, ctrl, handle);
 	}
 
 	return 0;
@@ -2378,6 +2413,30 @@ int uvc_ctrl_init_device(struct uvc_device *dev)
 	}
 
 	return 0;
+}
+
+void uvc_ctrl_cleanup_fh(struct uvc_fh *handle)
+{
+	struct uvc_entity *entity;
+
+	mutex_lock(&handle->chain->ctrl_mutex);
+
+	if (!handle->pending_async_ctrls) {
+		mutex_unlock(&handle->chain->ctrl_mutex);
+		return;
+	}
+
+	list_for_each_entry(entity, &handle->chain->dev->entities, list) {
+		unsigned int i;
+		for (i = 0; i < entity->ncontrols; ++i) {
+			if (entity->controls[i].handle != handle)
+				continue;
+			uvc_ctrl_set_handle(handle, &entity->controls[i], NULL);
+		}
+	}
+
+	WARN_ON(handle->pending_async_ctrls);
+	mutex_unlock(&handle->chain->ctrl_mutex);
 }
 
 /*

--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1585,16 +1585,18 @@ int __uvc_ctrl_commit(struct uvc_fh *handle, int rollback,
 	list_for_each_entry(entity, &chain->entities, chain) {
 		ret = uvc_ctrl_commit_entity(chain->dev, entity, rollback,
 					     &err_ctrl);
-		if (ret < 0)
+		if (ret < 0) {
+			if (ctrls)
+				ctrls->error_idx =
+					uvc_ctrl_find_ctrl_idx(entity, ctrls,
+							       err_ctrl);
 			goto done;
+		}
 	}
 
 	if (!rollback)
 		uvc_ctrl_send_events(handle, ctrls->controls, ctrls->count);
 done:
-	if (ret < 0 && ctrls)
-		ctrls->error_idx = uvc_ctrl_find_ctrl_idx(entity, ctrls,
-							  err_ctrl);
 	mutex_unlock(&chain->ctrl_mutex);
 	return ret;
 }
@@ -1890,7 +1892,7 @@ static int uvc_ctrl_init_xu_ctrl(struct uvc_device *dev,
 int uvc_xu_ctrl_query(struct uvc_video_chain *chain,
 	struct uvc_xu_control_query *xqry)
 {
-	struct uvc_entity *entity;
+	struct uvc_entity *entity, *iter;
 	struct uvc_control *ctrl;
 	unsigned int i;
 	bool found;
@@ -1900,16 +1902,16 @@ int uvc_xu_ctrl_query(struct uvc_video_chain *chain,
 	int ret;
 
 	/* Find the extension unit. */
-	found = false;
-	list_for_each_entry(entity, &chain->entities, chain) {
-		if (UVC_ENTITY_TYPE(entity) == UVC_VC_EXTENSION_UNIT &&
-		    entity->id == xqry->unit) {
-			found = true;
+	entity = NULL;
+	list_for_each_entry(iter, &chain->entities, chain) {
+		if (UVC_ENTITY_TYPE(iter) == UVC_VC_EXTENSION_UNIT &&
+		    iter->id == xqry->unit) {
+			entity = iter;
 			break;
 		}
 	}
 
-	if (!found) {
+	if (!entity) {
 		uvc_dbg(chain->dev, CONTROL, "Extension unit %u not found\n",
 			xqry->unit);
 		return -ENOENT;

--- a/drivers/media/usb/uvc/uvc_ctrl.c
+++ b/drivers/media/usb/uvc/uvc_ctrl.c
@@ -1500,7 +1500,10 @@ int uvc_ctrl_begin(struct uvc_video_chain *chain)
 }
 
 static int uvc_ctrl_commit_entity(struct uvc_device *dev,
-	struct uvc_entity *entity, int rollback, struct uvc_control **err_ctrl)
+				  struct uvc_fh *handle,
+				  struct uvc_entity *entity,
+				  int rollback,
+				  struct uvc_control **err_ctrl)
 {
 	struct uvc_control *ctrl;
 	unsigned int i;
@@ -1547,6 +1550,10 @@ static int uvc_ctrl_commit_entity(struct uvc_device *dev,
 				*err_ctrl = ctrl;
 			return ret;
 		}
+
+		if (!rollback && handle &&
+		    ctrl->info.flags & UVC_CTRL_FLAG_ASYNCHRONOUS)
+			ctrl->handle = handle;
 	}
 
 	return 0;
@@ -1583,8 +1590,8 @@ int __uvc_ctrl_commit(struct uvc_fh *handle, int rollback,
 
 	/* Find the control. */
 	list_for_each_entry(entity, &chain->entities, chain) {
-		ret = uvc_ctrl_commit_entity(chain->dev, entity, rollback,
-					     &err_ctrl);
+		ret = uvc_ctrl_commit_entity(chain->dev, handle, entity,
+					     rollback, &err_ctrl);
 		if (ret < 0) {
 			if (ctrls)
 				ctrls->error_idx =
@@ -1723,9 +1730,6 @@ int uvc_ctrl_set(struct uvc_fh *handle,
 
 	mapping->set(mapping, value,
 		uvc_ctrl_data(ctrl, UVC_CTRL_DATA_CURRENT));
-
-	if (ctrl->info.flags & UVC_CTRL_FLAG_ASYNCHRONOUS)
-		ctrl->handle = handle;
 
 	ctrl->dirty = 1;
 	ctrl->modified = 1;
@@ -2048,7 +2052,7 @@ int uvc_ctrl_restore_values(struct uvc_device *dev)
 			ctrl->dirty = 1;
 		}
 
-		ret = uvc_ctrl_commit_entity(dev, entity, 0, NULL);
+		ret = uvc_ctrl_commit_entity(dev, NULL, entity, 0, NULL);
 		if (ret < 0)
 			return ret;
 	}

--- a/drivers/media/usb/uvc/uvc_v4l2.c
+++ b/drivers/media/usb/uvc/uvc_v4l2.c
@@ -1024,6 +1024,7 @@ static int uvc_ioctl_s_ctrl(struct file *file, void *fh,
 	struct uvc_fh *handle = fh;
 	struct uvc_video_chain *chain = handle->chain;
 	struct v4l2_ext_control xctrl;
+	struct v4l2_ext_controls xctrls;
 	int ret;
 
 	memset(&xctrl, 0, sizeof(xctrl));
@@ -1040,7 +1041,9 @@ static int uvc_ioctl_s_ctrl(struct file *file, void *fh,
 		return ret;
 	}
 
-	ret = uvc_ctrl_commit(handle, &xctrl, 1);
+	xctrls.controls = &xctrl;
+	xctrls.count = 1;
+	ret = uvc_ctrl_commit(handle, &xctrls);
 	if (ret < 0)
 		return ret;
 
@@ -1120,7 +1123,7 @@ static int uvc_ioctl_s_try_ext_ctrls(struct uvc_fh *handle,
 	ctrls->error_idx = 0;
 
 	if (commit)
-		return uvc_ctrl_commit(handle, ctrls->controls, ctrls->count);
+		return uvc_ctrl_commit(handle, ctrls);
 	else
 		return uvc_ctrl_rollback(handle);
 }

--- a/drivers/media/usb/uvc/uvc_v4l2.c
+++ b/drivers/media/usb/uvc/uvc_v4l2.c
@@ -591,6 +591,8 @@ static int uvc_v4l2_release(struct file *file)
 
 	uvc_dbg(stream->dev, CALLS, "%s\n", __func__);
 
+	uvc_ctrl_cleanup_fh(handle);
+
 	/* Only free resources if this is a privileged handle. */
 	if (uvc_has_privileges(handle))
 		uvc_queue_release(&stream->queue);

--- a/drivers/media/usb/uvc/uvcvideo.h
+++ b/drivers/media/usb/uvc/uvcvideo.h
@@ -471,7 +471,11 @@ struct uvc_video_chain {
 	struct uvc_entity *processing;		/* Processing unit */
 	struct uvc_entity *selector;		/* Selector unit */
 
-	struct mutex ctrl_mutex;		/* Protects ctrl.info */
+	struct mutex ctrl_mutex;		/*
+						 * Protects ctrl.info,
+						 * ctrl.handle and
+						 * uvc_fh.pending_async_ctrls
+						 */
 
 	struct v4l2_prio_state prio;		/* V4L2 priority state */
 	u32 caps;				/* V4L2 chain-wide caps */
@@ -721,6 +725,7 @@ struct uvc_fh {
 	struct uvc_video_chain *chain;
 	struct uvc_streaming *stream;
 	enum uvc_handle_state state;
+	unsigned int pending_async_ctrls;
 };
 
 struct uvc_driver {
@@ -899,6 +904,8 @@ int uvc_ctrl_set(struct uvc_fh *handle, struct v4l2_ext_control *xctrl);
 
 int uvc_xu_ctrl_query(struct uvc_video_chain *chain,
 		      struct uvc_xu_control_query *xqry);
+
+void uvc_ctrl_cleanup_fh(struct uvc_fh *handle);
 
 /* Utility functions */
 void uvc_simplify_fraction(u32 *numerator, u32 *denominator,

--- a/drivers/media/usb/uvc/uvcvideo.h
+++ b/drivers/media/usb/uvc/uvcvideo.h
@@ -883,17 +883,15 @@ void uvc_ctrl_status_event(struct uvc_video_chain *chain,
 
 int uvc_ctrl_begin(struct uvc_video_chain *chain);
 int __uvc_ctrl_commit(struct uvc_fh *handle, int rollback,
-		      const struct v4l2_ext_control *xctrls,
-		      unsigned int xctrls_count);
+		      struct v4l2_ext_controls *ctrls);
 static inline int uvc_ctrl_commit(struct uvc_fh *handle,
-				  const struct v4l2_ext_control *xctrls,
-				  unsigned int xctrls_count)
+				  struct v4l2_ext_controls *ctrls)
 {
-	return __uvc_ctrl_commit(handle, 0, xctrls, xctrls_count);
+	return __uvc_ctrl_commit(handle, 0, ctrls);
 }
 static inline int uvc_ctrl_rollback(struct uvc_fh *handle)
 {
-	return __uvc_ctrl_commit(handle, 1, NULL, 0);
+	return __uvc_ctrl_commit(handle, 1, NULL);
 }
 
 int uvc_ctrl_get(struct uvc_video_chain *chain, struct v4l2_ext_control *xctrl);

--- a/fs/nfsd/nfsctl.c
+++ b/fs/nfsd/nfsctl.c
@@ -1524,7 +1524,10 @@ static int __init init_nfsd(void)
 	retval = nfsd4_init_pnfs();
 	if (retval)
 		goto out_free_slabs;
-	nfsd_stat_init();	/* Statistics */
+	if (!nfsd_stat_init()) {	/* Statistics */
+		retval = -ENOMEM;
+		goto out_free_pnfs;
+	}
 	retval = nfsd_drc_slab_create();
 	if (retval)
 		goto out_free_stat;
@@ -1549,6 +1552,7 @@ out_free_lockd:
 	nfsd_drc_slab_free();
 out_free_stat:
 	nfsd_stat_shutdown();
+out_free_pnfs:
 	nfsd4_exit_pnfs();
 out_free_slabs:
 	nfsd4_free_slabs();

--- a/fs/nfsd/stats.c
+++ b/fs/nfsd/stats.c
@@ -91,10 +91,10 @@ static const struct file_operations nfsd_proc_fops = {
 	.release = single_release,
 };
 
-void
+struct proc_dir_entry *
 nfsd_stat_init(void)
 {
-	svc_proc_register(&init_net, &nfsd_svcstats, &nfsd_proc_fops);
+	return svc_proc_register(&init_net, &nfsd_svcstats, &nfsd_proc_fops);
 }
 
 void

--- a/fs/nfsd/stats.h
+++ b/fs/nfsd/stats.h
@@ -38,7 +38,7 @@ struct nfsd_stats {
 extern struct nfsd_stats	nfsdstats;
 extern struct svc_stat		nfsd_svcstats;
 
-void	nfsd_stat_init(void);
+struct proc_dir_entry *	nfsd_stat_init(void);
 void	nfsd_stat_shutdown(void);
 
 #endif /* _NFSD_STATS_H */

--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -1408,18 +1408,40 @@ static int vsock_stream_connect(struct socket *sock, struct sockaddr *addr,
 		timeout = schedule_timeout(timeout);
 		lock_sock(sk);
 
-		if (signal_pending(current)) {
-			err = sock_intr_errno(timeout);
-			sk->sk_state = sk->sk_state == TCP_ESTABLISHED ? TCP_CLOSING : TCP_CLOSE;
-			sock->state = SS_UNCONNECTED;
-			vsock_transport_cancel_pkt(vsk);
-			vsock_remove_connected(vsk);
-			goto out_wait;
-		} else if ((sk->sk_state != TCP_ESTABLISHED) && (timeout == 0)) {
-			err = -ETIMEDOUT;
+		/* Connection established. Whatever happens to socket once we
+		 * release it, that's not connect()'s concern. No need to go
+		 * into signal and timeout handling. Call it a day.
+		 *
+		 * Note that allowing to "reset" an already established socket
+		 * here is racy and insecure.
+		 */
+		if (sk->sk_state == TCP_ESTABLISHED)
+			break;
+
+		/* If connection was _not_ established and a signal/timeout came
+		 * to be, we want the socket's state reset. User space may want
+		 * to retry.
+		 *
+		 * sk_state != TCP_ESTABLISHED implies that socket is not on
+		 * vsock_connected_table. We keep the binding and the transport
+		 * assigned.
+		 */
+		if (signal_pending(current) || timeout == 0) {
+			err = timeout == 0 ? -ETIMEDOUT : sock_intr_errno(timeout);
+
+			/* Listener might have already responded with
+			 * VIRTIO_VSOCK_OP_RESPONSE. Its handling expects our
+			 * sk_state == TCP_SYN_SENT, which hereby we break.
+			 * In such case VIRTIO_VSOCK_OP_RST will follow.
+			 */
 			sk->sk_state = TCP_CLOSE;
 			sock->state = SS_UNCONNECTED;
+
+			/* Try to cancel VIRTIO_VSOCK_OP_REQUEST skb sent out by
+			 * transport->connect().
+			 */
 			vsock_transport_cancel_pkt(vsk);
+
 			goto out_wait;
 		}
 

--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -1413,6 +1413,7 @@ static int vsock_stream_connect(struct socket *sock, struct sockaddr *addr,
 			sk->sk_state = sk->sk_state == TCP_ESTABLISHED ? TCP_CLOSING : TCP_CLOSE;
 			sock->state = SS_UNCONNECTED;
 			vsock_transport_cancel_pkt(vsk);
+			vsock_remove_connected(vsk);
 			goto out_wait;
 		} else if (timeout == 0) {
 			err = -ETIMEDOUT;

--- a/net/vmw_vsock/af_vsock.c
+++ b/net/vmw_vsock/af_vsock.c
@@ -1415,7 +1415,7 @@ static int vsock_stream_connect(struct socket *sock, struct sockaddr *addr,
 			vsock_transport_cancel_pkt(vsk);
 			vsock_remove_connected(vsk);
 			goto out_wait;
-		} else if (timeout == 0) {
+		} else if ((sk->sk_state != TCP_ESTABLISHED) && (timeout == 0)) {
 			err = -ETIMEDOUT;
 			sk->sk_state = TCP_CLOSE;
 			sock->state = SS_UNCONNECTED;


### PR DESCRIPTION
[LTS 8.6]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2024-58002</td>
<td class="org-left">VULN-53459</td>
</tr>


<tr>
<td class="org-left">CVE-2025-40248</td>
<td class="org-left">VULN-160776</td>
</tr>


<tr>
<td class="org-left">CVE-2022-48786</td>
<td class="org-left">VULN-32672</td>
</tr>


<tr>
<td class="org-left">CVE-2025-22026</td>
<td class="org-left">VULN-64890</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2024-58002

    media: uvcvideo: Set error_idx during ctrl_commit errors
    
    jira VULN-53459
    cve-pre CVE-2024-58002
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit 6350d6a4ed487d16a3a021f76a7edcb9cb60fdbf
    upstream-diff |
      - Modified the `uvc_ioctl_s_ctrl()' function body to align with the new
        signature of `uvc_ctrl_commit()' it is using. A throwaway object
        `xctrls' is created on stack to encapsulate `xctrl' formerly passed to
        `uvc_ctrl_commit()' directly. This adaptation was missing from the
        backported commit, because at the moment of its introduction the
        `uvc_ioctl_s_ctrl()' function was no longer present, removed in
        0c6bcbdfefa83b8a1e9659b3c127758dce0fe7ac ("media: uvcvideo: Remove
        s_ctrl and g_ctrl"), which was not backported to LTS 8.6.
      - Solved the context conflict stemming from the missing
        ee929d5a10ca433a1c21b9aaeb70a67c5507c101

>

    media: uvcvideo: Avoid invalid memory access
    
    jira VULN-53459
    cve-pre CVE-2024-58002
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit f0577b1b6394f954903fcc67e12fe9e7001dafd6

>

    media: uvcvideo: Avoid returning invalid controls
    
    jira VULN-53459
    cve-pre CVE-2024-58002
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit 414d3b49d9fd4a0bb16a13d929027847fd094f3f

> 

    media: uvcvideo: Refactor iterators
    
    jira VULN-53459
    cve-pre CVE-2024-58002
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit 64627daf0c5f7838111f52bbbd1a597cb5d6871a

>

    media: uvcvideo: Only save async fh if success
    
    jira VULN-53459
    cve-pre CVE-2024-58002
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit d9fecd096f67a4469536e040a8a10bbfb665918b

> 

    media: uvcvideo: Remove dangling pointers
    
    jira VULN-53459
    cve CVE-2024-58002
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit 221cd51efe4565501a3dbf04cc011b537dcce7fb
    upstream-diff Used linux-5.15.y backport
      117f7a2975baa4b7d702d3f4830d5a4ebd0c6d50 as the base because of the
      missing backport of 54da6a0924311c7cf5015533991e44fb8eb12773 which
      changed the locking scheme used in the upstream version. Resolved
      context conflicts around the `uvc_ctrl_cleanup_fh()' function

This solution is similar to the one in 

-   LTS 9.2 (2118d6ffbf6974953576beb38a106e4dbdd2d53e, 82f93b782b8b9151ab22814f2b3b9ae93df82d4f, 0d11dcfbf312ef482c9069d663a6a3acb7c36bb7),
-   LTS 9.4 (d070b4fdca5d8f75a1911b0273dd65177f4b9387, 470288b9c5d064293ecdd4e796fe6d7b49f604ec, a12f9cb963ea16737d1f199a549933455efa97fa),
-   FIPS 9 Compliant (f0a1015e6afcf66dbc32f5fe2c93e355b628a96f, 024b947c540a1df99a220ad0d78c85dc166c9a7e, 28bd6c4781bcd576d512b9215ce58c076799946c) and
-   FIPS 8 Compliant (181b6df858ac1bfad5b506125394d470d17cdd4c, 204f2126c1ca7e0ec11847fa5f31a7a28a50e658, f51d42ab35ac0d027840b2e35dc47981041218c3).

The difference is the first prerequisite `media: uvcvideo: Set error_idx during ctrl_commit errors` which all those versions were lucky to have backported already. It required some manual stitching in the `uvc_ioctl_s_ctrl()` function. Backporting 0c6bcbdfefa83b8a1e9659b3c127758dce0fe7ac was considered, which would avoid the problem of modifying `uvc_ioctl_s_ctrl()`, but it was not clear whether the basis for this commit holds true for LTS 8.6 (from the commit's message):

> If we do not implement these callbacks the framework will call the
> ext\_ctrl callbaks instead, which are a superset of this functions.

Adapting `uvc_ioctl_s_ctrl()` to the 6350d6a4ed487d16a3a021f76a7edcb9cb60fdbf change was easier, faster and less risky than establishing how the framework works in LTS 8.6.

The following two commits 

-   `media: uvcvideo: Avoid invalid memory access`,
-   `media: uvcvideo: Avoid returning invalid controls`

are not really prerequisites, but the bugfixes for the `media: uvcvideo: Set error_idx during ctrl_commit errors` prerequisite.


## CVE-2025-40248 (+ CVE-2022-48786)

    vsock: remove vsock from connected table when connect is interrupted by a signal
    
    jira VULN-32672
    cve CVE-2022-48786
    commit-author Seth Forshee <sforshee@digitalocean.com>
    commit b9208492fcaecff8f43915529ae34b3bcb03877c

>

    vsock: avoid to close connected socket after the timeout
    
    jira VULN-160776
    cve-pre CVE-2025-40248
    commit-author Zhuang Shengen <zhuangshengen@huawei.com>
    commit 6d4486efe9c69626cab423456169e250a5cd3af5o

>

    vsock: Ignore signal/timeout on connect() if already established
    
    jira VULN-160776
    cve CVE-2025-40248
    commit-author Michal Luczaj <mhal@rbox.co>
    commit 002541ef650b742a198e4be363881439bb9d86b4

The `vsock: remove vsock from connected table when connect is interrupted by a signal` commit was used as prerequisite for CVE-2025-40248, but it had its own CVE.


## CVE-2025-22026

    nfsd: don't ignore the return code of svc_proc_register()
    
    jira VULN-64890
    cve CVE-2025-22026
    commit-author Jeff Layton <jlayton@kernel.org>
    commit 930b64ca0c511521f0abdd1d57ce52b2a6e3476b
    upstream-diff Ignored cherry-pick of the upstrem fix - the LTS 8.6 nfsd
      codebase was too distinct from the upstream for auto merging to be
      useful in any way. Backported checking of the `svc_proc_register()' exit
      code manually:
      fs/nfsd/stats.c
            Modified function `nfsd_stat_init()' instead of
            `nfsd_proc_stat_init()' because it was renamed in the
            non-backported commit 93483ac5fec62cc1de166051b219d953bb5e4ef4.
      fs/nfsd/stats.h
            Like above
      fs/nfsd/nfsctl.c
            - Modified `init_nfsd()' where `nfsd_stat_init()' is actually used
              in LTS 8.6 instead of `nfsd_net_init()', where this function
              call (named `nfsd_proc_stat_init()' at that time) was moved in
              the non-backported commit
              93483ac5fec62cc1de166051b219d953bb5e4ef4.
            - Ignored the `percpu_counter_destroy_many()' cleanup not
              applicable to the `init_nfsd()' function. Included in the exit
              path instead the `nfsd4_exit_pnfs()' call with the use of newly
              introduced label `out_free_pnfs'.


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts8_6-CVE-batch-25]	_kabi_check_kernel__x86_64--test--ciqlts8_6-CVE-batch-25
    + dist_git_version=el-8.6
    + local_version=ciqlts8_6-CVE-batch-25
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts8_6
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-8.6
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-batch-25
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-8.6/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts8_6 ''\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-batch-25/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-batch-25/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/26145396/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/26145397/kselftests--ciqlts8_6--run1.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-batch-25&#x2013;run1.log](<https://github.com/user-attachments/files/26145405/kselftests--ciqlts8_6-CVE-batch-25--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-batch-25&#x2013;run2.log](<https://github.com/user-attachments/files/26145406/kselftests--ciqlts8_6-CVE-batch-25--run2.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-batch-25&#x2013;run3.log](<https://github.com/user-attachments/files/26145407/kselftests--ciqlts8_6-CVE-batch-25--run3.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff  kselftests*.log

    Column    File
    --------  --------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6-CVE-batch-25--run1.log
    Status2   kselftests--ciqlts8_6-CVE-batch-25--run2.log
    Status3   kselftests--ciqlts8_6-CVE-batch-25--run3.log
    
    TestCase                                     Status0  Status1  Status2  Status3  Summary
    android:run.sh                               skip     skip     skip     skip     same
    bpf:get_cgroup_id_user                       pass     pass     pass     pass     same
    bpf:test_bpftool.sh                          pass     pass     pass     pass     same
    bpf:test_bpftool_build.sh                    pass     pass     pass     pass     same
    bpf:test_bpftool_metadata.sh                 pass     pass     pass     pass     same
    bpf:test_cgroup_storage                      pass     pass     pass     pass     same
    bpf:test_dev_cgroup                          pass     pass     pass     pass     same
    bpf:test_doc_build.sh                        pass     pass     pass     pass     same
    bpf:test_flow_dissector.sh                   pass     pass     pass     pass     same
    bpf:test_lirc_mode2.sh                       pass     pass     pass     pass     same
    bpf:test_lpm_map                             pass     pass     pass     pass     same
    bpf:test_lru_map                             pass     pass     pass     pass     same
    bpf:test_lwt_ip_encap.sh                     pass     pass     pass     pass     same
    bpf:test_lwt_seg6local.sh                    pass     pass     pass     pass     same
    bpf:test_netcnt                              pass     pass     pass     pass     same
    bpf:test_offload.py                          fail     fail     fail     fail     same
    bpf:test_skb_cgroup_id.sh                    pass     pass     pass     pass     same
    bpf:test_sock                                pass     pass     pass     pass     same
    bpf:test_sock_addr.sh                        pass     pass     pass     pass     same
    bpf:test_sysctl                              pass     pass     pass     pass     same
    bpf:test_tag                                 pass     pass     pass     pass     same
    bpf:test_tc_edt.sh                           pass     pass     pass     pass     same
    bpf:test_tc_tunnel.sh                        pass     pass     pass     pass     same
    bpf:test_tcp_check_syncookie.sh              pass     pass     pass     pass     same
    bpf:test_tcpnotify_user                      pass     pass     pass     pass     same
    bpf:test_tunnel.sh                           pass     pass     pass     pass     same
    bpf:test_verifier                            pass     pass     pass     pass     same
    bpf:test_verifier_log                        pass     pass     pass     pass     same
    bpf:test_xdp_meta.sh                         pass     pass     pass     pass     same
    bpf:test_xdp_redirect.sh                     pass     pass     pass     pass     same
    bpf:test_xdp_veth.sh                         pass     pass     pass     pass     same
    bpf:test_xdp_vlan_mode_generic.sh            pass     pass     pass     pass     same
    bpf:test_xdp_vlan_mode_native.sh             pass     pass     pass     pass     same
    bpf:test_xdping.sh                           pass     pass     pass     pass     same
    bpf:urandom_read                             pass     pass     pass     pass     same
    breakpoints:breakpoint_test                  pass     pass     pass     pass     same
    capabilities:test_execve                     pass     pass     pass     pass     same
    core:close_range_test                        pass     pass     pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh               pass     pass     pass     pass     same
    cpufreq:main.sh                              fail     fail     fail     fail     same
    exec:execveat                                pass     pass     pass     pass     same
    firmware:fw_run_tests.sh                     skip     skip     skip     skip     same
    fpu:run_test_fpu.sh                          skip     skip     skip     skip     same
    fpu:test_fpu                                 pass     pass     pass     pass     same
    ftrace:ftracetest                            fail     fail     fail     fail     same
    futex:run.sh                                 pass     pass     pass     pass     same
    gpio:gpio-mockup.sh                          fail     fail     fail     fail     same
    intel_pstate:run.sh                          pass     pass     pass     pass     same
    ipc:msgque                                   pass     pass     pass     pass     same
    kcmp:kcmp_test                               pass     pass     pass     pass     same
    kexec:test_kexec_file_load.sh                skip     skip     skip     skip     same
    kexec:test_kexec_load.sh                     skip     skip     skip     skip     same
    kvm:access_tracking_perf_test                fail     fail     fail     fail     same
    kvm:amx_test                                 fail     fail     fail     fail     same
    kvm:cr4_cpuid_sync_test                      fail     fail     fail     fail     same
    kvm:debug_regs                               fail     fail     fail     fail     same
    kvm:demand_paging_test                       pass     pass     pass     pass     same
    kvm:dirty_log_perf_test                      pass     pass     pass     pass     same
    kvm:dirty_log_test                           fail     fail     fail     fail     same
    kvm:emulator_error_test                      fail     fail     fail     fail     same
    kvm:evmcs_test                               fail     fail     fail     fail     same
    kvm:get_cpuid_test                           fail     fail     fail     fail     same
    kvm:get_msr_index_features                   fail     fail     fail     fail     same
    kvm:hardware_disable_test                    pass     pass     pass     pass     same
    kvm:hyperv_clock                             fail     fail     fail     fail     same
    kvm:hyperv_cpuid                             fail     fail     fail     fail     same
    kvm:hyperv_features                          fail     fail     fail     fail     same
    kvm:kvm_binary_stats_test                    pass     pass     pass     pass     same
    kvm:kvm_create_max_vcpus                     skip     skip     skip     skip     same
    kvm:kvm_page_table_test                      pass     pass     pass     pass     same
    kvm:kvm_pv_test                              fail     fail     fail     fail     same
    kvm:memslot_modification_stress_test         pass     pass     pass     pass     same
    kvm:memslot_perf_test                        fail     fail     fail     fail     same
    kvm:mmio_warning_test                        fail     fail     fail     fail     same
    kvm:mmu_role_test                            fail     fail     fail     fail     same
    kvm:platform_info_test                       fail     fail     fail     fail     same
    kvm:rseq_test                                fail     fail     fail     fail     same
    kvm:set_boot_cpu_id                          fail     fail     fail     fail     same
    kvm:set_memory_region_test                   pass     pass     pass     pass     same
    kvm:set_sregs_test                           fail     fail     fail     fail     same
    kvm:smm_test                                 fail     fail     fail     fail     same
    kvm:state_test                               fail     fail     fail     fail     same
    kvm:steal_time                               pass     pass     pass     pass     same
    kvm:svm_int_ctl_test                         fail     fail     fail     fail     same
    kvm:svm_vmcall_test                          fail     fail     fail     fail     same
    kvm:sync_regs_test                           fail     fail     fail     fail     same
    kvm:tsc_msrs_test                            fail     fail     fail     fail     same
    kvm:userspace_msr_exit_test                  fail     fail     fail     fail     same
    kvm:vmx_apic_access_test                     fail     fail     fail     fail     same
    kvm:vmx_close_while_nested_test              fail     fail     fail     fail     same
    kvm:vmx_dirty_log_test                       fail     fail     fail     fail     same
    kvm:vmx_nested_tsc_scaling_test              fail     fail     fail     fail     same
    kvm:vmx_pmu_msrs_test                        fail     fail     fail     fail     same
    kvm:vmx_preemption_timer_test                fail     fail     fail     fail     same
    kvm:vmx_set_nested_state_test                fail     fail     fail     fail     same
    kvm:vmx_tsc_adjust_test                      fail     fail     fail     fail     same
    kvm:xapic_ipi_test                           fail     fail     fail     fail     same
    kvm:xen_shinfo_test                          fail     fail     fail     fail     same
    kvm:xen_vmcall_test                          fail     fail     fail     fail     same
    kvm:xss_msr_test                             fail     fail     fail     fail     same
    lib:bitmap.sh                                skip     skip     skip     skip     same
    lib:prime_numbers.sh                         skip     skip     skip     skip     same
    lib:printf.sh                                skip     skip     skip     skip     same
    lib:scanf.sh                                 fail     fail     fail     fail     same
    livepatch:test-callbacks.sh                  pass     pass     pass     pass     same
    livepatch:test-ftrace.sh                     pass     pass     pass     pass     same
    livepatch:test-livepatch.sh                  pass     pass     pass     pass     same
    livepatch:test-shadow-vars.sh                pass     pass     pass     pass     same
    livepatch:test-state.sh                      pass     pass     pass     pass     same
    membarrier:membarrier_test_multi_thread      pass     pass     pass     pass     same
    membarrier:membarrier_test_single_thread     pass     pass     pass     pass     same
    memfd:memfd_test                             pass     pass     pass     pass     same
    memfd:run_fuse_test.sh                       fail     fail     fail     fail     same
    memfd:run_hugetlbfs_test.sh                  pass     pass     pass     pass     same
    memory-hotplug:mem-on-off-test.sh            pass     pass     pass     pass     same
    mount:run_tests.sh                           pass     pass     pass     pass     same
    net/forwarding:bridge_port_isolation.sh      pass     pass     pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh          pass     pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh          fail     fail     fail     fail     same
    net/forwarding:bridge_vlan_unaware.sh        pass     pass     pass     pass     same
    net/forwarding:ethtool.sh                    fail     fail     fail     fail     same
    net/forwarding:gre_multipath.sh              fail     fail     fail     fail     same
    net/forwarding:ip6_forward_instats_vrf.sh    fail     fail     fail     fail     same
    net/forwarding:ipip_flat_gre.sh              pass     pass     pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh          pass     pass     pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh         pass     pass     pass     pass     same
    net/forwarding:ipip_hier_gre.sh              pass     pass     pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh          pass     pass     pass     pass     same
    net/forwarding:loopback.sh                   skip     skip     skip     skip     same
    net/forwarding:mirror_gre.sh                 fail     fail     fail     fail     same
    net/forwarding:mirror_gre_bound.sh           pass     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh       pass     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh       pass     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh   pass     pass     pass     pass     same
    net/forwarding:mirror_gre_changes.sh         fail     fail     fail     fail     same
    net/forwarding:mirror_gre_flower.sh          fail     fail     fail     fail     same
    net/forwarding:mirror_gre_lag_lacp.sh        pass     pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh           pass     pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh              pass     pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh            pass     pass     pass     pass     same
    net/forwarding:mirror_vlan.sh                pass     pass     pass     pass     same
    net/forwarding:router.sh                     fail     fail     fail     fail     same
    net/forwarding:router_bridge.sh              pass     pass     pass     pass     same
    net/forwarding:router_bridge_vlan.sh         pass     pass     pass     pass     same
    net/forwarding:router_broadcast.sh           fail     fail     fail     fail     same
    net/forwarding:router_multicast.sh           fail     fail     fail     fail     same
    net/forwarding:router_multipath.sh           fail     fail     fail     fail     same
    net/forwarding:router_vid_1.sh               pass     pass     pass     pass     same
    net/forwarding:tc_chains.sh                  pass     pass     pass     pass     same
    net/forwarding:tc_flower.sh                  pass     pass     pass     pass     same
    net/forwarding:tc_flower_router.sh           pass     pass     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh              pass     pass     pass     pass     same
    net/forwarding:tc_shblocks.sh                pass     pass     pass     pass     same
    net/forwarding:tc_vlan_modify.sh             pass     pass     pass     pass     same
    net/forwarding:vxlan_asymmetric.sh           pass     pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh            fail     fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh  pass     pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh            fail     fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh  pass     pass     pass     pass     same
    net/forwarding:vxlan_symmetric.sh            pass     pass     pass     pass     same
    net/mptcp:diag.sh                            pass     pass     pass     pass     same
    net/mptcp:mptcp_connect.sh                   pass     pass     pass     pass     same
    net/mptcp:mptcp_sockopt.sh                   pass     pass     pass     pass     same
    net/mptcp:pm_netlink.sh                      pass     pass     pass     pass     same
    net:bareudp.sh                               pass     pass     pass     pass     same
    net:devlink_port_split.py                    pass     pass     pass     pass     same
    net:drop_monitor_tests.sh                    skip     skip     skip     skip     same
    net:fcnal-test.sh                            pass     pass     pass     pass     same
    net:fib-onlink-tests.sh                      pass     pass     pass     pass     same
    net:fib_rule_tests.sh                        fail     fail     fail     fail     same
    net:fib_tests.sh                             pass     pass     pass     pass     same
    net:gre_gso.sh                               pass     pass     pass     pass     same
    net:icmp_redirect.sh                         pass     pass     pass     pass     same
    net:ip6_gre_headroom.sh                      pass     pass     pass     pass     same
    net:ipv6_flowlabel.sh                        pass     pass     pass     pass     same
    net:l2tp.sh                                  pass     pass     pass     pass     same
    net:msg_zerocopy.sh                          fail     fail     fail     fail     same
    net:netdevice.sh                             pass     pass     pass     pass     same
    net:pmtu.sh                                  pass     pass     pass     pass     same
    net:psock_snd.sh                             fail     fail     fail     fail     same
    net:reuseaddr_conflict                       pass     pass     pass     pass     same
    net:reuseport_bpf                            pass     pass     pass     pass     same
    net:reuseport_bpf_cpu                        pass     pass     pass     pass     same
    net:reuseport_bpf_numa                       pass     pass     pass     pass     same
    net:reuseport_dualstack                      pass     pass     pass     pass     same
    net:rtnetlink.sh                             skip     skip     skip     skip     same
    net:run_afpackettests                        pass     pass     pass     pass     same
    net:run_netsocktests                         pass     pass     pass     pass     same
    net:rxtimestamp.sh                           pass     pass     pass     pass     same
    net:so_txtime.sh                             fail     fail     fail     fail     same
    net:test_bpf.sh                              pass     pass     pass     pass     same
    net:test_vxlan_fdb_changelink.sh             pass     pass     pass     pass     same
    net:tls                                      pass     pass     pass     pass     same
    net:traceroute.sh                            pass     pass     pass     pass     same
    net:udpgro.sh                                fail     fail     fail     fail     same
    net:udpgro_bench.sh                          fail     fail     fail     fail     same
    net:udpgso.sh                                pass     pass     pass     pass     same
    net:veth.sh                                  fail     fail     fail     fail     same
    net:vrf-xfrm-tests.sh                        pass     pass     pass     pass     same
    netfilter:conntrack_icmp_related.sh          fail     fail     fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh         fail     fail     fail     fail     same
    netfilter:ipvs.sh                            skip     skip     skip     skip     same
    netfilter:nft_flowtable.sh                   fail     fail     fail     fail     same
    netfilter:nft_meta.sh                        pass     pass     pass     pass     same
    netfilter:nft_nat.sh                         skip     skip     skip     skip     same
    netfilter:nft_queue.sh                       skip     skip     skip     skip     same
    nsfs:owner                                   pass     pass     pass     pass     same
    nsfs:pidns                                   pass     pass     pass     pass     same
    proc:fd-001-lookup                           pass     pass     pass     pass     same
    proc:fd-002-posix-eq                         pass     pass     pass     pass     same
    proc:fd-003-kthread                          pass     pass     pass     pass     same
    proc:proc-loadavg-001                        pass     pass     pass     pass     same
    proc:proc-self-map-files-001                 pass     pass     pass     pass     same
    proc:proc-self-map-files-002                 fail     fail     fail     fail     same
    proc:proc-self-syscall                       pass     pass     pass     pass     same
    proc:proc-self-wchan                         pass     pass     pass     pass     same
    proc:proc-uptime-001                         pass     pass     pass     pass     same
    proc:proc-uptime-002                         pass     pass     pass     pass     same
    proc:read                                    pass     pass     pass     pass     same
    proc:setns-dcache                            fail     fail     fail     fail     same
    pstore:pstore_post_reboot_tests              skip     skip     skip     skip     same
    pstore:pstore_tests                          fail     fail     fail     fail     same
    ptrace:peeksiginfo                           pass     pass     pass     pass     same
    ptrace:vmaccess                              fail     fail     fail     fail     same
    rseq:basic_percpu_ops_test                   pass     pass     pass     pass     same
    rseq:basic_test                              pass     pass     pass     pass     same
    rseq:param_test                              pass     pass     pass     pass     same
    rseq:param_test_benchmark                    pass     pass     pass     pass     same
    rseq:param_test_compare_twice                pass     pass     pass     pass     same
    rseq:run_param_test.sh                       fail     fail     fail     fail     same
    sgx:test_sgx                                 fail     fail     fail     fail     same
    sigaltstack:sas                              pass     pass     pass     pass     same
    size:get_size                                pass     pass     pass     pass     same
    splice:default_file_splice_read.sh           pass     pass     pass     pass     same
    static_keys:test_static_keys.sh              skip     skip     skip     skip     same
    tc-testing:tdc.sh                            pass     pass     pass     pass     same
    timens:clock_nanosleep                       pass     pass     pass     pass     same
    timens:exec                                  pass     pass     pass     pass     same
    timens:procfs                                pass     pass     pass     pass     same
    timens:timens                                pass     pass     pass     pass     same
    timens:timer                                 pass     pass     pass     pass     same
    timens:timerfd                               pass     pass     pass     pass     same
    timers:inconsistency-check                   fail     fail     fail     fail     same
    timers:mqueue-lat                            pass     pass     pass     pass     same
    timers:nanosleep                             pass     pass     pass     pass     same
    timers:nsleep-lat                            fail     fail     fail     fail     same
    timers:posix_timers                          pass     pass     pass     pass     same
    timers:rtcpie                                pass     pass     pass     pass     same
    timers:set-timer-lat                         fail     fail     fail     fail     same
    timers:threadtest                            pass     pass     pass     pass     same
    tpm2:test_smoke.sh                           fail     fail     fail     fail     same
    tpm2:test_space.sh                           fail     fail     fail     fail     same
    vm:run_vmtests                               fail     fail     fail     fail     same
    x86:amx_64                                   fail     fail     fail     fail     same
    x86:check_initial_reg_state_64               pass     pass     pass     pass     same
    x86:corrupt_xstate_header_64                 pass     pass     pass     pass     same
    x86:fsgsbase_64                              pass     pass     pass     pass     same
    x86:fsgsbase_restore_64                      pass     pass     pass     pass     same
    x86:ioperm_64                                pass     pass     pass     pass     same
    x86:iopl_64                                  pass     pass     pass     pass     same
    x86:mov_ss_trap_64                           pass     pass     pass     pass     same
    x86:mpx-mini-test_64                         fail     fail     fail     fail     same
    x86:protection_keys_64                       pass     pass     pass     pass     same
    x86:sigaltstack_64                           pass     pass     pass     pass     same
    x86:sigreturn_64                             pass     pass     pass     pass     same
    x86:single_step_syscall_64                   pass     pass     pass     pass     same
    x86:syscall_nt_64                            pass     pass     pass     pass     same
    x86:sysret_rip_64                            pass     pass     pass     pass     same
    x86:sysret_ss_attrs_64                       pass     pass     pass     pass     same
    x86:test_mremap_vdso_64                      pass     pass     pass     pass     same
    x86:test_vdso_64                             pass     pass     pass     pass     same
    x86:test_vsyscall_64                         pass     pass     pass     pass     same
    zram:zram.sh                                 pass     pass     pass     pass     same

