### PR TITLE
TEST Revert "ALSA: usb-audio: Fix potential overflow of PCM transfer buffer"

### DIFF
--- a/sound/usb/endpoint.c
+++ b/sound/usb/endpoint.c
@@ -1284,11 +1284,6 @@ static int snd_usb_endpoint_set_params(struct snd_usb_audio *chip,
 	ep->sample_rem = ep->cur_rate % ep->pps;
 	ep->packsize[0] = ep->cur_rate / ep->pps;
 	ep->packsize[1] = (ep->cur_rate + (ep->pps - 1)) / ep->pps;
-	if (ep->packsize[1] > ep->maxpacksize) {
-		usb_audio_dbg(chip, "Too small maxpacksize %u for rate %u / pps %u\n",
-			      ep->maxpacksize, ep->cur_rate, ep->pps);
-		return -EINVAL;
-	}
 
 	/* calculate the frequency in 16.16 format */
 	ep->freqm = ep->freqn;


### PR DESCRIPTION
This reverts commit 5cdfabb7e98774a4a28c5ffa4d75075899b326ca.