### PR TITLE
[LTS 8.6] drm: CVE-2025-38449 (re-open)

### DIFF
--- a/drivers/gpu/drm/drm_framebuffer.c
+++ b/drivers/gpu/drm/drm_framebuffer.c
@@ -841,10 +841,22 @@ void drm_framebuffer_free(struct kref *kref)
 int drm_framebuffer_init(struct drm_device *dev, struct drm_framebuffer *fb,
 			 const struct drm_framebuffer_funcs *funcs)
 {
+	unsigned int i;
 	int ret;
+	bool exists;
 
 	if (WARN_ON_ONCE(fb->dev != dev || !fb->format))
 		return -EINVAL;
+
+	for (i = 0; i < fb->format->num_planes; i++) {
+		if (drm_WARN_ON_ONCE(dev, fb->internal_flags & DRM_FRAMEBUFFER_HAS_HANDLE_REF(i)))
+			fb->internal_flags &= ~DRM_FRAMEBUFFER_HAS_HANDLE_REF(i);
+		if (fb->obj[i]) {
+			exists = drm_gem_object_handle_get_if_exists_unlocked(fb->obj[i]);
+			if (exists)
+				fb->internal_flags |= DRM_FRAMEBUFFER_HAS_HANDLE_REF(i);
+		}
+	}
 
 	INIT_LIST_HEAD(&fb->filp_head);
 
@@ -854,7 +866,7 @@ int drm_framebuffer_init(struct drm_device *dev, struct drm_framebuffer *fb,
 	ret = __drm_mode_object_add(dev, &fb->base, DRM_MODE_OBJECT_FB,
 				    false, drm_framebuffer_free);
 	if (ret)
-		goto out;
+		goto err;
 
 	mutex_lock(&dev->mode_config.fb_lock);
 	dev->mode_config.num_fb++;
@@ -862,7 +874,16 @@ int drm_framebuffer_init(struct drm_device *dev, struct drm_framebuffer *fb,
 	mutex_unlock(&dev->mode_config.fb_lock);
 
 	drm_mode_object_register(dev, &fb->base);
-out:
+
+	return 0;
+
+err:
+	for (i = 0; i < fb->format->num_planes; i++) {
+		if (fb->internal_flags & DRM_FRAMEBUFFER_HAS_HANDLE_REF(i)) {
+			drm_gem_object_handle_put_unlocked(fb->obj[i]);
+			fb->internal_flags &= ~DRM_FRAMEBUFFER_HAS_HANDLE_REF(i);
+		}
+	}
 	return ret;
 }
 EXPORT_SYMBOL(drm_framebuffer_init);
@@ -939,6 +960,12 @@ EXPORT_SYMBOL(drm_framebuffer_unregister_private);
 void drm_framebuffer_cleanup(struct drm_framebuffer *fb)
 {
 	struct drm_device *dev = fb->dev;
+	unsigned int i;
+
+	for (i = 0; i < fb->format->num_planes; i++) {
+		if (fb->internal_flags & DRM_FRAMEBUFFER_HAS_HANDLE_REF(i))
+			drm_gem_object_handle_put_unlocked(fb->obj[i]);
+	}
 
 	mutex_lock(&dev->mode_config.fb_lock);
 	list_del(&fb->head);

--- a/drivers/gpu/drm/drm_gem.c
+++ b/drivers/gpu/drm/drm_gem.c
@@ -182,6 +182,37 @@ drm_gem_remove_prime_handles(struct drm_gem_object *obj, struct drm_file *filp)
 	mutex_unlock(&filp->prime.lock);
 }
 
+static void drm_gem_object_handle_get(struct drm_gem_object *obj)
+{
+	struct drm_device *dev = obj->dev;
+
+	drm_WARN_ON(dev, !mutex_is_locked(&dev->object_name_lock));
+
+	if (obj->handle_count++ == 0)
+		drm_gem_object_get(obj);
+}
+
+/**
+ * drm_gem_object_handle_get_unlocked - acquire reference on user-space handles
+ * @obj: GEM object
+ *
+ * Acquires a reference on the GEM buffer object's handle. Required
+ * to keep the GEM object alive. Call drm_gem_object_handle_put_unlocked()
+ * to release the reference.
+ */
+void drm_gem_object_handle_get_unlocked(struct drm_gem_object *obj)
+{
+	struct drm_device *dev = obj->dev;
+
+	mutex_lock(&dev->object_name_lock);
+
+	drm_WARN_ON(dev, !obj->handle_count); /* first ref taken in create-tail helper */
+	drm_gem_object_handle_get(obj);
+
+	mutex_unlock(&dev->object_name_lock);
+}
+EXPORT_SYMBOL(drm_gem_object_handle_get_unlocked);
+
 /**
  * drm_gem_object_handle_free - release resources bound to userspace handles
  * @obj: GEM object to clean up.
@@ -212,8 +243,14 @@ static void drm_gem_object_exported_dma_buf_free(struct drm_gem_object *obj)
 	}
 }
 
-static void
-drm_gem_object_handle_put_unlocked(struct drm_gem_object *obj)
+/**
+ * drm_gem_object_handle_put_unlocked - releases reference on user-space handles
+ * @obj: GEM object
+ *
+ * Releases a reference on the GEM buffer object's handle. Possibly releases
+ * the GEM buffer object and associated dma-buf objects.
+ */
+void drm_gem_object_handle_put_unlocked(struct drm_gem_object *obj)
 {
 	struct drm_device *dev = obj->dev;
 	bool final = false;
@@ -238,6 +275,7 @@ drm_gem_object_handle_put_unlocked(struct drm_gem_object *obj)
 	if (final)
 		drm_gem_object_put(obj);
 }
+EXPORT_SYMBOL(drm_gem_object_handle_put_unlocked);
 
 /*
  * Called at device or object close to release the file's
@@ -366,8 +404,8 @@ drm_gem_handle_create_tail(struct drm_file *file_priv,
 	int ret;
 
 	WARN_ON(!mutex_is_locked(&dev->object_name_lock));
-	if (obj->handle_count++ == 0)
-		drm_gem_object_get(obj);
+
+	drm_gem_object_handle_get(obj);
 
 	/*
 	 * Get the user-visible handle using idr.  Preload and perform

--- a/drivers/gpu/drm/drm_gem.c
+++ b/drivers/gpu/drm/drm_gem.c
@@ -193,25 +193,39 @@ static void drm_gem_object_handle_get(struct drm_gem_object *obj)
 }
 
 /**
- * drm_gem_object_handle_get_unlocked - acquire reference on user-space handles
+ * drm_gem_object_handle_get_if_exists_unlocked - acquire reference on user-space handle, if any
  * @obj: GEM object
  *
- * Acquires a reference on the GEM buffer object's handle. Required
- * to keep the GEM object alive. Call drm_gem_object_handle_put_unlocked()
- * to release the reference.
+ * Acquires a reference on the GEM buffer object's handle. Required to keep
+ * the GEM object alive. Call drm_gem_object_handle_put_if_exists_unlocked()
+ * to release the reference. Does nothing if the buffer object has no handle.
+ *
+ * Returns:
+ * True if a handle exists, or false otherwise
  */
-void drm_gem_object_handle_get_unlocked(struct drm_gem_object *obj)
+bool drm_gem_object_handle_get_if_exists_unlocked(struct drm_gem_object *obj)
 {
 	struct drm_device *dev = obj->dev;
 
 	mutex_lock(&dev->object_name_lock);
 
-	drm_WARN_ON(dev, !obj->handle_count); /* first ref taken in create-tail helper */
+	/*
+	 * First ref taken during GEM object creation, if any. Some
+	 * drivers set up internal framebuffers with GEM objects that
+	 * do not have a GEM handle. Hence, this counter can be zero.
+	 */
+	if (!obj->handle_count) {
+		mutex_unlock(&dev->object_name_lock);
+		return false;
+	}
+
 	drm_gem_object_handle_get(obj);
 
 	mutex_unlock(&dev->object_name_lock);
+
+	return true;
 }
-EXPORT_SYMBOL(drm_gem_object_handle_get_unlocked);
+
 
 /**
  * drm_gem_object_handle_free - release resources bound to userspace handles
@@ -244,7 +258,7 @@ static void drm_gem_object_exported_dma_buf_free(struct drm_gem_object *obj)
 }
 
 /**
- * drm_gem_object_handle_put_unlocked - releases reference on user-space handles
+ * drm_gem_object_handle_put_unlocked - releases reference on user-space handle
  * @obj: GEM object
  *
  * Releases a reference on the GEM buffer object's handle. Possibly releases
@@ -255,14 +269,14 @@ void drm_gem_object_handle_put_unlocked(struct drm_gem_object *obj)
 	struct drm_device *dev = obj->dev;
 	bool final = false;
 
-	if (WARN_ON(READ_ONCE(obj->handle_count) == 0))
+	if (drm_WARN_ON(dev, READ_ONCE(obj->handle_count) == 0))
 		return;
 
 	/*
-	* Must bump handle count first as this may be the last
-	* ref, in which case the object would disappear before we
-	* checked for a name
-	*/
+	 * Must bump handle count first as this may be the last
+	 * ref, in which case the object would disappear before
+	 * we checked for a name.
+	 */
 
 	mutex_lock(&dev->object_name_lock);
 	if (--obj->handle_count == 0) {
@@ -275,7 +289,6 @@ void drm_gem_object_handle_put_unlocked(struct drm_gem_object *obj)
 	if (final)
 		drm_gem_object_put(obj);
 }
-EXPORT_SYMBOL(drm_gem_object_handle_put_unlocked);
 
 /*
  * Called at device or object close to release the file's

--- a/drivers/gpu/drm/drm_gem_atomic_helper.c
+++ b/drivers/gpu/drm/drm_gem_atomic_helper.c
@@ -278,10 +278,7 @@ int drm_gem_prepare_shadow_fb(struct drm_plane *plane, struct drm_plane_state *p
 {
 	struct drm_shadow_plane_state *shadow_plane_state = to_drm_shadow_plane_state(plane_state);
 	struct drm_framebuffer *fb = plane_state->fb;
-	struct drm_gem_object *obj;
-	struct dma_buf_map map;
 	int ret;
-	size_t i;
 
 	if (!fb)
 		return 0;
@@ -290,27 +287,7 @@ int drm_gem_prepare_shadow_fb(struct drm_plane *plane, struct drm_plane_state *p
 	if (ret)
 		return ret;
 
-	for (i = 0; i < ARRAY_SIZE(shadow_plane_state->map); ++i) {
-		obj = drm_gem_fb_get_obj(fb, i);
-		if (!obj)
-			continue;
-		ret = drm_gem_vmap(obj, &map);
-		if (ret)
-			goto err_drm_gem_vunmap;
-		shadow_plane_state->map[i] = map;
-	}
-
-	return 0;
-
-err_drm_gem_vunmap:
-	while (i) {
-		--i;
-		obj = drm_gem_fb_get_obj(fb, i);
-		if (!obj)
-			continue;
-		drm_gem_vunmap(obj, &shadow_plane_state->map[i]);
-	}
-	return ret;
+	return drm_gem_fb_vmap(fb, shadow_plane_state->map);
 }
 EXPORT_SYMBOL(drm_gem_prepare_shadow_fb);
 
@@ -328,19 +305,11 @@ void drm_gem_cleanup_shadow_fb(struct drm_plane *plane, struct drm_plane_state *
 {
 	struct drm_shadow_plane_state *shadow_plane_state = to_drm_shadow_plane_state(plane_state);
 	struct drm_framebuffer *fb = plane_state->fb;
-	size_t i = ARRAY_SIZE(shadow_plane_state->map);
-	struct drm_gem_object *obj;
 
 	if (!fb)
 		return;
 
-	while (i) {
-		--i;
-		obj = drm_gem_fb_get_obj(fb, i);
-		if (!obj)
-			continue;
-		drm_gem_vunmap(obj, &shadow_plane_state->map[i]);
-	}
+	drm_gem_fb_vunmap(fb, shadow_plane_state->map);
 }
 EXPORT_SYMBOL(drm_gem_cleanup_shadow_fb);
 

--- a/drivers/gpu/drm/drm_gem_atomic_helper.c
+++ b/drivers/gpu/drm/drm_gem_atomic_helper.c
@@ -287,7 +287,7 @@ int drm_gem_prepare_shadow_fb(struct drm_plane *plane, struct drm_plane_state *p
 	if (ret)
 		return ret;
 
-	return drm_gem_fb_vmap(fb, shadow_plane_state->map);
+	return drm_gem_fb_vmap(fb, shadow_plane_state->map, shadow_plane_state->data);
 }
 EXPORT_SYMBOL(drm_gem_prepare_shadow_fb);
 

--- a/drivers/gpu/drm/drm_gem_atomic_helper.c
+++ b/drivers/gpu/drm/drm_gem_atomic_helper.c
@@ -147,6 +147,8 @@ int drm_gem_plane_helper_prepare_fb(struct drm_plane *plane, struct drm_plane_st
 		return 0;
 
 	obj = drm_gem_fb_get_obj(state->fb, 0);
+	if (!obj)
+		return -EINVAL;
 	fence = dma_resv_get_excl_unlocked(obj->resv);
 	drm_atomic_set_fence_for_plane(state, fence);
 

--- a/drivers/gpu/drm/drm_gem_framebuffer_helper.c
+++ b/drivers/gpu/drm/drm_gem_framebuffer_helper.c
@@ -315,11 +315,16 @@ EXPORT_SYMBOL_GPL(drm_gem_fb_create_with_dirty);
  * drm_gem_fb_vmap - maps all framebuffer BOs into kernel address space
  * @fb: the framebuffer
  * @map: returns the mapping's address for each BO
+ * @data: returns the data address for each BO, can be NULL
  *
  * This function maps all buffer objects of the given framebuffer into
  * kernel address space and stores them in struct dma_buf_map. If the
  * mapping operation fails for one of the BOs, the function unmaps the
  * already established mappings automatically.
+ *
+ * Callers that want to access a BO's stored data should pass @data.
+ * The argument returns the addresses of the data stored in each BO. This
+ * is different from @map if the framebuffer's offsets field is non-zero.
  *
  * See drm_gem_fb_vunmap() for unmapping.
  *
@@ -327,7 +332,8 @@ EXPORT_SYMBOL_GPL(drm_gem_fb_create_with_dirty);
  * 0 on success, or a negative errno code otherwise.
  */
 int drm_gem_fb_vmap(struct drm_framebuffer *fb,
-		    struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES])
+		    struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES],
+		    struct dma_buf_map data[DRM_FORMAT_MAX_PLANES])
 {
 	struct drm_gem_object *obj;
 	unsigned int i;
@@ -342,6 +348,15 @@ int drm_gem_fb_vmap(struct drm_framebuffer *fb,
 		ret = drm_gem_vmap(obj, &map[i]);
 		if (ret)
 			goto err_drm_gem_vunmap;
+	}
+
+	if (data) {
+		for (i = 0; i < DRM_FORMAT_MAX_PLANES; ++i) {
+			memcpy(&data[i], &map[i], sizeof(data[i]));
+			if (dma_buf_map_is_null(&data[i]))
+				continue;
+			dma_buf_map_incr(&data[i], fb->offsets[i]);
+		}
 	}
 
 	return 0;

--- a/drivers/gpu/drm/drm_gem_framebuffer_helper.c
+++ b/drivers/gpu/drm/drm_gem_framebuffer_helper.c
@@ -400,6 +400,28 @@ void drm_gem_fb_vunmap(struct drm_framebuffer *fb,
 }
 EXPORT_SYMBOL(drm_gem_fb_vunmap);
 
+static void __drm_gem_fb_end_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir,
+					unsigned int num_planes)
+{
+	struct dma_buf_attachment *import_attach;
+	struct drm_gem_object *obj;
+	int ret;
+
+	while (num_planes) {
+		--num_planes;
+		obj = drm_gem_fb_get_obj(fb, num_planes);
+		if (!obj)
+			continue;
+		import_attach = obj->import_attach;
+		if (!import_attach)
+			continue;
+		ret = dma_buf_end_cpu_access(import_attach->dmabuf, dir);
+		if (ret)
+			drm_err(fb->dev, "dma_buf_end_cpu_access(%u, %d) failed: %d\n",
+				ret, num_planes, dir);
+	}
+}
+
 /**
  * drm_gem_fb_begin_cpu_access - prepares GEM buffer objects for CPU access
  * @fb: the framebuffer
@@ -419,7 +441,7 @@ int drm_gem_fb_begin_cpu_access(struct drm_framebuffer *fb, enum dma_data_direct
 	struct dma_buf_attachment *import_attach;
 	struct drm_gem_object *obj;
 	size_t i;
-	int ret, ret2;
+	int ret;
 
 	for (i = 0; i < ARRAY_SIZE(fb->obj); ++i) {
 		obj = drm_gem_fb_get_obj(fb, i);
@@ -430,28 +452,13 @@ int drm_gem_fb_begin_cpu_access(struct drm_framebuffer *fb, enum dma_data_direct
 			continue;
 		ret = dma_buf_begin_cpu_access(import_attach->dmabuf, dir);
 		if (ret)
-			goto err_dma_buf_end_cpu_access;
+			goto err___drm_gem_fb_end_cpu_access;
 	}
 
 	return 0;
 
-err_dma_buf_end_cpu_access:
-	while (i) {
-		--i;
-		obj = drm_gem_fb_get_obj(fb, i);
-		if (!obj)
-			continue;
-		import_attach = obj->import_attach;
-		if (!import_attach)
-			continue;
-		ret2 = dma_buf_end_cpu_access(import_attach->dmabuf, dir);
-		if (ret2) {
-			drm_err(fb->dev,
-				"dma_buf_end_cpu_access() failed during error handling: %d\n",
-				ret2);
-		}
-	}
-
+err___drm_gem_fb_end_cpu_access:
+	__drm_gem_fb_end_cpu_access(fb, dir, i);
 	return ret;
 }
 EXPORT_SYMBOL(drm_gem_fb_begin_cpu_access);
@@ -469,23 +476,7 @@ EXPORT_SYMBOL(drm_gem_fb_begin_cpu_access);
  */
 void drm_gem_fb_end_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir)
 {
-	size_t i = ARRAY_SIZE(fb->obj);
-	struct dma_buf_attachment *import_attach;
-	struct drm_gem_object *obj;
-	int ret;
-
-	while (i) {
-		--i;
-		obj = drm_gem_fb_get_obj(fb, i);
-		if (!obj)
-			continue;
-		import_attach = obj->import_attach;
-		if (!import_attach)
-			continue;
-		ret = dma_buf_end_cpu_access(import_attach->dmabuf, dir);
-		if (ret)
-			drm_err(fb->dev, "dma_buf_end_cpu_access() failed: %d\n", ret);
-	}
+	__drm_gem_fb_end_cpu_access(fb, dir, ARRAY_SIZE(fb->obj));
 }
 EXPORT_SYMBOL(drm_gem_fb_end_cpu_access);
 

--- a/drivers/gpu/drm/drm_gem_framebuffer_helper.c
+++ b/drivers/gpu/drm/drm_gem_framebuffer_helper.c
@@ -335,8 +335,10 @@ int drm_gem_fb_vmap(struct drm_framebuffer *fb,
 
 	for (i = 0; i < DRM_FORMAT_MAX_PLANES; ++i) {
 		obj = drm_gem_fb_get_obj(fb, i);
-		if (!obj)
+		if (!obj) {
+			dma_buf_map_clear(&map[i]);
 			continue;
+		}
 		ret = drm_gem_vmap(obj, &map[i]);
 		if (ret)
 			goto err_drm_gem_vunmap;
@@ -375,6 +377,8 @@ void drm_gem_fb_vunmap(struct drm_framebuffer *fb,
 		--i;
 		obj = drm_gem_fb_get_obj(fb, i);
 		if (!obj)
+			continue;
+		if (dma_buf_map_is_null(&map[i]))
 			continue;
 		drm_gem_vunmap(obj, &map[i]);
 	}

--- a/drivers/gpu/drm/drm_gem_framebuffer_helper.c
+++ b/drivers/gpu/drm/drm_gem_framebuffer_helper.c
@@ -92,7 +92,7 @@ void drm_gem_fb_destroy(struct drm_framebuffer *fb)
 	unsigned int i;
 
 	for (i = 0; i < fb->format->num_planes; i++)
-		drm_gem_object_handle_put_unlocked(fb->obj[i]);
+		drm_gem_object_put(fb->obj[i]);
 
 	drm_framebuffer_cleanup(fb);
 	kfree(fb);
@@ -167,10 +167,8 @@ int drm_gem_fb_init_with_funcs(struct drm_device *dev,
 		if (!objs[i]) {
 			drm_dbg_kms(dev, "Failed to lookup GEM object\n");
 			ret = -ENOENT;
-			goto err_gem_object_handle_put_unlocked;
+			goto err_gem_object_put;
 		}
-		drm_gem_object_handle_get_unlocked(objs[i]);
-		drm_gem_object_put(objs[i]);
 
 		min_size = (height - 1) * mode_cmd->pitches[i]
 			 + drm_format_info_min_pitch(info, i, width)
@@ -180,22 +178,22 @@ int drm_gem_fb_init_with_funcs(struct drm_device *dev,
 			drm_dbg_kms(dev,
 				    "GEM object size (%zu) smaller than minimum size (%u) for plane %d\n",
 				    objs[i]->size, min_size, i);
-			drm_gem_object_handle_put_unlocked(objs[i]);
+			drm_gem_object_put(objs[i]);
 			ret = -EINVAL;
-			goto err_gem_object_handle_put_unlocked;
+			goto err_gem_object_put;
 		}
 	}
 
 	ret = drm_gem_fb_init(dev, fb, mode_cmd, objs, i, funcs);
 	if (ret)
-		goto err_gem_object_handle_put_unlocked;
+		goto err_gem_object_put;
 
 	return 0;
 
-err_gem_object_handle_put_unlocked:
+err_gem_object_put:
 	while (i > 0) {
 		--i;
-		drm_gem_object_handle_put_unlocked(objs[i]);
+		drm_gem_object_put(objs[i]);
 	}
 	return ret;
 }

--- a/drivers/gpu/drm/drm_gem_framebuffer_helper.c
+++ b/drivers/gpu/drm/drm_gem_framebuffer_helper.c
@@ -92,7 +92,7 @@ void drm_gem_fb_destroy(struct drm_framebuffer *fb)
 	unsigned int i;
 
 	for (i = 0; i < fb->format->num_planes; i++)
-		drm_gem_object_put(fb->obj[i]);
+		drm_gem_object_handle_put_unlocked(fb->obj[i]);
 
 	drm_framebuffer_cleanup(fb);
 	kfree(fb);
@@ -167,8 +167,10 @@ int drm_gem_fb_init_with_funcs(struct drm_device *dev,
 		if (!objs[i]) {
 			drm_dbg_kms(dev, "Failed to lookup GEM object\n");
 			ret = -ENOENT;
-			goto err_gem_object_put;
+			goto err_gem_object_handle_put_unlocked;
 		}
+		drm_gem_object_handle_get_unlocked(objs[i]);
+		drm_gem_object_put(objs[i]);
 
 		min_size = (height - 1) * mode_cmd->pitches[i]
 			 + drm_format_info_min_pitch(info, i, width)
@@ -178,22 +180,22 @@ int drm_gem_fb_init_with_funcs(struct drm_device *dev,
 			drm_dbg_kms(dev,
 				    "GEM object size (%zu) smaller than minimum size (%u) for plane %d\n",
 				    objs[i]->size, min_size, i);
-			drm_gem_object_put(objs[i]);
+			drm_gem_object_handle_put_unlocked(objs[i]);
 			ret = -EINVAL;
-			goto err_gem_object_put;
+			goto err_gem_object_handle_put_unlocked;
 		}
 	}
 
 	ret = drm_gem_fb_init(dev, fb, mode_cmd, objs, i, funcs);
 	if (ret)
-		goto err_gem_object_put;
+		goto err_gem_object_handle_put_unlocked;
 
 	return 0;
 
-err_gem_object_put:
+err_gem_object_handle_put_unlocked:
 	while (i > 0) {
 		--i;
-		drm_gem_object_put(objs[i]);
+		drm_gem_object_handle_put_unlocked(objs[i]);
 	}
 	return ret;
 }

--- a/drivers/gpu/drm/drm_gem_framebuffer_helper.c
+++ b/drivers/gpu/drm/drm_gem_framebuffer_helper.c
@@ -89,9 +89,9 @@ drm_gem_fb_init(struct drm_device *dev,
  */
 void drm_gem_fb_destroy(struct drm_framebuffer *fb)
 {
-	size_t i;
+	unsigned int i;
 
-	for (i = 0; i < ARRAY_SIZE(fb->obj); i++)
+	for (i = 0; i < fb->format->num_planes; i++)
 		drm_gem_object_put(fb->obj[i]);
 
 	drm_framebuffer_cleanup(fb);
@@ -326,24 +326,26 @@ EXPORT_SYMBOL_GPL(drm_gem_fb_create_with_dirty);
  * The argument returns the addresses of the data stored in each BO. This
  * is different from @map if the framebuffer's offsets field is non-zero.
  *
+ * Both, @map and @data, must each refer to arrays with at least
+ * fb->format->num_planes elements.
+ *
  * See drm_gem_fb_vunmap() for unmapping.
  *
  * Returns:
  * 0 on success, or a negative errno code otherwise.
  */
-int drm_gem_fb_vmap(struct drm_framebuffer *fb,
-		    struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES],
-		    struct dma_buf_map data[DRM_FORMAT_MAX_PLANES])
+int drm_gem_fb_vmap(struct drm_framebuffer *fb, struct dma_buf_map *map,
+		    struct dma_buf_map *data)
 {
 	struct drm_gem_object *obj;
 	unsigned int i;
 	int ret;
 
-	for (i = 0; i < DRM_FORMAT_MAX_PLANES; ++i) {
+	for (i = 0; i < fb->format->num_planes; ++i) {
 		obj = drm_gem_fb_get_obj(fb, i);
 		if (!obj) {
-			dma_buf_map_clear(&map[i]);
-			continue;
+			ret = -EINVAL;
+			goto err_drm_gem_vunmap;
 		}
 		ret = drm_gem_vmap(obj, &map[i]);
 		if (ret)
@@ -351,7 +353,7 @@ int drm_gem_fb_vmap(struct drm_framebuffer *fb,
 	}
 
 	if (data) {
-		for (i = 0; i < DRM_FORMAT_MAX_PLANES; ++i) {
+		for (i = 0; i < fb->format->num_planes; ++i) {
 			memcpy(&data[i], &map[i], sizeof(data[i]));
 			if (dma_buf_map_is_null(&data[i]))
 				continue;
@@ -382,10 +384,9 @@ EXPORT_SYMBOL(drm_gem_fb_vmap);
  *
  * See drm_gem_fb_vmap() for more information.
  */
-void drm_gem_fb_vunmap(struct drm_framebuffer *fb,
-		       struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES])
+void drm_gem_fb_vunmap(struct drm_framebuffer *fb, struct dma_buf_map *map)
 {
-	unsigned int i = DRM_FORMAT_MAX_PLANES;
+	unsigned int i = fb->format->num_planes;
 	struct drm_gem_object *obj;
 
 	while (i) {
@@ -440,13 +441,15 @@ int drm_gem_fb_begin_cpu_access(struct drm_framebuffer *fb, enum dma_data_direct
 {
 	struct dma_buf_attachment *import_attach;
 	struct drm_gem_object *obj;
-	size_t i;
+	unsigned int i;
 	int ret;
 
-	for (i = 0; i < ARRAY_SIZE(fb->obj); ++i) {
+	for (i = 0; i < fb->format->num_planes; ++i) {
 		obj = drm_gem_fb_get_obj(fb, i);
-		if (!obj)
-			continue;
+		if (!obj) {
+			ret = -EINVAL;
+			goto err___drm_gem_fb_end_cpu_access;
+		}
 		import_attach = obj->import_attach;
 		if (!import_attach)
 			continue;
@@ -476,7 +479,7 @@ EXPORT_SYMBOL(drm_gem_fb_begin_cpu_access);
  */
 void drm_gem_fb_end_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir)
 {
-	__drm_gem_fb_end_cpu_access(fb, dir, ARRAY_SIZE(fb->obj));
+	__drm_gem_fb_end_cpu_access(fb, dir, fb->format->num_planes);
 }
 EXPORT_SYMBOL(drm_gem_fb_end_cpu_access);
 

--- a/drivers/gpu/drm/drm_internal.h
+++ b/drivers/gpu/drm/drm_internal.h
@@ -158,6 +158,8 @@ void drm_sysfs_lease_event(struct drm_device *dev);
 
 /* drm_gem.c */
 int drm_gem_init(struct drm_device *dev);
+void drm_gem_object_handle_get_unlocked(struct drm_gem_object *obj);
+void drm_gem_object_handle_put_unlocked(struct drm_gem_object *obj);
 int drm_gem_handle_create_tail(struct drm_file *file_priv,
 			       struct drm_gem_object *obj,
 			       u32 *handlep);

--- a/drivers/gpu/drm/drm_internal.h
+++ b/drivers/gpu/drm/drm_internal.h
@@ -158,7 +158,7 @@ void drm_sysfs_lease_event(struct drm_device *dev);
 
 /* drm_gem.c */
 int drm_gem_init(struct drm_device *dev);
-void drm_gem_object_handle_get_unlocked(struct drm_gem_object *obj);
+bool drm_gem_object_handle_get_if_exists_unlocked(struct drm_gem_object *obj);
 void drm_gem_object_handle_put_unlocked(struct drm_gem_object *obj);
 int drm_gem_handle_create_tail(struct drm_file *file_priv,
 			       struct drm_gem_object *obj,

--- a/drivers/gpu/drm/gud/gud_pipe.c
+++ b/drivers/gpu/drm/gud/gud_pipe.c
@@ -15,7 +15,8 @@
 #include <drm/drm_format_helper.h>
 #include <drm/drm_fourcc.h>
 #include <drm/drm_framebuffer.h>
-#include <drm/drm_gem_shmem_helper.h>
+#include <drm/drm_gem.h>
+#include <drm/drm_gem_framebuffer_helper.h>
 #include <drm/drm_print.h>
 #include <drm/drm_rect.h>
 #include <drm/drm_simple_kms_helper.h>
@@ -139,7 +140,7 @@ static int gud_prep_flush(struct gud_device *gdrm, struct drm_framebuffer *fb,
 {
 	struct dma_buf_attachment *import_attach = fb->obj[0]->import_attach;
 	u8 compression = gdrm->compression;
-	struct dma_buf_map map;
+	struct dma_buf_map map[DRM_FORMAT_MAX_PLANES];
 	void *vaddr, *buf;
 	size_t pitch, len;
 	int ret = 0;
@@ -149,11 +150,11 @@ static int gud_prep_flush(struct gud_device *gdrm, struct drm_framebuffer *fb,
 	if (len > gdrm->bulk_len)
 		return -E2BIG;
 
-	ret = drm_gem_shmem_vmap(fb->obj[0], &map);
+	ret = drm_gem_fb_vmap(fb, map);
 	if (ret)
 		return ret;
 
-	vaddr = map.vaddr + fb->offsets[0];
+	vaddr = map[0].vaddr + fb->offsets[0];
 
 	if (import_attach) {
 		ret = dma_buf_begin_cpu_access(import_attach->dmabuf, DMA_FROM_DEVICE);
@@ -215,7 +216,7 @@ end_cpu_access:
 	if (import_attach)
 		dma_buf_end_cpu_access(import_attach->dmabuf, DMA_FROM_DEVICE);
 vunmap:
-	drm_gem_shmem_vunmap(fb->obj[0], &map);
+	drm_gem_fb_vunmap(fb, map);
 
 	return ret;
 }

--- a/drivers/gpu/drm/gud/gud_pipe.c
+++ b/drivers/gpu/drm/gud/gud_pipe.c
@@ -150,7 +150,7 @@ static int gud_prep_flush(struct gud_device *gdrm, struct drm_framebuffer *fb,
 	if (len > gdrm->bulk_len)
 		return -E2BIG;
 
-	ret = drm_gem_fb_vmap(fb, map);
+	ret = drm_gem_fb_vmap(fb, map, NULL);
 	if (ret)
 		return ret;
 

--- a/drivers/gpu/drm/vkms/vkms_composer.c
+++ b/drivers/gpu/drm/vkms/vkms_composer.c
@@ -259,7 +259,7 @@ void vkms_composer_worker(struct work_struct *work)
 		return;
 
 	if (wb_pending)
-		vaddr_out = crtc_state->active_writeback;
+		vaddr_out = crtc_state->active_writeback->map[0].vaddr;
 
 	ret = compose_active_planes(&vaddr_out, primary_composer,
 				    crtc_state);

--- a/drivers/gpu/drm/vkms/vkms_drv.h
+++ b/drivers/gpu/drm/vkms/vkms_drv.h
@@ -7,6 +7,7 @@
 
 #include <drm/drm.h>
 #include <drm/drm_gem.h>
+#include <drm/drm_gem_atomic_helper.h>
 #include <drm/drm_encoder.h>
 #include <drm/drm_writeback.h>
 
@@ -18,6 +19,10 @@
 
 #define XRES_MAX  8192
 #define YRES_MAX  8192
+
+struct vkms_writeback_job {
+	struct dma_buf_map map[DRM_FORMAT_MAX_PLANES];
+};
 
 struct vkms_composer {
 	struct drm_framebuffer fb;
@@ -55,7 +60,7 @@ struct vkms_crtc_state {
 	int num_active_planes;
 	/* stack of active planes for crc computation, should be in z order */
 	struct vkms_plane_state **active_planes;
-	void *active_writeback;
+	struct vkms_writeback_job *active_writeback;
 
 	/* below four are protected by vkms_output.composer_lock */
 	bool crc_pending;

--- a/drivers/gpu/drm/vkms/vkms_writeback.c
+++ b/drivers/gpu/drm/vkms/vkms_writeback.c
@@ -75,7 +75,7 @@ static int vkms_wb_prepare_job(struct drm_writeback_connector *wb_connector,
 	if (!vkmsjob)
 		return -ENOMEM;
 
-	ret = drm_gem_fb_vmap(job->fb, vkmsjob->map);
+	ret = drm_gem_fb_vmap(job->fb, vkmsjob->map, NULL);
 	if (ret) {
 		DRM_ERROR("vmap failed: %d\n", ret);
 		goto err_kfree;

--- a/drivers/gpu/drm/vkms/vkms_writeback.c
+++ b/drivers/gpu/drm/vkms/vkms_writeback.c
@@ -65,41 +65,45 @@ static int vkms_wb_connector_get_modes(struct drm_connector *connector)
 static int vkms_wb_prepare_job(struct drm_writeback_connector *wb_connector,
 			       struct drm_writeback_job *job)
 {
-	struct drm_gem_object *gem_obj;
-	struct dma_buf_map map;
+	struct vkms_writeback_job *vkmsjob;
 	int ret;
 
 	if (!job->fb)
 		return 0;
 
-	gem_obj = drm_gem_fb_get_obj(job->fb, 0);
-	ret = drm_gem_shmem_vmap(gem_obj, &map);
+	vkmsjob = kzalloc(sizeof(*vkmsjob), GFP_KERNEL);
+	if (!vkmsjob)
+		return -ENOMEM;
+
+	ret = drm_gem_fb_vmap(job->fb, vkmsjob->map);
 	if (ret) {
 		DRM_ERROR("vmap failed: %d\n", ret);
-		return ret;
+		goto err_kfree;
 	}
 
-	job->priv = map.vaddr;
+	job->priv = vkmsjob;
 
 	return 0;
+
+err_kfree:
+	kfree(vkmsjob);
+	return ret;
 }
 
 static void vkms_wb_cleanup_job(struct drm_writeback_connector *connector,
 				struct drm_writeback_job *job)
 {
-	struct drm_gem_object *gem_obj;
+	struct vkms_writeback_job *vkmsjob = job->priv;
 	struct vkms_device *vkmsdev;
-	struct dma_buf_map map;
 
 	if (!job->fb)
 		return;
 
-	gem_obj = drm_gem_fb_get_obj(job->fb, 0);
-	dma_buf_map_set_vaddr(&map, job->priv);
-	drm_gem_shmem_vunmap(gem_obj, &map);
+	drm_gem_fb_vunmap(job->fb, vkmsjob->map);
 
-	vkmsdev = drm_device_to_vkms_device(gem_obj->dev);
+	vkmsdev = drm_device_to_vkms_device(job->fb->dev);
 	vkms_set_composer(&vkmsdev->output, false);
+	kfree(vkmsjob);
 }
 
 static void vkms_wb_atomic_commit(struct drm_connector *conn,

--- a/include/drm/drm_fourcc.h
+++ b/include/drm/drm_fourcc.h
@@ -25,6 +25,11 @@
 #include <linux/types.h>
 #include <uapi/drm/drm_fourcc.h>
 
+/**
+ * DRM_FORMAT_MAX_PLANES - maximum number of planes a DRM format can have
+ */
+#define DRM_FORMAT_MAX_PLANES	4u
+
 /*
  * DRM formats are little endian.  Define host endian variants for the
  * most common formats here, to reduce the #ifdefs needed in drivers.
@@ -78,7 +83,7 @@ struct drm_format_info {
 		 * triplet @char_per_block, @block_w, @block_h for better
 		 * describing the pixel format.
 		 */
-		u8 cpp[4];
+		u8 cpp[DRM_FORMAT_MAX_PLANES];
 
 		/**
 		 * @char_per_block:
@@ -104,7 +109,7 @@ struct drm_format_info {
 		 * information from their drm_mode_config.get_format_info hook
 		 * if they want the core to be validating the pitch.
 		 */
-		u8 char_per_block[4];
+		u8 char_per_block[DRM_FORMAT_MAX_PLANES];
 	};
 
 	/**
@@ -113,7 +118,7 @@ struct drm_format_info {
 	 * Block width in pixels, this is intended to be accessed through
 	 * drm_format_info_block_width()
 	 */
-	u8 block_w[4];
+	u8 block_w[DRM_FORMAT_MAX_PLANES];
 
 	/**
 	 * @block_h:
@@ -121,7 +126,7 @@ struct drm_format_info {
 	 * Block height in pixels, this is intended to be accessed through
 	 * drm_format_info_block_height()
 	 */
-	u8 block_h[4];
+	u8 block_h[DRM_FORMAT_MAX_PLANES];
 
 	/** @hsub: Horizontal chroma subsampling factor */
 	u8 hsub;

--- a/include/drm/drm_framebuffer.h
+++ b/include/drm/drm_framebuffer.h
@@ -23,6 +23,7 @@
 #ifndef __DRM_FRAMEBUFFER_H__
 #define __DRM_FRAMEBUFFER_H__
 
+#include <linux/bits.h>
 #include <linux/ctype.h>
 #include <linux/list.h>
 #include <linux/sched.h>
@@ -99,6 +100,8 @@ struct drm_framebuffer_funcs {
 		     unsigned color, struct drm_clip_rect *clips,
 		     unsigned num_clips);
 };
+
+#define DRM_FRAMEBUFFER_HAS_HANDLE_REF(_i)	BIT(0u + (_i))
 
 /**
  * struct drm_framebuffer - frame buffer object
@@ -188,6 +191,10 @@ struct drm_framebuffer {
 	 * DRM_MODE_FB_MODIFIERS.
 	 */
 	int flags;
+	/**
+	 * @internal_flags: Framebuffer flags like DRM_FRAMEBUFFER_HAS_HANDLE_REF.
+	 */
+	unsigned int internal_flags;
 	/**
 	 * @hot_x: X coordinate of the cursor hotspot. Used by the legacy cursor
 	 * IOCTL when the driver supports cursor through a DRM_PLANE_TYPE_CURSOR

--- a/include/drm/drm_framebuffer.h
+++ b/include/drm/drm_framebuffer.h
@@ -27,12 +27,12 @@
 #include <linux/list.h>
 #include <linux/sched.h>
 
+#include <drm/drm_fourcc.h>
 #include <drm/drm_mode_object.h>
 
 struct drm_clip_rect;
 struct drm_device;
 struct drm_file;
-struct drm_format_info;
 struct drm_framebuffer;
 struct drm_gem_object;
 
@@ -147,7 +147,7 @@ struct drm_framebuffer {
 	 * @pitches: Line stride per buffer. For userspace created object this
 	 * is copied from drm_mode_fb_cmd2.
 	 */
-	unsigned int pitches[4];
+	unsigned int pitches[DRM_FORMAT_MAX_PLANES];
 	/**
 	 * @offsets: Offset from buffer start to the actual pixel data in bytes,
 	 * per buffer. For userspace created object this is copied from
@@ -165,7 +165,7 @@ struct drm_framebuffer {
 	 * data (even for linear buffers). Specifying an x/y pixel offset is
 	 * instead done through the source rectangle in &struct drm_plane_state.
 	 */
-	unsigned int offsets[4];
+	unsigned int offsets[DRM_FORMAT_MAX_PLANES];
 	/**
 	 * @modifier: Data layout modifier. This is used to describe
 	 * tiling, or also special layouts (like compression) of auxiliary
@@ -210,7 +210,7 @@ struct drm_framebuffer {
 	 * This is used by the GEM framebuffer helpers, see e.g.
 	 * drm_gem_fb_create().
 	 */
-	struct drm_gem_object *obj[4];
+	struct drm_gem_object *obj[DRM_FORMAT_MAX_PLANES];
 };
 
 #define obj_to_fb(x) container_of(x, struct drm_framebuffer, base)

--- a/include/drm/drm_gem_atomic_helper.h
+++ b/include/drm/drm_gem_atomic_helper.h
@@ -42,6 +42,14 @@ struct drm_shadow_plane_state {
 	 * prepare_fb callback and removed in the cleanup_fb callback.
 	 */
 	struct dma_buf_map map[DRM_FORMAT_MAX_PLANES];
+
+	/**
+	 * @data: Address of each framebuffer BO's data
+	 *
+	 * The address of the data stored in each mapping. This is different
+	 * for framebuffers with non-zero offset fields.
+	 */
+	struct dma_buf_map data[DRM_FORMAT_MAX_PLANES];
 };
 
 /**

--- a/include/drm/drm_gem_atomic_helper.h
+++ b/include/drm/drm_gem_atomic_helper.h
@@ -5,6 +5,7 @@
 
 #include <linux/dma-buf-map.h>
 
+#include <drm/drm_fourcc.h>
 #include <drm/drm_plane.h>
 
 struct drm_simple_display_pipe;
@@ -40,7 +41,7 @@ struct drm_shadow_plane_state {
 	 * The memory mappings stored in map should be established in the plane's
 	 * prepare_fb callback and removed in the cleanup_fb callback.
 	 */
-	struct dma_buf_map map[4];
+	struct dma_buf_map map[DRM_FORMAT_MAX_PLANES];
 };
 
 /**

--- a/include/drm/drm_gem_framebuffer_helper.h
+++ b/include/drm/drm_gem_framebuffer_helper.h
@@ -40,7 +40,8 @@ drm_gem_fb_create_with_dirty(struct drm_device *dev, struct drm_file *file,
 			     const struct drm_mode_fb_cmd2 *mode_cmd);
 
 int drm_gem_fb_vmap(struct drm_framebuffer *fb,
-		    struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES]);
+		    struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES],
+		    struct dma_buf_map data[DRM_FORMAT_MAX_PLANES]);
 void drm_gem_fb_vunmap(struct drm_framebuffer *fb,
 		       struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES]);
 int drm_gem_fb_begin_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir);

--- a/include/drm/drm_gem_framebuffer_helper.h
+++ b/include/drm/drm_gem_framebuffer_helper.h
@@ -1,6 +1,9 @@
 #ifndef __DRM_GEM_FB_HELPER_H__
 #define __DRM_GEM_FB_HELPER_H__
 
+#include <linux/dma-buf.h>
+#include <linux/dma-buf-map.h>
+
 struct drm_afbc_framebuffer;
 struct drm_device;
 struct drm_fb_helper_surface_size;
@@ -33,6 +36,9 @@ drm_gem_fb_create(struct drm_device *dev, struct drm_file *file,
 struct drm_framebuffer *
 drm_gem_fb_create_with_dirty(struct drm_device *dev, struct drm_file *file,
 			     const struct drm_mode_fb_cmd2 *mode_cmd);
+
+int drm_gem_fb_begin_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir);
+void drm_gem_fb_end_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir);
 
 #define drm_is_afbc(modifier) \
 	(((modifier) & AFBC_VENDOR_AND_TYPE_MASK) == DRM_FORMAT_MOD_ARM_AFBC(0))

--- a/include/drm/drm_gem_framebuffer_helper.h
+++ b/include/drm/drm_gem_framebuffer_helper.h
@@ -4,6 +4,8 @@
 #include <linux/dma-buf.h>
 #include <linux/dma-buf-map.h>
 
+#include <drm/drm_fourcc.h>
+
 struct drm_afbc_framebuffer;
 struct drm_device;
 struct drm_fb_helper_surface_size;
@@ -37,6 +39,10 @@ struct drm_framebuffer *
 drm_gem_fb_create_with_dirty(struct drm_device *dev, struct drm_file *file,
 			     const struct drm_mode_fb_cmd2 *mode_cmd);
 
+int drm_gem_fb_vmap(struct drm_framebuffer *fb,
+		    struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES]);
+void drm_gem_fb_vunmap(struct drm_framebuffer *fb,
+		       struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES]);
 int drm_gem_fb_begin_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir);
 void drm_gem_fb_end_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir);
 

--- a/include/drm/drm_gem_framebuffer_helper.h
+++ b/include/drm/drm_gem_framebuffer_helper.h
@@ -4,8 +4,6 @@
 #include <linux/dma-buf.h>
 #include <linux/dma-buf-map.h>
 
-#include <drm/drm_fourcc.h>
-
 struct drm_afbc_framebuffer;
 struct drm_device;
 struct drm_fb_helper_surface_size;
@@ -39,11 +37,9 @@ struct drm_framebuffer *
 drm_gem_fb_create_with_dirty(struct drm_device *dev, struct drm_file *file,
 			     const struct drm_mode_fb_cmd2 *mode_cmd);
 
-int drm_gem_fb_vmap(struct drm_framebuffer *fb,
-		    struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES],
-		    struct dma_buf_map data[DRM_FORMAT_MAX_PLANES]);
-void drm_gem_fb_vunmap(struct drm_framebuffer *fb,
-		       struct dma_buf_map map[static DRM_FORMAT_MAX_PLANES]);
+int drm_gem_fb_vmap(struct drm_framebuffer *fb, struct dma_buf_map *map,
+		    struct dma_buf_map *data);
+void drm_gem_fb_vunmap(struct drm_framebuffer *fb, struct dma_buf_map *map);
 int drm_gem_fb_begin_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir);
 void drm_gem_fb_end_cpu_access(struct drm_framebuffer *fb, enum dma_data_direction dir);
 


### PR DESCRIPTION
This PR is the "re-opened" PR <https://github.com/ctrliq/kernel-src-tree/pull/987> in which changes were requested after it was closed.

[LTS 8.6]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2025-38449</td>
<td class="org-left">VULN-136703</td>
</tr>
</tbody>
</table>


# Commits

    drm/gem: Provide drm_gem_fb_{begin,end}_cpu_access() helpers
    
    jira VULN-136703
    cve-pre CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit 37408cd825a47b89c2302b88ad3c071f796a2ec0

>

    drm: Define DRM_FORMAT_MAX_PLANES
    
    jira VULN-136703
    cve-pre CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit 279cc2e9543eb357c0ef299cf398b2e74a021f6b

>

    drm/gem: Provide drm_gem_fb_{vmap,vunmap}()
    
    jira VULN-136703
    cve-pre CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit f6424ecdb3c8aba18997a6992f780ab9c27734bc

>

    drm/gem: Clear mapping addresses for unused framebuffer planes
    
    jira VULN-136703
    cve-pre CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit 0ec77bd92b513aa4e556e5b92ccd993677d21cbc

>

    drm/gud: Map framebuffer BOs with drm_gem_fb_vmap()
    
    jira VULN-136703
    cve-pre CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit 0029d3182969d8dc67e4fedb00d6cf50eee74670
    upstream-diff Included drm/drm_gem_framebuffer_helper.h which was
      incorporated in 08b7ef0524f52cfd7f247270e0f95480709f210a on upstream,
      not backported to LTS 8.6. It was needed for the newly used functions
      `drm_gem_fb_vmap()' and `drm_gem_fb_vunmap()'

>

    drm/vkms: Map output framebuffer BOs with drm_gem_fb_vmap()
    
    jira VULN-136703
    cve-pre CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit 50fff206c5e3a04fcb239ad58d89cad166711b7f
    upstream-diff Included drm/drm_gem_atomic_helper.h in
      drivers/gpu/drm/vkms/vkms_drv.h, which was done on upstream in
      7602d4221842c12777363591df04672e2c8b6a61, not backported to LTS 8.6.
      It was needed for the definition of `dma_buf_map'.

>

    drm/gem: Provide offset-adjusted framebuffer BO mappings
    
    jira VULN-136703
    cve-pre CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit 43b36232ded23ce943224df3d1451f981446ae23

>

    drm/gem: Share code between drm_gem_fb_{begin,end}_cpu_access()
    
    jira VULN-136703
    cve-pre CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit f159b1b22c8a2d3d7c1fa877fafc8aacff0deeba

>

    drm/gem: Ignore color planes that are unused by framebuffer format
    
    jira VULN-136703
    cve-pre CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit 746b9c62cc8614fa59c23f3332682b5e9e1d801c
    upstream-diff |
      drivers/gpu/drm/drm_gem_atomic_helper.c
            The upstream change to `drm_gem_plane_helper_prepare_fb()' breaks
            the loop which was introduced in the non-backported commit
            1ea28bc5542d607ff7c806e409a72862c5af8f5e ("drm: handle kernel
            fences in drm_gem_plane_helper_prepare_fb v2"). Adapted it to
            cover the first plane only as it's present in the LTS 8.6
            codebase.
      drivers/gpu/drm/drm_gem_framebuffer_helper.c
            Used the existing `dma_buf_map' name of the struct instead of
            `iosys_map'. The struct renaming was done in
            7938f4218168ae9fc4bdddb15976f9ebbae41999 ("dma-buf-map: Rename to
            iosys-map"), missing from LTS 8.6. It cannot be backported due to
            its scope, also the change it introduces is purely syntactic and
            can be corrected for easily.
      include/drm/drm_gem_framebuffer_helper.h
            Same as above.

>

    drm/gem: Acquire references on GEM handles for framebuffers
    
    jira VULN-136703
    cve CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit 5307dce878d4126e1b375587318955bd019c3741
    upstream-diff In `drm_gem_object_handle_get_unlocked()' used
      `mutex_lock()' and `mutex_unlock()' instead of `guard()' - it was
      introduced in 54da6a0924311c7cf5015533991e44fb8eb12773 ("locking:
      Introduce __cleanup() based infrastructure"), not backported to LTS
      8.6.

>

    drm/framebuffer: Acquire internal references on GEM handles
    
    jira VULN-136703
    cve-bf CVE-2025-38449
    commit-author Thomas Zimmermann <tzimmermann@suse.de>
    commit f6bfc9afc7510cb5e6fbe0a17c507917b0120280
    upstream-diff Adapted `drm_gem_object_handle_get_unlocked()' (now
      `drm_gem_object_handle_get_if_exists_unlocked()') to use mutex_lock /
      mutex_unlock instead of guard(mutex). Resolved context conflicts in
      include/drm/drm_framebuffer.h due to missing
      bce3dab7eb6ee596388699e8a052a7d58954c472.


# Discussion


## Comparison with other versions

CVE-2025-38449 is solved on upstream with 5307dce878d4126e1b375587318955bd019c3741 `drm/gem: Acquire references on GEM handles for framebuffers` and comes with a bugfix f6bfc9afc7510cb5e6fbe0a17c507917b0120280 `drm/framebuffer: Acquire internal references on GEM handles`. These two commits were the basis of CVE solution for a number of Linux versions:

-   `ciqlts9_2`
    -   f45b60718f04e3a782a57f2b25e13121c20b203d Prerequisite (not really needed though)
    -   11f7a1eb1073ea5d6557d5a0d45c7544f27c8ac4 Fix
    -   6d1b009002ca1636b8976280b581029981f22714 Bugfix
-   `ciqlts9_4`
    -   ebe977a79659a61547d20ee73df62785d3c85d0a Fix
    -   5180601035c63ff970f6c5a701abdaf022f6b454 Bugfix
-   `ciqlts9_6`
    -   61a583adce2b72326eaaa36a1110e676a0c0a158 Fix (back-engineered)
    -   304da2d7727fcc997fd927d285d382f2dbaeeb98 Bugfix (back-engineered)
-   `rocky8_10`
    -   fbe9e9b5107f0737027c8f95671b8a0cb932567b Fix (back-engineered)
    -   743695cd545716b3b8e7ec91e1edd150287124d0 Bugfix (back-engineered)
-   `rocky10_0`
    -   8accf0be97279876a2337a49ca9a6c24295c35de Fix (back-engineered)
    -   21bcfe4dfb57c2544b5c2a2ba555e8350430f26a Bugfix (back-engineered)
-   `centos9`
    -   7f31889659208a90edca2405eba0a9b427681ed2 Fix
    -   0511ce9b8cdb5e5ccfca226a6a78c336810bd8eb Bugfix
-   `centos10`
    -   a24ee35d9f590b3888b256f7c08884c0a602569a Fix
    -   5817af921105003fc18ad3c37391e36a4a96d9b6 Bugfix
-   `linux-6.6.y`
    -   `cb4c956a15f8b7f870649454771fc3761f504b5f` Fix
    -   `2e2e9b3d708473040a08ab884f7dc2369752bb69` Bugfix
-   `linux-6.12.y`
    -   08480e285c6a82ce689008d643e4a51db0aaef8b Fix
    -   065bd940ee0a0033ea9a7dbb1a9110baef9415a4 Bugfix
-   `linux-6.15.y`
    -   `3cf520d9860d4ec9f7f32068825da31f18dd3f25` Fix
    -   `b5cc8e1e1cba7377f22f85ad7aefbe8efdf4f2ea` Bugfix

What **all** these versions have in common is the backported commit 746b9c62cc8614fa59c23f3332682b5e9e1d801c `drm/gem: Ignore color planes that are unused by framebuffer format` (directly or embedded in a larger update):

-   `ciqlts9_2`, `ciqlts9_4`, `ciqlts9_6`, `centos9`: 7a3deb5bcc6e380cde56b81a22fd32f5413c5ff7
-   `rocky8_10`: 8fe840b35a7226b11ee39118c54fbecdd8b8ab29
-   `rocky10_0`, `centos10`, `linux-6.6.y`, `linux-6.12.y`, `linux-6.15.y`: 746b9c62cc8614fa59c23f3332682b5e9e1d801c (native)

Version `ciqlts8_6` is missing this prerequisite.


## Prerequisite meaning

Both the CVE-2025-38449 fix 5307dce878d4126e1b375587318955bd019c3741 and its bugfix f6bfc9afc7510cb5e6fbe0a17c507917b0120280 modify (or introduce) code operating on frame buffer planes iterated in loops, which all follow the same pattern of indexing from `0` (inclusive) to `fb->format->num_planes` (exclusive), easily observable in the small `drm_gem_fb_destroy()` function:

<https://github.com/ctrliq/kernel-src-tree/blob/5307dce878d4126e1b375587318955bd019c3741/drivers/gpu/drm/drm_gem_framebuffer_helper.c#L97-L106>

The (dynamic) upper bound `fb->format->num_planes` is what was introduced by the prerequisite 746b9c62cc8614fa59c23f3332682b5e9e1d801c `drm/gem: Ignore color planes that are unused by framebuffer format`. Previously the loops were always iterated a fixed number of times. See the `drm_gem_fb_destroy()` function at revision 746b9c62cc8614fa59c23f3332682b5e9e1d801c~1 = f159b1b22c8a2d3d7c1fa877fafc8aacff0deeba:

<https://github.com/ctrliq/kernel-src-tree/blob/f159b1b22c8a2d3d7c1fa877fafc8aacff0deeba/drivers/gpu/drm/drm_gem_framebuffer_helper.c#L93-L102>

The compile-time upper bound parameterization wasn't even present until 279cc2e9543eb357c0ef299cf398b2e74a021f6b `drm: Define DRM_FORMAT_MAX_PLANES`. See the same function at revision 279cc2e9543eb357c0ef299cf398b2e74a021f6b~1 = 6e5b47a4f1dde38d42b054cc6d16b6840de08bd2 where the upper bound is hardcoded to `4`:

<https://github.com/ctrliq/kernel-src-tree/blob/6e5b47a4f1dde38d42b054cc6d16b6840de08bd2/drivers/gpu/drm/drm_gem_framebuffer_helper.c#L87-L96>

This version of the planes iterating loops is what can be found in `ciqlts8_6`.

While `drm: Define DRM_FORMAT_MAX_PLANES` was just a matter of code cohesion the `drm/gem: Ignore color planes that are unused by framebuffer format` introduced an actual, important behavior change. From the commit message:

> So far, several helpers assumed that all 4 planes are available and
> silently ignored non-existing planes. This lead to subtil bugs with
> uninitialized data in instances of struct iosys\_map. [1]

See <https://lore.kernel.org/dri-devel/20210730183511.20080-1-tzimmermann@suse.de/T/#md0172b10bb588d8f20f4f456e304f08d2a4505f7>.


## Necessity of the prerequisite backport

Cherry-picking the CVE-2025-38449 fix 5307dce878d4126e1b375587318955bd019c3741 directly onto `ciqlts8_6` did not cause conflicts for the loop upper bound in the `drm_gem_fb_init_with_funcs()` function, and in the `drm_gem_fb_destroy()` they may have been treated as context conflicts only, prompting to leave hardcoded `4` as it was. The bugfix f6bfc9afc7510cb5e6fbe0a17c507917b0120280, however, introduces new loops of this kind in the `drm_framebuffer_init()` function with the upper bound being `fb->format->num_planes` and not raising any conflicts whatsoever. This led to the consideration of four solutions:

1.  Leave `ciqlts8_6`-native upper bound `4` in the fix and `fb->format->num_planes` in the bugfix. This was very unlikely to result in correct code, introducing inconsistency in getting/putting object handles between the `drm_framebuffer_init()` function and all the rest.
2.  Change the upper bound in the bugfix to `4` to match the existing codebase. This also seemed risky, given that this bound was already problematic before the bugfix, and the bugfix itself was not prepared with the wider span of planes in mind - merely changing the number of iterations may not have been sufficient to obtain correct code. More involved fix altereation, in turn, was not possible due to lack of expertise in the `drm` subsystem.
3.  Leave out the bugfix altogether based on its possibly low importance. However, it was too difficult to assess the severity of the bug introduced by the CVE-2025-38449 fix based on the only discussion about it found at <https://lore.kernel.org/dri-devel/20250703115915.3096-1-spasswolf@web.de/#t>.
4.  Align the planes iterating loops in the `ciqlts8_6` codebase with the bugfix to use the `fb->format->num_planes` upper bound. This required sizable backporting, but seemed to be the least risky approach of all four, and was ultimately chosen as the proposed solution for CVE-2025-38449 on LTS 8.6.


## Changes overview

Let the commits be numbered as follows, starting from the oldest:

1.  `drm/gem: Provide drm_gem_fb_{begin,end}_cpu_access() helpers`
2.  `drm: Define DRM_FORMAT_MAX_PLANES`
3.  `drm/gem: Provide drm_gem_fb_{vmap,vunmap}()`
4.  `drm/gem: Clear mapping addresses for unused framebuffer planes`
5.  `drm/gud: Map framebuffer BOs with drm_gem_fb_vmap()`
6.  `drm/vkms: Map output framebuffer BOs with drm_gem_fb_vmap()`
7.  `drm/gem: Provide offset-adjusted framebuffer BO mappings`
8.  `drm/gem: Share code between drm_gem_fb_{begin,end}_cpu_access()`
9.  `drm/gem: Ignore color planes that are unused by framebuffer format`
10. `drm/gem: Acquire references on GEM handles for framebuffers`
11. `drm/framebuffer: Acquire internal references on GEM handles`

Commits (10) and (11) are the fix for CVE-2025-38449 and its bugfix, as the typical solutions in other versions. Commit (9) introduces the key change of setting the upper bound of the planes iterating loop to `fb->format->num_planes`. Commits (1) to (8) exist for the sole purpose of painless inclusion of (9) in the solution. In particular commit (2) provides the intermediary transition from the the number of planes hardcoded to `4` to parameterized `DRM_FORMAT_MAX_PLANES`.

For the commits (1) to (8) there are essentially no differences from the upstream. Technically (5) and (6) were modified, but the adaptations are functionally neutral, reduced to the inclusion of necessary headers, which were already in place for the upstream code, required by some previous changes, so the upstream commits didn't include them.

Upstream commit (9) assumes that 7938f4218168ae9fc4bdddb15976f9ebbae41999 `dma-buf-map: Rename to iosys-map` is in place. It is a very voluminous commit which would be difficult to backport and probably shouldn't be. Fortunately it's just a structure renaming, from `dma_buf_map` to `iosys_map`. The proposed backport of (9) kept the original `dma_buf_map` name. It was decided not to backport it to keep the growing size of the solution under control.

The CVE fix (10) was modified compared to the upstream in the same way as the `ciqlts9_2` backport 11f7a1eb1073ea5d6557d5a0d45c7544f27c8ac4 was - by using older synchronization scheme based on explicit `mutex_lock()` / `mutex_unlock()` instead of upstream's `guard()` construct. The bugfix (11) followed suit and included `mutex_unlock()` in the newly added exit branch, again, like in the `ciqlts9_2` bugfix 6d1b009002ca1636b8976280b581029981f22714.


## Consistency with `rocky8_10`

Analyzing the history of `rocky8_10` - closest version to `ciqlts8_6` where CVE-2025-38449 was fixed outside of CIQ - it can be seen that *all* prerequisites (1) to (9) were included in that version in the `Rebuild centos8 with kernel-4.18.0-448.el8` commit 8fe840b35a7226b11ee39118c54fbecdd8b8ab29. Even if some of them are not immediately visible in the changes it's only because they were altered / overriden by other mixed-in commits, often from the same batch of (1)-(9).

1.  `drm/gem: Provide drm_gem_fb_{begin,end}_cpu_access() helpers`: Changes present.
2.  `drm: Define DRM_FORMAT_MAX_PLANES`: Changes present, but altered by 746b9c62cc8614fa59c23f3332682b5e9e1d801c (9).
3.  `drm/gem: Provide drm_gem_fb_{vmap,vunmap}()`: Changes present, altered by 0ec77bd92b513aa4e556e5b92ccd993677d21cbc (4) and 7938f4218168ae9fc4bdddb15976f9ebbae41999.
4.  `drm/gem: Clear mapping addresses for unused framebuffer planes`: Changes present, altered by 746b9c62cc8614fa59c23f3332682b5e9e1d801c (9) and 7938f4218168ae9fc4bdddb15976f9ebbae41999.
5.  `drm/gud: Map framebuffer BOs with drm_gem_fb_vmap()`: Changes present, altered by 7938f4218168ae9fc4bdddb15976f9ebbae41999, 43b36232ded23ce943224df3d1451f981446ae23 (7), 6d463aaf5632ed9e409fcc72eb90f862341e4d95.
6.  `drm/vkms: Map output framebuffer BOs with drm_gem_fb_vmap()`: Changes present, altered by 2ca380ea0e6a31046b7c4048e3f61cfc2f6b2aa3, 7938f4218168ae9fc4bdddb15976f9ebbae41999, 43b36232ded23ce943224df3d1451f981446ae23 (7), bbdf7b2a0b0e69e4e18b5722341dfa6266d19390.
7.  `drm/gem: Provide offset-adjusted framebuffer BO mappings`: Changes present.
8.  `drm/gem: Share code between drm_gem_fb_{begin,end}_cpu_access()`: Changes present.
9.  `drm/gem: Ignore color planes that are unused by framebuffer format`: Changes present.

CentOS 8 underwent `drm` subsystem update which is a superset of the prerequisites included in this solution for CVE-2025-38449.


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts8_6-CVE-2025-38449]	_kabi_check_kernel__x86_64--test--ciqlts8_6-CVE-2025-38449
    ninja explain: output state/kernels/ciqlts8_6-CVE-2025-38449/x86_64/kabi_checked doesn't exist
    ninja explain: state/kernels/ciqlts8_6-CVE-2025-38449/x86_64/kabi_checked is dirty
    + dist_git_version=el-8.6
    + local_version=ciqlts8_6-CVE-2025-38449
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts8_6
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-8.6
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-2025-38449
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-8.6/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts8_6 ''\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-2025-38449/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2025-38449/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/26104169/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/26104170/kselftests--ciqlts8_6--run1.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2025-38449&#x2013;run1.log](<https://github.com/user-attachments/files/26104171/kselftests--ciqlts8_6-CVE-2025-38449--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2025-38449&#x2013;run2.log](<https://github.com/user-attachments/files/26104172/kselftests--ciqlts8_6-CVE-2025-38449--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff  kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6-CVE-2025-38449--run1.log
    Status2   kselftests--ciqlts8_6-CVE-2025-38449--run2.log
    
    TestCase                                     Status0  Status1  Status2  Summary
    android:run.sh                               skip     skip     skip     same
    bpf:get_cgroup_id_user                       pass     pass     pass     same
    bpf:test_bpftool.sh                          pass     pass     pass     same
    bpf:test_bpftool_build.sh                    pass     pass     pass     same
    bpf:test_bpftool_metadata.sh                 pass     pass     pass     same
    bpf:test_cgroup_storage                      pass     pass     pass     same
    bpf:test_dev_cgroup                          pass     pass     pass     same
    bpf:test_doc_build.sh                        pass     pass     pass     same
    bpf:test_flow_dissector.sh                   pass     pass     pass     same
    bpf:test_lirc_mode2.sh                       pass     pass     pass     same
    bpf:test_lpm_map                             pass     pass     pass     same
    bpf:test_lru_map                             pass     pass     pass     same
    bpf:test_lwt_ip_encap.sh                     pass     pass     pass     same
    bpf:test_lwt_seg6local.sh                    pass     pass     pass     same
    bpf:test_netcnt                              pass     pass     pass     same
    bpf:test_offload.py                          fail     fail     fail     same
    bpf:test_skb_cgroup_id.sh                    pass     pass     pass     same
    bpf:test_sock                                pass     pass     pass     same
    bpf:test_sock_addr.sh                        pass     pass     pass     same
    bpf:test_sysctl                              pass     pass     pass     same
    bpf:test_tag                                 pass     pass     pass     same
    bpf:test_tc_edt.sh                           pass     pass     pass     same
    bpf:test_tc_tunnel.sh                        pass     pass     pass     same
    bpf:test_tcp_check_syncookie.sh              pass     pass     pass     same
    bpf:test_tcpnotify_user                      pass     pass     pass     same
    bpf:test_tunnel.sh                           pass     pass     pass     same
    bpf:test_verifier                            pass     pass     pass     same
    bpf:test_verifier_log                        pass     pass     pass     same
    bpf:test_xdp_meta.sh                         pass     pass     pass     same
    bpf:test_xdp_redirect.sh                     pass     pass     pass     same
    bpf:test_xdp_veth.sh                         pass     pass     pass     same
    bpf:test_xdp_vlan_mode_generic.sh            pass     pass     pass     same
    bpf:test_xdp_vlan_mode_native.sh             pass     pass     pass     same
    bpf:test_xdping.sh                           pass     pass     pass     same
    bpf:urandom_read                             pass     pass     pass     same
    breakpoints:breakpoint_test                  pass     pass     pass     same
    capabilities:test_execve                     pass     pass     pass     same
    core:close_range_test                        pass     pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh               pass     pass     pass     same
    cpufreq:main.sh                              fail     fail     fail     same
    exec:execveat                                pass     pass     pass     same
    firmware:fw_run_tests.sh                     skip     skip     skip     same
    fpu:run_test_fpu.sh                          skip     skip     skip     same
    fpu:test_fpu                                 pass     pass     pass     same
    ftrace:ftracetest                            fail     fail     fail     same
    futex:run.sh                                 pass     pass     pass     same
    gpio:gpio-mockup.sh                          fail     fail     fail     same
    intel_pstate:run.sh                          pass     pass     pass     same
    ipc:msgque                                   pass     pass     pass     same
    kcmp:kcmp_test                               pass     pass     pass     same
    kexec:test_kexec_file_load.sh                skip     skip     skip     same
    kexec:test_kexec_load.sh                     skip     skip     skip     same
    kvm:access_tracking_perf_test                fail     fail     fail     same
    kvm:amx_test                                 fail     fail     fail     same
    kvm:cr4_cpuid_sync_test                      fail     fail     fail     same
    kvm:debug_regs                               fail     fail     fail     same
    kvm:demand_paging_test                       pass     pass     pass     same
    kvm:dirty_log_perf_test                      pass     pass     pass     same
    kvm:dirty_log_test                           fail     fail     fail     same
    kvm:emulator_error_test                      fail     fail     fail     same
    kvm:evmcs_test                               fail     fail     fail     same
    kvm:get_cpuid_test                           fail     fail     fail     same
    kvm:get_msr_index_features                   fail     fail     fail     same
    kvm:hardware_disable_test                    pass     pass     pass     same
    kvm:hyperv_clock                             fail     fail     fail     same
    kvm:hyperv_cpuid                             fail     fail     fail     same
    kvm:hyperv_features                          fail     fail     fail     same
    kvm:kvm_binary_stats_test                    pass     pass     pass     same
    kvm:kvm_create_max_vcpus                     skip     skip     skip     same
    kvm:kvm_page_table_test                      pass     pass     pass     same
    kvm:kvm_pv_test                              fail     fail     fail     same
    kvm:memslot_modification_stress_test         pass     pass     pass     same
    kvm:memslot_perf_test                        fail     fail     fail     same
    kvm:mmio_warning_test                        fail     fail     fail     same
    kvm:mmu_role_test                            fail     fail     fail     same
    kvm:platform_info_test                       fail     fail     fail     same
    kvm:rseq_test                                fail     fail     fail     same
    kvm:set_boot_cpu_id                          fail     fail     fail     same
    kvm:set_memory_region_test                   pass     pass     pass     same
    kvm:set_sregs_test                           fail     fail     fail     same
    kvm:smm_test                                 fail     fail     fail     same
    kvm:state_test                               fail     fail     fail     same
    kvm:steal_time                               pass     pass     pass     same
    kvm:svm_int_ctl_test                         fail     fail     fail     same
    kvm:svm_vmcall_test                          fail     fail     fail     same
    kvm:sync_regs_test                           fail     fail     fail     same
    kvm:tsc_msrs_test                            fail     fail     fail     same
    kvm:userspace_msr_exit_test                  fail     fail     fail     same
    kvm:vmx_apic_access_test                     fail     fail     fail     same
    kvm:vmx_close_while_nested_test              fail     fail     fail     same
    kvm:vmx_dirty_log_test                       fail     fail     fail     same
    kvm:vmx_nested_tsc_scaling_test              fail     fail     fail     same
    kvm:vmx_pmu_msrs_test                        fail     fail     fail     same
    kvm:vmx_preemption_timer_test                fail     fail     fail     same
    kvm:vmx_set_nested_state_test                fail     fail     fail     same
    kvm:vmx_tsc_adjust_test                      fail     fail     fail     same
    kvm:xapic_ipi_test                           fail     fail     fail     same
    kvm:xen_shinfo_test                          fail     fail     fail     same
    kvm:xen_vmcall_test                          fail     fail     fail     same
    kvm:xss_msr_test                             fail     fail     fail     same
    lib:bitmap.sh                                skip     skip     skip     same
    lib:prime_numbers.sh                         skip     skip     skip     same
    lib:printf.sh                                skip     skip     skip     same
    lib:scanf.sh                                 fail     fail     fail     same
    livepatch:test-callbacks.sh                  pass     pass     pass     same
    livepatch:test-ftrace.sh                     pass     pass     pass     same
    livepatch:test-livepatch.sh                  pass     pass     pass     same
    livepatch:test-shadow-vars.sh                pass     pass     pass     same
    livepatch:test-state.sh                      pass     pass     pass     same
    membarrier:membarrier_test_multi_thread      pass     pass     pass     same
    membarrier:membarrier_test_single_thread     pass     pass     pass     same
    memfd:memfd_test                             pass     pass     pass     same
    memfd:run_fuse_test.sh                       fail     fail     fail     same
    memfd:run_hugetlbfs_test.sh                  pass     pass     pass     same
    memory-hotplug:mem-on-off-test.sh            pass     pass     pass     same
    mount:run_tests.sh                           pass     pass     pass     same
    net/forwarding:bridge_port_isolation.sh      pass     pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh          pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh          fail     fail     fail     same
    net/forwarding:bridge_vlan_unaware.sh        pass     pass     pass     same
    net/forwarding:ethtool.sh                    fail     fail     fail     same
    net/forwarding:gre_multipath.sh              fail     fail     fail     same
    net/forwarding:ip6_forward_instats_vrf.sh    fail     fail     fail     same
    net/forwarding:ipip_flat_gre.sh              pass     pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh          pass     pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh         pass     pass     pass     same
    net/forwarding:ipip_hier_gre.sh              pass     pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh          pass     pass     pass     same
    net/forwarding:loopback.sh                   skip     skip     skip     same
    net/forwarding:mirror_gre.sh                 fail     fail     fail     same
    net/forwarding:mirror_gre_bound.sh           pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh       pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh       pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh   pass     pass     pass     same
    net/forwarding:mirror_gre_changes.sh         fail     fail     fail     same
    net/forwarding:mirror_gre_flower.sh          fail     fail     fail     same
    net/forwarding:mirror_gre_lag_lacp.sh        pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh           pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh              pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh            pass     pass     pass     same
    net/forwarding:mirror_vlan.sh                pass     pass     pass     same
    net/forwarding:router.sh                     fail     fail     fail     same
    net/forwarding:router_bridge.sh              pass     pass     pass     same
    net/forwarding:router_bridge_vlan.sh         pass     pass     pass     same
    net/forwarding:router_broadcast.sh           fail     fail     fail     same
    net/forwarding:router_multicast.sh           fail     fail     fail     same
    net/forwarding:router_multipath.sh           fail     fail     fail     same
    net/forwarding:router_vid_1.sh               pass     pass     pass     same
    net/forwarding:tc_chains.sh                  pass     pass     pass     same
    net/forwarding:tc_flower.sh                  pass     pass     pass     same
    net/forwarding:tc_flower_router.sh           pass     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh              pass     pass     pass     same
    net/forwarding:tc_shblocks.sh                pass     pass     pass     same
    net/forwarding:tc_vlan_modify.sh             pass     pass     pass     same
    net/forwarding:vxlan_asymmetric.sh           pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh  pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh  pass     pass     pass     same
    net/forwarding:vxlan_symmetric.sh            pass     pass     pass     same
    net/mptcp:diag.sh                            pass     pass     pass     same
    net/mptcp:mptcp_connect.sh                   pass     pass     pass     same
    net/mptcp:mptcp_sockopt.sh                   pass     pass     pass     same
    net/mptcp:pm_netlink.sh                      pass     pass     pass     same
    net:bareudp.sh                               pass     pass     pass     same
    net:devlink_port_split.py                    pass     pass     pass     same
    net:drop_monitor_tests.sh                    skip     skip     skip     same
    net:fcnal-test.sh                            pass     pass     pass     same
    net:fib-onlink-tests.sh                      pass     pass     pass     same
    net:fib_rule_tests.sh                        fail     fail     fail     same
    net:fib_tests.sh                             pass     pass     pass     same
    net:gre_gso.sh                               pass     pass     pass     same
    net:icmp_redirect.sh                         pass     pass     pass     same
    net:ip6_gre_headroom.sh                      pass     pass     pass     same
    net:ipv6_flowlabel.sh                        pass     pass     pass     same
    net:l2tp.sh                                  pass     pass     pass     same
    net:msg_zerocopy.sh                          fail     fail     fail     same
    net:netdevice.sh                             pass     pass     pass     same
    net:pmtu.sh                                  pass     pass     pass     same
    net:psock_snd.sh                             fail     fail     fail     same
    net:reuseaddr_conflict                       pass     pass     pass     same
    net:reuseport_bpf                            pass     pass     pass     same
    net:reuseport_bpf_cpu                        pass     pass     pass     same
    net:reuseport_bpf_numa                       pass     pass     pass     same
    net:reuseport_dualstack                      pass     pass     pass     same
    net:rtnetlink.sh                             skip     skip     skip     same
    net:run_afpackettests                        pass     pass     pass     same
    net:run_netsocktests                         pass     pass     pass     same
    net:rxtimestamp.sh                           pass     pass     pass     same
    net:so_txtime.sh                             fail     fail     fail     same
    net:test_bpf.sh                              pass     pass     pass     same
    net:test_vxlan_fdb_changelink.sh             pass     pass     pass     same
    net:tls                                      pass     pass     pass     same
    net:traceroute.sh                            pass     pass     pass     same
    net:udpgro.sh                                fail     fail     fail     same
    net:udpgro_bench.sh                          fail     fail     fail     same
    net:udpgso.sh                                pass     pass     pass     same
    net:veth.sh                                  fail     fail     fail     same
    net:vrf-xfrm-tests.sh                        pass     pass     pass     same
    netfilter:conntrack_icmp_related.sh          fail     fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh         fail     fail     fail     same
    netfilter:ipvs.sh                            skip     skip     skip     same
    netfilter:nft_flowtable.sh                   fail     fail     fail     same
    netfilter:nft_meta.sh                        pass     pass     pass     same
    netfilter:nft_nat.sh                         skip     skip     skip     same
    netfilter:nft_queue.sh                       skip     skip     skip     same
    nsfs:owner                                   pass     pass     pass     same
    nsfs:pidns                                   pass     pass     pass     same
    proc:fd-001-lookup                           pass     pass     pass     same
    proc:fd-002-posix-eq                         pass     pass     pass     same
    proc:fd-003-kthread                          pass     pass     pass     same
    proc:proc-loadavg-001                        pass     pass     pass     same
    proc:proc-self-map-files-001                 pass     pass     pass     same
    proc:proc-self-map-files-002                 fail     fail     fail     same
    proc:proc-self-syscall                       pass     pass     pass     same
    proc:proc-self-wchan                         pass     pass     pass     same
    proc:proc-uptime-001                         pass     pass     pass     same
    proc:proc-uptime-002                         pass     pass     pass     same
    proc:read                                    pass     pass     pass     same
    proc:setns-dcache                            fail     fail     fail     same
    pstore:pstore_post_reboot_tests              skip     skip     skip     same
    pstore:pstore_tests                          fail     fail     fail     same
    ptrace:peeksiginfo                           pass     pass     pass     same
    ptrace:vmaccess                              fail     fail     fail     same
    rseq:basic_percpu_ops_test                   pass     pass     pass     same
    rseq:basic_test                              pass     pass     pass     same
    rseq:param_test                              pass     pass     pass     same
    rseq:param_test_benchmark                    pass     pass     pass     same
    rseq:param_test_compare_twice                pass     pass     pass     same
    rseq:run_param_test.sh                       fail     fail     fail     same
    sgx:test_sgx                                 fail     fail     fail     same
    sigaltstack:sas                              pass     pass     pass     same
    size:get_size                                pass     pass     pass     same
    splice:default_file_splice_read.sh           pass     pass     pass     same
    static_keys:test_static_keys.sh              skip     skip     skip     same
    tc-testing:tdc.sh                            pass     pass     pass     same
    timens:clock_nanosleep                       pass     pass     pass     same
    timens:exec                                  pass     pass     pass     same
    timens:procfs                                pass     pass     pass     same
    timens:timens                                pass     pass     pass     same
    timens:timer                                 pass     pass     pass     same
    timens:timerfd                               pass     pass     pass     same
    timers:inconsistency-check                   fail     fail     fail     same
    timers:mqueue-lat                            pass     pass     pass     same
    timers:nanosleep                             pass     pass     pass     same
    timers:nsleep-lat                            fail     fail     fail     same
    timers:posix_timers                          pass     pass     pass     same
    timers:rtcpie                                pass     pass     pass     same
    timers:set-timer-lat                         fail     fail     fail     same
    timers:threadtest                            pass     pass     pass     same
    tpm2:test_smoke.sh                           fail     fail     fail     same
    tpm2:test_space.sh                           fail     fail     fail     same
    vm:run_vmtests                               fail     fail     fail     same
    x86:amx_64                                   fail     fail     fail     same
    x86:check_initial_reg_state_64               pass     pass     pass     same
    x86:corrupt_xstate_header_64                 pass     pass     pass     same
    x86:fsgsbase_64                              pass     pass     pass     same
    x86:fsgsbase_restore_64                      pass     pass     pass     same
    x86:ioperm_64                                pass     pass     pass     same
    x86:iopl_64                                  pass     pass     pass     same
    x86:mov_ss_trap_64                           pass     pass     pass     same
    x86:mpx-mini-test_64                         fail     fail     fail     same
    x86:protection_keys_64                       pass     pass     pass     same
    x86:sigaltstack_64                           pass     pass     pass     same
    x86:sigreturn_64                             pass     pass     pass     same
    x86:single_step_syscall_64                   pass     pass     pass     same
    x86:syscall_nt_64                            pass     pass     pass     same
    x86:sysret_rip_64                            pass     pass     pass     same
    x86:sysret_ss_attrs_64                       pass     pass     pass     same
    x86:test_mremap_vdso_64                      pass     pass     pass     same
    x86:test_vdso_64                             pass     pass     pass     same
    x86:test_vsyscall_64                         pass     pass     pass     same
    zram:zram.sh                                 pass     pass     pass     same

