### PR TITLE
[LTS 8.6] cifs: CVE-2023-53751

### DIFF
--- a/fs/cifs/cifs_debug.c
+++ b/fs/cifs/cifs_debug.c
@@ -609,10 +609,13 @@ static int cifs_stats_proc_show(struct seq_file *m, void *v)
 				server->fastest_cmd[j],
 				server->slowest_cmd[j]);
 		for (j = 0; j < NUMBER_OF_SMB2_COMMANDS; j++)
-			if (atomic_read(&server->smb2slowcmd[j]))
+			if (atomic_read(&server->smb2slowcmd[j])) {
+				spin_lock(&server->srv_lock);
 				seq_printf(m, "  %d slow responses from %s for command %d\n",
 					atomic_read(&server->smb2slowcmd[j]),
 					server->hostname, j);
+				spin_unlock(&server->srv_lock);
+			}
 #endif /* STATS2 */
 		list_for_each(tmp2, &server->smb_ses_list) {
 			ses = list_entry(tmp2, struct cifs_ses,

--- a/fs/cifs/cifs_debug.h
+++ b/fs/cifs/cifs_debug.h
@@ -95,19 +95,19 @@ do {									\
 
 #define cifs_server_dbg_func(ratefunc, type, fmt, ...)			\
 do {									\
-	const char *sn = "";						\
-	if (server && server->hostname)					\
-		sn = server->hostname;					\
+	spin_lock(&server->srv_lock);					\
 	if ((type) & FYI && cifsFYI & CIFS_INFO) {			\
 		pr_debug_ ## ratefunc("%s: \\\\%s " fmt,		\
-				      __FILE__, sn, ##__VA_ARGS__);	\
+				      __FILE__, server->hostname,	\
+				      ##__VA_ARGS__);			\
 	} else if ((type) & VFS) {					\
 		pr_err_ ## ratefunc("VFS: \\\\%s " fmt,			\
-				    sn, ##__VA_ARGS__);			\
+				    server->hostname, ##__VA_ARGS__);	\
 	} else if ((type) & NOISY && (NOISY != 0)) {			\
 		pr_debug_ ## ratefunc("\\\\%s " fmt,			\
-				      sn, ##__VA_ARGS__);		\
+				      server->hostname, ##__VA_ARGS__);	\
 	}								\
+	spin_unlock(&server->srv_lock);					\
 } while (0)
 
 #define cifs_server_dbg(type, fmt, ...)					\

--- a/fs/cifs/cifs_swn.c
+++ b/fs/cifs/cifs_swn.c
@@ -482,7 +482,7 @@ static int cifs_swn_store_swn_addr(const struct sockaddr_storage *new,
 static int cifs_swn_reconnect(struct cifs_tcon *tcon, struct sockaddr_storage *addr)
 {
 	/* Store the reconnect address */
-	mutex_lock(&tcon->ses->server->srv_mutex);
+	cifs_server_lock(tcon->ses->server);
 	if (!cifs_sockaddr_equal(&tcon->ses->server->dstaddr, addr)) {
 		int ret;
 
@@ -520,7 +520,7 @@ static int cifs_swn_reconnect(struct cifs_tcon *tcon, struct sockaddr_storage *a
 			tcon->ses->server->tcpStatus = CifsNeedReconnect;
 		spin_unlock(&GlobalMid_Lock);
 	}
-	mutex_unlock(&tcon->ses->server->srv_mutex);
+	cifs_server_unlock(tcon->ses->server);
 
 	return 0;
 }

--- a/fs/cifs/cifsencrypt.c
+++ b/fs/cifs/cifsencrypt.c
@@ -245,9 +245,9 @@ int cifs_verify_signature(struct smb_rqst *rqst,
 					cpu_to_le32(expected_sequence_number);
 	cifs_pdu->Signature.Sequence.Reserved = 0;
 
-	mutex_lock(&server->srv_mutex);
+	cifs_server_lock(server);
 	rc = cifs_calc_signature(rqst, server, what_we_think_sig_should_be);
-	mutex_unlock(&server->srv_mutex);
+	cifs_server_unlock(server);
 
 	if (rc)
 		return rc;
@@ -716,7 +716,7 @@ setup_ntlmv2_rsp(struct cifs_ses *ses, const struct nls_table *nls_cp)
 
 	memcpy(ses->auth_key.response + baselen, tiblob, tilen);
 
-	mutex_lock(&ses->server->srv_mutex);
+	cifs_server_lock(ses->server);
 
 	rc = cifs_alloc_hash("hmac(md5)",
 			     &ses->server->secmech.hmacmd5,
@@ -768,7 +768,7 @@ setup_ntlmv2_rsp(struct cifs_ses *ses, const struct nls_table *nls_cp)
 		cifs_dbg(VFS, "%s: Could not generate md5 hash\n", __func__);
 
 unlock:
-	mutex_unlock(&ses->server->srv_mutex);
+	cifs_server_unlock(ses->server);
 setup_ntlmv2_rsp_ret:
 	kfree(tiblob);
 

--- a/fs/cifs/cifsglob.h
+++ b/fs/cifs/cifsglob.h
@@ -580,6 +580,7 @@ inc_rfc1001_len(void *buf, int count)
 struct TCP_Server_Info {
 	struct list_head tcp_ses_list;
 	struct list_head smb_ses_list;
+	spinlock_t srv_lock;  /* protect anything here that is not protected */
 	int srv_count; /* reference counter */
 	/* 15 character server name + 0x20 16th byte indicating type = srv */
 	char server_RFC1001_name[RFC1001_NAME_LEN_WITH_NULL];

--- a/fs/cifs/cifsglob.h
+++ b/fs/cifs/cifsglob.h
@@ -26,6 +26,7 @@
 #include <linux/mm.h>
 #include <linux/mempool.h>
 #include <linux/workqueue.h>
+#include <linux/sched/mm.h>
 #include "cifs_fs_sb.h"
 #include "cifsacl.h"
 #include <crypto/internal/hash.h>
@@ -603,7 +604,8 @@ struct TCP_Server_Info {
 	unsigned int in_flight;  /* number of requests on the wire to server */
 	unsigned int max_in_flight; /* max number of requests that were on wire */
 	spinlock_t req_lock;  /* protect the two values above */
-	struct mutex srv_mutex;
+	struct mutex _srv_mutex;
+	unsigned int nofs_flag;
 	struct task_struct *tsk;
 	char server_GUID[16];
 	__u16 sec_mode;
@@ -694,6 +696,22 @@ struct TCP_Server_Info {
 	struct sockaddr_storage swn_dstaddr;
 #endif
 };
+
+static inline void cifs_server_lock(struct TCP_Server_Info *server)
+{
+	unsigned int nofs_flag = memalloc_nofs_save();
+
+	mutex_lock(&server->_srv_mutex);
+	server->nofs_flag = nofs_flag;
+}
+
+static inline void cifs_server_unlock(struct TCP_Server_Info *server)
+{
+	unsigned int nofs_flag = server->nofs_flag;
+
+	mutex_unlock(&server->_srv_mutex);
+	memalloc_nofs_restore(nofs_flag);
+}
 
 struct cifs_credits {
 	unsigned int value;

--- a/fs/cifs/connect.c
+++ b/fs/cifs/connect.c
@@ -130,6 +130,7 @@ static void reconn_set_next_dfs_target(struct TCP_Server_Info *server,
 				       struct dfs_cache_tgt_iterator **tgt_it)
 {
 	const char *name;
+	char *hostname;
 	int rc;
 
 	if (!cifs_sb || !cifs_sb->origin_fullpath)
@@ -147,13 +148,18 @@ static void reconn_set_next_dfs_target(struct TCP_Server_Info *server,
 
 	name = dfs_cache_get_tgt_name(*tgt_it);
 
-	kfree(server->hostname);
-
-	server->hostname = extract_hostname(name);
-	if (IS_ERR(server->hostname)) {
+	hostname = extract_hostname(name);
+	if (!IS_ERR(hostname)) {
+		spin_lock(&server->srv_lock);
+		kfree(server->hostname);
+		server->hostname = hostname;
+		spin_unlock(&server->srv_lock);
+	} else {
 		cifs_dbg(FYI,
 			 "%s: failed to extract hostname from target: %ld\n",
-			 __func__, PTR_ERR(server->hostname));
+			 __func__, PTR_ERR(hostname));
+		cifs_dbg(FYI, "%s: default to last target server: %s\n", __func__,
+			 server->hostname);
 	}
 
 	rc = reconn_set_ipaddr_from_hostname(server);
@@ -418,9 +424,7 @@ cifs_echo_request(struct work_struct *work)
 		goto requeue_echo;
 
 	rc = server->ops->echo ? server->ops->echo(server) : -ENOSYS;
-	if (rc)
-		cifs_dbg(FYI, "Unable to send echo request to server: %s\n",
-			 server->hostname);
+	cifs_server_dbg(FYI, "send echo request: rc = %d\n", rc);
 
 #ifdef CONFIG_CIFS_SWN_UPCALL
 	/* Check witness registrations */
@@ -1194,8 +1198,12 @@ static int match_server(struct TCP_Server_Info *server, struct smb3_fs_context *
 	if (!net_eq(cifs_net_ns(server), current->nsproxy->net_ns))
 		return 0;
 
-	if (strcasecmp(server->hostname, ctx->server_hostname))
+	spin_lock(&server->srv_lock);
+	if (strcasecmp(server->hostname, ctx->server_hostname)) {
+		spin_unlock(&server->srv_lock);
 		return 0;
+	}
+	spin_unlock(&server->srv_lock);
 
 	if (!match_address(server, addr,
 			   (struct sockaddr *)&ctx->srcaddr))
@@ -1343,6 +1351,7 @@ cifs_get_tcp_session(struct smb3_fs_context *ctx)
 	tcp_ses->lstrp = jiffies;
 	tcp_ses->compress_algorithm = cpu_to_le16(ctx->compression);
 	spin_lock_init(&tcp_ses->req_lock);
+	spin_lock_init(&tcp_ses->srv_lock);
 	INIT_LIST_HEAD(&tcp_ses->tcp_ses_list);
 	INIT_LIST_HEAD(&tcp_ses->smb_ses_list);
 	INIT_DELAYED_WORK(&tcp_ses->echo, cifs_echo_request);
@@ -1512,7 +1521,9 @@ cifs_setup_ipc(struct cifs_ses *ses, struct smb3_fs_context *ctx)
 	if (tcon == NULL)
 		return -ENOMEM;
 
+	spin_lock(&server->srv_lock);
 	scnprintf(unc, sizeof(unc), "\\\\%s\\IPC$", server->hostname);
+	spin_unlock(&server->srv_lock);
 
 	xid = get_xid();
 	tcon->ses = ses;

--- a/fs/cifs/connect.c
+++ b/fs/cifs/connect.c
@@ -4081,7 +4081,9 @@ int cifs_tree_connect(const unsigned int xid, struct cifs_tcon *tcon, const stru
 
 	if (!tcon->dfs_path) {
 		if (tcon->ipc) {
+			cifs_server_lock(server);
 			scnprintf(tree, MAX_TREE_SIZE, "\\\\%s\\IPC$", server->hostname);
+			cifs_server_unlock(server);
 			rc = ops->tree_connect(xid, tcon->ses, tree, tcon, nlsc);
 		} else {
 			rc = ops->tree_connect(xid, tcon->ses, tcon->treeName, tcon, nlsc);
@@ -4094,8 +4096,6 @@ int cifs_tree_connect(const unsigned int xid, struct cifs_tcon *tcon, const stru
 		goto out;
 	isroot = ref.server_type == DFS_TYPE_ROOT;
 	free_dfs_info_param(&ref);
-
-	extract_unc_hostname(server->hostname, &tcp_host, &tcp_host_len);
 
 	for (it = dfs_cache_get_tgt_iterator(&tl); it; it = dfs_cache_get_next_tgt(&tl, it)) {
 		bool target_match;
@@ -4114,10 +4114,13 @@ int cifs_tree_connect(const unsigned int xid, struct cifs_tcon *tcon, const stru
 
 		extract_unc_hostname(share, &dfs_host, &dfs_host_len);
 
+		cifs_server_lock(server);
+		extract_unc_hostname(server->hostname, &tcp_host, &tcp_host_len);
 		if (dfs_host_len != tcp_host_len
 		    || strncasecmp(dfs_host, tcp_host, dfs_host_len) != 0) {
 			cifs_dbg(FYI, "%s: %.*s doesn't match %.*s\n", __func__, (int)dfs_host_len,
 				 dfs_host, (int)tcp_host_len, tcp_host);
+			cifs_server_unlock(server);
 
 			rc = match_target_ip(server, dfs_host, dfs_host_len, &target_match);
 			if (rc) {
@@ -4129,7 +4132,8 @@ int cifs_tree_connect(const unsigned int xid, struct cifs_tcon *tcon, const stru
 				cifs_dbg(FYI, "%s: skipping target\n", __func__);
 				continue;
 			}
-		}
+		} else
+			cifs_server_unlock(server);
 
 		if (tcon->ipc) {
 			scnprintf(tree, MAX_TREE_SIZE, "\\\\%s\\IPC$", share);

--- a/fs/cifs/connect.c
+++ b/fs/cifs/connect.c
@@ -261,7 +261,7 @@ cifs_reconnect(struct TCP_Server_Info *server)
 
 	/* do not want to be sending data on a socket we are freeing */
 	cifs_dbg(FYI, "%s: tearing down socket\n", __func__);
-	mutex_lock(&server->srv_mutex);
+	cifs_server_lock(server);
 	if (server->ssocket) {
 		cifs_dbg(FYI, "State: 0x%x Flags: 0x%lx\n",
 			 server->ssocket->state, server->ssocket->flags);
@@ -291,7 +291,7 @@ cifs_reconnect(struct TCP_Server_Info *server)
 		mid_entry->mid_flags |= MID_DELETED;
 	}
 	spin_unlock(&GlobalMid_Lock);
-	mutex_unlock(&server->srv_mutex);
+	cifs_server_unlock(server);
 
 	cifs_dbg(FYI, "%s: issuing mid callbacks\n", __func__);
 	list_for_each_safe(tmp, tmp2, &retry_list) {
@@ -302,15 +302,15 @@ cifs_reconnect(struct TCP_Server_Info *server)
 	}
 
 	if (cifs_rdma_enabled(server)) {
-		mutex_lock(&server->srv_mutex);
+		cifs_server_lock(server);
 		smbd_destroy(server);
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 	}
 
 	do {
 		try_to_freeze();
 
-		mutex_lock(&server->srv_mutex);
+		cifs_server_lock(server);
 
 #ifdef CONFIG_CIFS_SWN_UPCALL
 		if (server->use_swn_dstaddr) {
@@ -352,7 +352,7 @@ cifs_reconnect(struct TCP_Server_Info *server)
 			rc = generic_ip_connect(server);
 		if (rc) {
 			cifs_dbg(FYI, "reconnect error %d\n", rc);
-			mutex_unlock(&server->srv_mutex);
+			cifs_server_unlock(server);
 			msleep(3000);
 		} else {
 			atomic_inc(&tcpSesReconnectCount);
@@ -364,7 +364,7 @@ cifs_reconnect(struct TCP_Server_Info *server)
 #ifdef CONFIG_CIFS_SWN_UPCALL
 			server->use_swn_dstaddr = false;
 #endif
-			mutex_unlock(&server->srv_mutex);
+			cifs_server_unlock(server);
 		}
 	} while (server->tcpStatus == CifsNeedReconnect);
 
@@ -1332,7 +1332,7 @@ cifs_get_tcp_session(struct smb3_fs_context *ctx)
 	init_waitqueue_head(&tcp_ses->response_q);
 	init_waitqueue_head(&tcp_ses->request_q);
 	INIT_LIST_HEAD(&tcp_ses->pending_mid_q);
-	mutex_init(&tcp_ses->srv_mutex);
+	mutex_init(&tcp_ses->_srv_mutex);
 	memcpy(tcp_ses->workstation_RFC1001_name,
 		ctx->source_rfc1001_name, RFC1001_NAME_LEN_WITH_NULL);
 	memcpy(tcp_ses->server_RFC1001_name,

--- a/fs/cifs/misc.c
+++ b/fs/cifs/misc.c
@@ -1123,8 +1123,10 @@ int match_target_ip(struct TCP_Server_Info *server,
 		goto out;
 	}
 
+	spin_lock(&cifs_tcp_ses_lock);
 	*result = cifs_match_ipaddr((struct sockaddr *)&server->dstaddr,
 				    &tipaddr);
+	spin_unlock(&cifs_tcp_ses_lock);
 	cifs_dbg(FYI, "%s: ip addresses match: %u\n", __func__, *result);
 	rc = 0;
 

--- a/fs/cifs/sess.c
+++ b/fs/cifs/sess.c
@@ -903,14 +903,14 @@ sess_establish_session(struct sess_data *sess_data)
 {
 	struct cifs_ses *ses = sess_data->ses;
 
-	mutex_lock(&ses->server->srv_mutex);
+	cifs_server_lock(ses->server);
 	if (!ses->server->session_estab) {
 		if (ses->server->sign) {
 			ses->server->session_key.response =
 				kmemdup(ses->auth_key.response,
 				ses->auth_key.len, GFP_KERNEL);
 			if (!ses->server->session_key.response) {
-				mutex_unlock(&ses->server->srv_mutex);
+				cifs_server_unlock(ses->server);
 				return -ENOMEM;
 			}
 			ses->server->session_key.len =
@@ -919,7 +919,7 @@ sess_establish_session(struct sess_data *sess_data)
 		ses->server->sequence_number = 0x2;
 		ses->server->session_estab = true;
 	}
-	mutex_unlock(&ses->server->srv_mutex);
+	cifs_server_unlock(ses->server);
 
 	cifs_dbg(FYI, "CIFS session established successfully\n");
 	spin_lock(&GlobalMid_Lock);

--- a/fs/cifs/smb1ops.c
+++ b/fs/cifs/smb1ops.c
@@ -49,10 +49,10 @@ send_nt_cancel(struct TCP_Server_Info *server, struct smb_rqst *rqst,
 	in_buf->WordCount = 0;
 	put_bcc(0, in_buf);
 
-	mutex_lock(&server->srv_mutex);
+	cifs_server_lock(server);
 	rc = cifs_sign_smb(in_buf, server, &mid->sequence_number);
 	if (rc) {
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 		return rc;
 	}
 
@@ -66,7 +66,7 @@ send_nt_cancel(struct TCP_Server_Info *server, struct smb_rqst *rqst,
 	if (rc < 0)
 		server->sequence_number--;
 
-	mutex_unlock(&server->srv_mutex);
+	cifs_server_unlock(server);
 
 	cifs_dbg(FYI, "issued NT_CANCEL for mid %u, rc = %d\n",
 		 get_mid(in_buf), rc);

--- a/fs/cifs/smb2pdu.c
+++ b/fs/cifs/smb2pdu.c
@@ -549,8 +549,10 @@ assemble_neg_contexts(struct smb2_negotiate_req *req,
 	} else
 		req->NegotiateContextCount = cpu_to_le16(4);
 
+	cifs_server_lock(server);
 	ctxt_len = build_netname_ctxt((struct smb2_netname_neg_context *)pneg_ctxt,
 					server->hostname);
+	cifs_server_unlock(server);
 	*total_len += ctxt_len;
 	pneg_ctxt += ctxt_len;
 

--- a/fs/cifs/smb2pdu.c
+++ b/fs/cifs/smb2pdu.c
@@ -1264,13 +1264,13 @@ SMB2_sess_establish_session(struct SMB2_sess_data *sess_data)
 	struct cifs_ses *ses = sess_data->ses;
 	struct TCP_Server_Info *server = cifs_ses_server(ses);
 
-	mutex_lock(&server->srv_mutex);
+	cifs_server_lock(server);
 	if (server->ops->generate_signingkey) {
 		rc = server->ops->generate_signingkey(ses);
 		if (rc) {
 			cifs_dbg(FYI,
 				"SMB3 session key generation failed\n");
-			mutex_unlock(&server->srv_mutex);
+			cifs_server_unlock(server);
 			return rc;
 		}
 	}
@@ -1278,7 +1278,7 @@ SMB2_sess_establish_session(struct SMB2_sess_data *sess_data)
 		server->sequence_number = 0x2;
 		server->session_estab = true;
 	}
-	mutex_unlock(&server->srv_mutex);
+	cifs_server_unlock(server);
 
 	cifs_dbg(FYI, "SMB2/3 session established successfully\n");
 	/* keep existing ses state if binding */

--- a/fs/cifs/smbdirect.c
+++ b/fs/cifs/smbdirect.c
@@ -1381,9 +1381,9 @@ void smbd_destroy(struct TCP_Server_Info *server)
 	log_rdma_event(INFO, "freeing mr list\n");
 	wake_up_interruptible_all(&info->wait_mr);
 	while (atomic_read(&info->mr_used_count)) {
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 		msleep(1000);
-		mutex_lock(&server->srv_mutex);
+		cifs_server_lock(server);
 	}
 	destroy_mr_list(info);
 

--- a/fs/cifs/transport.c
+++ b/fs/cifs/transport.c
@@ -790,7 +790,7 @@ cifs_call_async(struct TCP_Server_Info *server, struct smb_rqst *rqst,
 	} else
 		instance = exist_credits->instance;
 
-	mutex_lock(&server->srv_mutex);
+	cifs_server_lock(server);
 
 	/*
 	 * We can't use credits obtained from the previous session to send this
@@ -798,14 +798,14 @@ cifs_call_async(struct TCP_Server_Info *server, struct smb_rqst *rqst,
 	 * return -EAGAIN in such cases to let callers handle it.
 	 */
 	if (instance != server->reconnect_instance) {
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 		add_credits_and_wake_if(server, &credits, optype);
 		return -EAGAIN;
 	}
 
 	mid = server->ops->setup_async_request(server, rqst);
 	if (IS_ERR(mid)) {
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 		add_credits_and_wake_if(server, &credits, optype);
 		return PTR_ERR(mid);
 	}
@@ -836,7 +836,7 @@ cifs_call_async(struct TCP_Server_Info *server, struct smb_rqst *rqst,
 		cifs_delete_mid(mid);
 	}
 
-	mutex_unlock(&server->srv_mutex);
+	cifs_server_unlock(server);
 
 	if (rc == 0)
 		return 0;
@@ -1078,7 +1078,7 @@ compound_send_recv(const unsigned int xid, struct cifs_ses *ses,
 	 * of smb data.
 	 */
 
-	mutex_lock(&server->srv_mutex);
+	cifs_server_lock(server);
 
 	/*
 	 * All the parts of the compound chain belong obtained credits from the
@@ -1088,7 +1088,7 @@ compound_send_recv(const unsigned int xid, struct cifs_ses *ses,
 	 * handle it.
 	 */
 	if (instance != server->reconnect_instance) {
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 		for (j = 0; j < num_rqst; j++)
 			add_credits(server, &credits[j], optype);
 		return -EAGAIN;
@@ -1100,7 +1100,7 @@ compound_send_recv(const unsigned int xid, struct cifs_ses *ses,
 			revert_current_mid(server, i);
 			for (j = 0; j < i; j++)
 				cifs_delete_mid(midQ[j]);
-			mutex_unlock(&server->srv_mutex);
+			cifs_server_unlock(server);
 
 			/* Update # of requests on wire to server */
 			for (j = 0; j < num_rqst; j++)
@@ -1132,7 +1132,7 @@ compound_send_recv(const unsigned int xid, struct cifs_ses *ses,
 		server->sequence_number -= 2;
 	}
 
-	mutex_unlock(&server->srv_mutex);
+	cifs_server_unlock(server);
 
 	/*
 	 * If sending failed for some reason or it is an oplock break that we
@@ -1337,11 +1337,11 @@ SendReceive(const unsigned int xid, struct cifs_ses *ses,
 	   and avoid races inside tcp sendmsg code that could cause corruption
 	   of smb data */
 
-	mutex_lock(&server->srv_mutex);
+	cifs_server_lock(server);
 
 	rc = allocate_mid(ses, in_buf, &midQ);
 	if (rc) {
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 		/* Update # of requests on wire to server */
 		add_credits(server, &credits, 0);
 		return rc;
@@ -1349,7 +1349,7 @@ SendReceive(const unsigned int xid, struct cifs_ses *ses,
 
 	rc = cifs_sign_smb(in_buf, server, &midQ->sequence_number);
 	if (rc) {
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 		goto out;
 	}
 
@@ -1363,7 +1363,7 @@ SendReceive(const unsigned int xid, struct cifs_ses *ses,
 	if (rc < 0)
 		server->sequence_number -= 2;
 
-	mutex_unlock(&server->srv_mutex);
+	cifs_server_unlock(server);
 
 	if (rc < 0)
 		goto out;
@@ -1479,18 +1479,18 @@ SendReceiveBlockingLock(const unsigned int xid, struct cifs_tcon *tcon,
 	   and avoid races inside tcp sendmsg code that could cause corruption
 	   of smb data */
 
-	mutex_lock(&server->srv_mutex);
+	cifs_server_lock(server);
 
 	rc = allocate_mid(ses, in_buf, &midQ);
 	if (rc) {
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 		return rc;
 	}
 
 	rc = cifs_sign_smb(in_buf, server, &midQ->sequence_number);
 	if (rc) {
 		cifs_delete_mid(midQ);
-		mutex_unlock(&server->srv_mutex);
+		cifs_server_unlock(server);
 		return rc;
 	}
 
@@ -1503,7 +1503,7 @@ SendReceiveBlockingLock(const unsigned int xid, struct cifs_tcon *tcon,
 	if (rc < 0)
 		server->sequence_number -= 2;
 
-	mutex_unlock(&server->srv_mutex);
+	cifs_server_unlock(server);
 
 	if (rc < 0) {
 		cifs_delete_mid(midQ);


### PR DESCRIPTION
[LTS 8.6]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2023-53751</td>
<td class="org-left">VULN-169227</td>
</tr>
</tbody>
</table>


# Background

From <https://github.com/ctrliq/kernel-src-tree/pull/431>:

> CIFS (Common Internet File System) is basically a different name for Microsoft's SMB (Server Message Block) protocol, allowing for sharing files and printers on the network. Functionality-wise CIFS is the same as more Linux-native NFS system. From the practical perspective, using the CIFS module boils down to mounting appropriately addressed remote "share" at a local directory.


# Commits

    cifs: fix potential deadlock in direct reclaim
    
    jira VULN-169227
    cve-pre CVE-2023-53751
    commit-author Vincent Whitchurch <vincent.whitchurch@axis.com>
    commit cc391b694ff085f62f133e6b8f864d43a8e69dfd
    upstream-diff |
      Multiple differences across many files due to large discrepancies
      between upstream and LTS 8.6, HOWEVER, the commit was obtained in the
      exact same way as on upstream, namely:
      1. locating all usages of `TCP_Server_Info::srv_mutex',
      2. changing all `mutex_lock(&<server_ptr>->srv_mutex)' to
         `cifs_server_lock(<server_ptr>)',
      3. changing all `mutex_unlock(&<server_ptr>->srv_mutex)' to
         `cifs_server_unlock(<server_ptr>)',
      4. renaming `srv_mutex~' to `_srv_mutex' to make sure nothing was
         missed.
      In this regard the commit doesn't differ from the upstream.

>

    cifs: fix race in assemble_neg_contexts()
    
    jira VULN-169227
    cve CVE-2023-53751
    commit-author Paulo Alcantara <pc@cjr.nz>
    commit 775e44d6d86dca400d614cbda5dab4def4951fe7
    upstream-diff Ignored the introduction of `pserver' variable, as well as
      the usage of `hostname' local, as they were only needed in the upstream
      because of the dual source of the server hostname, introduced in the
      non-backported commit 9de74996a739bf0b7b5d8c260bd207ad6007442b ("smb3:
      use netname when available on secondary channels")

>

    cifs: protect access of TCP_Server_Info::{dstaddr,hostname}
    
    jira VULN-169227
    cve CVE-2023-53751
    commit-author Paulo Alcantara <pc@cjr.nz>
    commit 39a154fc2d172a3a5865e5a9fa2a2983eb7a99ac
    upstream-diff Manually obtained commit. Upstream fixes appear in
      multiple places, but they all cover only the `cifs_tree_connect()'
      function (the CONFIG_CIFS_DFS_UPCALL=y variant) and its call tree. Same
      goes for the backported version, taking into account the lack of a major
      function rewrite in c88f7dcd6d6429197fc2fd87b54a894ffcd48e8e ("cifs:
      support nested dfs links over reconnect").
      Upstream call tree at the moment of the fix and the changes at each
      level:
        cifs_tree_connect()
              Put `cifs_server_{lock/unlock}(server)' around `scnprintf(...,
              server->hostname);' call.
        tree_connect_dfs_target()
              No changes.
        __tree_connect_dfs_target()
              Removed `extract_unc_hostname(server->hostname, ...)' call, used
              full `server->hostname' instead of its substring `tcp_host'.
        target_share_matches_server()
              Put `cifs_server_{lock/unlock}(server)' around
              `server->hostname' accesses in conditional expression and debug
              message composition before the `match_target_ip()' call.
        match_target_ip()
              Put `spin_{lock/unlock}(&server->srv_lock)' around
              `cifs_match_ipaddr(...server->dstaddr, ....)' call.
      Backported version call tree:
        cifs_tree_connect()
              - Put `cifs_server_{lock/unlock}(server)' around `scnprintf(...,
                server->hostname)' call - like in the upstream.
              - Put `cifs_server_{lock/unlock}(server)' around
                `server->hostname' (and its substring `tcp_host') access in
                conditional expression and debug message composition before
                the `match_target_ip()' call - like in the upstream. This
                required moving the `extract_unc_hostname()' call inside the
                loop. Unlike in the upstream it was not removed entirely,
                opting for functional equivalence between the patched and
                non-patched version instead of strictly preserving backported
                commit's changes; perhaps at the time of the upstream fix the
                equality `server->hostname' = `tcp_host' held true, allowing
                for the reduction of `extract_unc_hostname()' call, but that
                was not certain for the ciqlts8_6 version. If it wasn't true
                then the commit mixed a bugfix with a functional change which
                was simply filtered out here. Moving `extract_unc_hostname()'
                call inside the loop did not create any algorithmic
                inconsistencies which weren't already present (if any), merely
                preventing them from ending in bad memory access. In the
                upstream the value of `server->hostname' isn't saved to remain
                constant for all loop iterations in the
                `__tree_connect_dfs_target()' function either. A ngeligible
                performance penalty associated with the calculation redundancy
                was accepted given the simplicity of the fix it allowed.
        match_target_ip()
              Put `spin_{lock/unlock}(&cifs_tcp_ses_lock)' around the
              `cifs_match_ipaddr(...server->dstaddr, ...)' call - like in the
              upstream, except for the `cifs_tcp_ses_lock' instead of
              `server->srv_lock'. The latter was introduced in the
              non-backported commit d7d7a66aacd6fd8ca57baf08a7bac5421282f6f8
              ("cifs: avoid use of global locks for high contention
              data"). The same pattern of protecting `server->dstaddr' with
              `cifs_tcp_ses_lock' can be observed in ciqlts8_6 in the
              `reconn_set_ipaddr_from_hostname()' function.

>

    cifs: fix potential use-after-free bugs in TCP_Server_Info::hostname
    
    jira VULN-169227
    cve CVE-2023-53751
    commit-author Paulo Alcantara <pc@manguebit.com>
    commit 90c49fce1c43e1cc152695e20363ff5087897c09
    upstream-diff |
      fs/cifs/cifsglob.h
            Added `srv_lock' to the `TCP_Server_Info' struct as it was done in
            the non-backported commit d7d7a66aacd6fd8ca57baf08a7bac5421282f6f8
            ("cifs: avoid use of global locks for high contention data").
      fs/cifs/cifs_debug.c
            Ignored changes in `cifs_debug_data_proc_show()' because the code
            using `hostname' was only added in the non-backported commit
            40f077a02bf9d70719128d2a807e28a3503711eb ("cifs: clarify hostname
            vs ip address in /proc/fs/cifs/DebugData").
      fs/cifs/connect.c
            - Changed the `reconn_set_next_dfs_target()' function instead of
              `__reconnect_target_unlocked()' which doesn't exist in LTS
              8.6. The `__reconnect_target_unlocked()' is where the `hostname'
              is "updated once or many times during reconnect" (see original
              commit message). The "reconnect" refers to the function
              `cifs_reconnect()', which calls `__reconnect_target_unlocked()'
              on a third level down the call tree.  Relative to LTS 8.6 the
              `cifs_reconnect()' underwent major rewrites in the commits
              bbcce368044572d0802c3bbb8ef3fe98f581d803 ("cifs: split out dfs
              code from cifs_reconnect()") and
              c88f7dcd6d6429197fc2fd87b54a894ffcd48e8e ("cifs: support nested
              dfs links over reconnect"). In LTS 8.6 the updating of
              `hostname' can be tracked down to the
              `reconn_set_next_dfs_target()' function called by
              `cifs_reconnect()'. Apart from guarding the `server->hostname'
              value change some elements of the commit bbcce3680 were included
              as well:
              - Used helper local variable `hostname' to store the value of
                `extract_hostname()' to avoid calling it while locked, which
                could lead to a schedule while atomic.
              - Avoided assigning to `server->hostname' the result of
                `extract_hostname()' call in case it ended with
                error. Otherwise `server->hostname' would contain
                rubbish. Added a debug message informing about that case.
            - Added initialization of `TCP_Server_Info::srv_lock' in
              `cifs_get_tcp_session()' as it's done in d7d7a66aa.
            - In `match_server()' sandwiched the `strcasecmp(server->hostname,
              ...)' call in the lock/unlock pair of `server->srv_lock',
              because in LTS 8.6 the `match_server()' is not called with the
              `server->srv_lock' held and yet this is the lock chosen to
              protect the `server->hostname' field.
      fs/cifs/sess.c
            Ignored changes in `cifs_try_adding_channels()' because the code
            using `hostname' was only added in the non-backported commit
            9c2dc11df50d1c8537075ff6b98472198e24438e ("smb3: do not attempt
            multichannel to server which does not support it"). As a result no
            changes to the file have been made.


# Discussion


## Overview

The official CVE-2023-53751 fix is just the last commit `cifs: fix potential use-after-free bugs in TCP_Server_Info::hostname`. However, the discrepancies between the upstream at the moment of that fix and LTS 8.6 were too large for cherry-picking to make any sense and the changes had to be done manually. This, in turn, prompted tracking of [all `TCP_Server_Info::hostname` usages](#org1ea6248), as locking problems require global awareness of the synchronized data usage to be done correctly. This led to the discovery of two other fixes addressing the exact same issue, which is a possible usage of `hostname` after it was freed during connection re-establishment:

-   `cifs: fix race in assemble_neg_contexts()`,
-   `cifs: protect access of TCP_Server_Info::{dstaddr,hostname}`.

As such they were included as part of CVE-2023-53751 fix too. The three commits are preceded by `cifs: fix potential deadlock in direct reclaim` serving as prerequisite. Coincidentally it also fixes a synchronization issue, although not related to CVE-2023-53751.


## Threads

While the exact threading layout in `cifs` module was not established, a key piece of information can be found in commit dca65818c80cf06e0f08ba2cf94060a5236e73c2:

<https://github.com/ctrliq/kernel-src-tree/blob/dca65818c80cf06e0f08ba2cf94060a5236e73c2/fs/cifs/connect.c#L168-L169>

The `cifs_reconnect()` function is a key player in CVE-2023-53751 issue, modifying the `TCP_Server_Info::hostname` field while other threads read it. While it wasn't backported to LTS 8.6 it references a "last patch"

> The last patch attempted to use the same helper function for
> both types of threads, but that causes other issues
> with lock dependencies.

most likely the `Fixes` commit 2a05137a0575b7d1006bdf4c1beeee9e391e22a0, which wasn't backported either. This suggests that the `cifs_reconnect()` being used only by a single "cifsd" thread applies to LTS 8.6 as well. This explains why some `server->hostname` readings on the [references list](#org1ea6248) remain (and should remain) unguarded - they all hang on the `cifs_reconnect()` call tree.


## Commits discussion

The following sections aim to complement the `upstream-diff` info, providing additional context, explanations, analysis, rationale, alternative solutions, etc.

The entirety of synchronization analysis carried out was based on the assumption that all the corresponding locking / unlocking pairs can be found in the same function. It would be infeasible otherwise. Fortunately the `cifs` module seems to be following that convention.


### `cifs: fix potential deadlock in direct reclaim`

The change seems extensive but it's conceptually simple: instead of using raw `mutex_lock()` / `mutex_unlock()` pairs use `cifs_server_lock()` / `cifs_server_unlock()` functions, which are newly introduced wrappers around `mutex_lock()` / `mutex_unlock()`. What they add is starting / ending the `GFP_NOFS` allocation scope:

<https://github.com/ctrliq/kernel-src-tree/blob/5cdfabb7e98774a4a28c5ffa4d75075899b326ca/include/linux/gfp.h#L235>

Without it a memory allocation within the mutex span cuold trigger direct reclaim and page writeback to a remote CIFS volume, which in turn would try to acquire the same mutex lock that is already held and cause a deadlock, see <https://lore.kernel.org/all/20220523123755.GA13668@axis.com/>:

> The crypto shash allocation does allocations with GFP\_KERNEL (i.e.,
> GFP\_NOFS is not set and so fs reclaim can be triggered) and this is
> called under the CIFS srv\_mutex.  However, the CIFS srv\_mutex is also
> used in the reclaim path as the splat shows.  This is the dependency
> which lockdep is complaining about.

The `cifs_server_lock()` / `cifs_server_unlock()` functions are used by other commits in the proposed solution. Backporting `cifs: fix potential deadlock in direct reclaim` helps to avoid the dillemma of either introducing new, potentially deadlocking code paths, or juggling the `nofs` flag ad hoc for each place the mutex is acquired / freed.


<a id="org6970886"></a>

### `cifs: fix race in assemble_neg_contexts()`

The LTS 8.6 codebase allowed for considerable simplification of the change, explained sufficiently in the `upstream-diff`. Apart from that three questions deserve to be addressed.

1.  Is the writing of `server->hostname` protected by the `server->srv_mutex` in LTS 8.6?

    It is. The main area of concern for writing `TCP_Server_Info::hostname` is [reconn\_set\_next\_dfs\_target()](#org092a576). It's called from [cifs\_reconnect()](#org3dc9e68) (and only there) at 
    
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L328>
    
    This call is surrounded by
    
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L313>
    
    and one of 
    
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L355>
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L367>
    
    Writing done by [cifs\_put\_tcp\_session()](#org38676b8) is not protected by the mutex, but neither it is on upstream. This function most likely marks the end of any `TCP_Server_Info` object usage.

2.  Is the LTS 8.6 version of `assemble_neg_contexts()` always called outside of `server->srv_mutex` lock?

    It is. The only `assemble_neg_contexts()` call can be found in the `SMB2_negotiate()` function at
    
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/smb2pdu.c#L850>
    
    The `SMB2_negotiate()`, in turn, is only called in `smb2_negotiate()` at
    
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/smb2ops.c#L349>
    
    No `srv_mutex` locking to be found in either of these functions. The `smb2_negotiate()` itself is an external operation
    
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/smb2ops.c#L5129>
    
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/smb2ops.c#L5228>
    
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/smb2ops.c#L5330>
    
    <https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/smb2ops.c#L5443>
    
    so unlikely to be called with the cifs-specific mutex held.

3.  Does the LTS 8.6 version of `build_netname_ctxt()` never lock the `server->srv_mutex` lock?

    It doesn't lock `server->srv_mutex`.
    
    The call tree:
    
    -   `build_netname_ctxt()` (`fs/nls/nls_base.c`): no locks
        -   `load_nls_default()` (`fs/nls/nls_base.c`): no locks
            -   `load_nls()` (`fs/nls/nls_base.c`): no locks
                -   `find_nls()` (`fs/nls/nls_base.c`): no locks
                    -   `try_module_get()` (`kernel/module.c`) function outside of `cifs` module, no cifs locks expected to be used.
                -   `try_then_request_module()` (`include/linux/kmod.h`): function outside of `cifs` module, no cifs locks expected to be used.
        -   `cifs_strtoUTF16()` (`fs/cifs/cifs_unicode.c`): string-related utility, unlikely to use any locks.
        -   `cpu_to_le16()` (`include/linux/byteorder/generic.h`) big endian / little endian calculations outside of `cifs`.


<a id="org3e3e495"></a>

### `cifs: protect access of TCP_Server_Info::{dstaddr,hostname}`

The upstream fix addresses the reads of `hostname` in the `cifs_tree_connect()` function and its subroutine `target_share_matches_server()`. The latter is basically a portion of code extracted from `cifs_tree_connect()` in the non-backported commit c88f7dcd6d6429197fc2fd87b54a894ffcd48e8e. That commit involves more changes to `cifs_tree_connect()`, transforming it from the LTS 8.6 call tree:

-   `cifs_tree_connect()` (`fs/cifs/connect.c`)
    -   `match_target_ip()` (`fs/cifs/misc.c`)

into:

-   `cifs_tree_connect()` (`fs/cifs/connect.c`)
    -   `tree_connect_dfs_target()` (`fs/cifs/dfs.c`)
        -   `__tree_connect_dfs_target()` (`fs/cifs/dfs.c`)
            -   `target_share_matches_server()` (`fs/cifs/dfs.c`)
                -   `match_target_ip()` (`fs/cifs/misc.c`)

(with functions narrowed down to those relevant to the fix).

The body of `target_share_matches_server()` from before the 39a154fc2d172a3a5865e5a9fa2a2983eb7a99ac fix

<https://github.com/ctrliq/kernel-src-tree/blob/775e44d6d86dca400d614cbda5dab4def4951fe7/fs/cifs/dfs.c#L338-L347>

corresponds to this LTS 8.6 fragment of the `cifs_tree_connect()` function:

<https://github.com/ctrliq/kernel-src-tree/blob/81026fbf043acfcce950cb0f559853d89701ab36/fs/cifs/connect.c#L4115-L4126>

The modified fragment of the `__tree_connect_dfs_target()` function, in turn

<https://github.com/ctrliq/kernel-src-tree/blob/775e44d6d86dca400d614cbda5dab4def4951fe7/fs/cifs/dfs.c#L366-L397>

corresponds roughly to this LTS 8.6 fragment of `cifs_tree_connect()` (encapsulating the previous one):

<https://github.com/ctrliq/kernel-src-tree/blob/81026fbf043acfcce950cb0f559853d89701ab36/fs/cifs/connect.c#L4098-L4132>

The upstream fix does not merely wrap the `hostname` usage with the `TCP_Server_Info::srv_mutex` lock, but also changes the functional semantics by comparing `dfs_host` with `server->hostname` directly instead of `tcp_host`. This functional change was omitted in the backport.

From the memory access synchronization perspective it's important to remember that `tcp_host` shares memory with `server->hostname` (see definition of `extract_unc_hostname()`), so it's not enough to just protect this single line

<https://github.com/ctrliq/kernel-src-tree/blob/81026fbf043acfcce950cb0f559853d89701ab36/fs/cifs/connect.c#L4098>

but all code execution paths starting from the `server->hostname` read to the last usage of `tcp_host`. This is what motivated moving the `extract_unc_hostname()` call inside the loop in the backported version. The alternative solutions considered were to either

1.  allocate a local copy of `server->hostname`, or
2.  guard the whole loop.

The first option was rejected as deviating too much from the upstream fix, at least compared to the eventually proposed solution. There was also no such code pattern found in the `cifs` module anywhere. The second option was rejected as deviating too much from the upstream as well - there might have been a reason in the upstream to lock the `hostname` access on a per-iteration basis.

Apart from protecting `TCP_Server_Info::hostname` the upstream fix also puts protection over `TCP_Server_Info::dstaddr`. While it's not part of the CVE-2023-53751 issue, the change was included for the sake of backport fidelity to the upstream. The `TCP_Server_Info::srv_lock` could not have been used, as it was introduced in the non-backported commit d7d7a66aacd6fd8ca57baf08a7bac5421282f6f8 `cifs: avoid use of global locks for high contention data`. (This lock was eventually included in the next commit [cifs: fix potential use-after-free bugs in TCP\_Server\_Info::hostname](#org4884c9d), but for a very specific function and could not work in this case.) The usage of `cifs_tcp_ses_lock` was motivated by the existence of this, `ciqlts8_6`-native, very similar code snippet:

<https://github.com/ctrliq/kernel-src-tree/blob/81026fbf043acfcce950cb0f559853d89701ab36/fs/cifs/connect.c#L116-L119>


<a id="org4884c9d"></a>

### `cifs: fix potential use-after-free bugs in TCP_Server_Info::hostname`

The main problem with backporting this commit was that it was based on using `TCP_Server_Info::srv_lock` lock not present in LTS 8.6. It was introduced in a large commit d7d7a66aacd6fd8ca57baf08a7bac5421282f6f8 `cifs: avoid use of global locks for high contention data` rewriting most of the spin locks used in the `cifs` module. Backporting it as prerequisite was not an option, as it is too extensive, too conflicting with LTS 8.6 codebase and dealing with too delicate matter.

In that commit, among other changes, most of the usages of `cifs_tcp_ses_lock` were offloaded to the newly introduced `cifs_tcon::tc_lock`, `cifs_ses::ses_lock` and `TCP_Server_Info::srv_lock`. At the same time the `TCP_Server_Info::srv_lock` was not used in place of any lock other than `cifs_tcp_ses_lock` (in particular not the `GlobalMid_Lock` - another de-loaded lock in that commit). As such the `TCP_Server_Info::srv_lock` became a "sub-lock" of the more general `cifs_tcp_ses_lock` used before, and in LTS 8.6. Naturally, using `cifs_tcp_ses_lock` instead of `srv_lock` was considered when backporting 90c49fce1c43e1cc152695e20363ff5087897c09.

Unfortunately the backported commit locks `srv_lock` in the `cifs_server_dbg_func()` macro, which - through the `cifs_server_dbg()` wrapper - is used quite extensively in the `cifs` module (78 references of `cifs_server_dbg()` found). Changing `srv_lock` to `cifs_tcp_ses_lock` required tracking all callers of the macro (and their callers, and so on) for whether they don't call it with the `cifs_tcp_ses_lock` locked already, or a deadlock would occur. As it turned out during the process there **was** at least one function which required changing, see 

<https://github.com/ctrliq/kernel-src-tree/blob/81026fbf043acfcce950cb0f559853d89701ab36/fs/cifs/smb2transport.c#L94-L147>

Given the extent of the work required, and the proven necessity of it, the attempt at using `cifs_tcp_ses_lock` instead of `srv_lock` in the backport was abandoned.

Instead the `TCP_Server_Info::srv_lock` was introduced as in d7d7a66aacd6fd8ca57baf08a7bac5421282f6f8, with its usages reduced to the extent of the 90c49fce1c43e1cc152695e20363ff5087897c09 backport only. This was perfectly enough for the CVE-2023-53751 fix to serve its purpose, as the commit was self-contained, in the sense, that:

-   no spinlock writing protection of `TCP_Server_Info::hostname` existed in LTS 8.6 before the fix, and
-   no spinlock reading protection of `TCP_Server_Info::hostname` existed in LTS 8.6 before the fix.

If that was not the case the other protection places would have to be aligned with the backported commit to also use the newly introduced `TCP_Server_Info::srv_lock`. (There were, of course, `hostname` writing protections in place already, upon which [cifs: protect access of TCP\_Server\_Info::{dstaddr,hostname}](#org3e3e495) and [cifs: fix race in assemble\_neg\_contexts()](#org6970886) backports were built, but they were mutex-based.)

Since `TCP_Server_Info::srv_lock` did not exist in LTS 8.6 before the backport it was not necessary to scan all the reversed call trees of the modified functions / macros.

Note that there is a bug in

<https://github.com/ctrliq/kernel-src-tree/blob/81026fbf043acfcce950cb0f559853d89701ab36/fs/cifs/connect.c#L152>

stemming, most likely, from the assumption that `extract_hostname()` returns NULL upon error, which is false. It was partially addressed in the (backported) commit 8428817dc40006dca0a531cfa06e89cb3b41790d, but the issue of `hostname`-reading threads receiving rubbish if `extract_hostname()` failed remains. Fixing it was deemed outside of CVE-2023-53751 fix scope though.


<a id="org1ea6248"></a>

## All `TCP_Server_Info::hostname` usages in LTS 8.6

Reference list with a comment about the protection situation for each.


### `reconn_set_ipaddr_from_hostname()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L95>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L98>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L105>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L111-L112>

Function called in two places, both within the `cifs_reconnect()` call tree - no need for reading protection.

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L159>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L334>


<a id="org092a576"></a>

### `reconn_set_next_dfs_target()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L150-L152>

Writing protection addressed in [cifs: fix potential use-after-free bugs in TCP\_Server\_Info::hostname](#org4884c9d).


<a id="org3dc9e68"></a>

### `cifs_reconnect()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L243>

Usage in the `cifs_reconnect()` function - no need for reading protection.


### `cifs_echo_request()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L422-L423>

Issue addressed in [cifs: fix potential use-after-free bugs in TCP\_Server\_Info::hostname](#org4884c9d) (got rid of `hostname` read entirely)


### `match_server()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L1197>

Issue addressed in [cifs: fix potential use-after-free bugs in TCP\_Server\_Info::hostname](#org4884c9d).


<a id="org38676b8"></a>

### `cifs_put_tcp_session()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L1287-L1288>

There is a separate CVE-2025-21673 for that and the upstream fix fa2f9906a7b333ba757a7dbae0713d8a5396186e. Did not investigate further, can include it in the PR on request.


### `cifs_setup_ipc()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L1515>

Issue addressed in [cifs: fix potential use-after-free bugs in TCP\_Server\_Info::hostname](#org4884c9d).


### `cifs_tree_connect()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L4084>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L4098>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L4117-L4120>

(memory is shared between `server->hostname` and `tcp_host`)

Issue addressed in [cifs: protect access of TCP\_Server\_Info::{dstaddr,hostname}](#org3e3e495).


### `cifs_stats_proc_show()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/cifs_debug.c#L613-L615>

Issue addressed in [cifs: fix potential use-after-free bugs in TCP\_Server\_Info::hostname](#org4884c9d).


### `assemble_neg_contexts()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/smb2pdu.c#L552-L553>

Issue addressed in [cifs: fix race in assemble\_neg\_contexts()](#org6970886).


### `cifs_get_spnego_key()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/cifs_spnego.c#L107>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/cifs_spnego.c#L112-L118>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/cifs_spnego.c#L131-L132>

Not protected even in the most recent upstream codebase - perhaps not needed.

<https://github.com/ctrliq/kernel-src-tree/blob/9147566d801602c9e7fc7f85e989735735bf38ba/fs/smb/client/cifs_spnego.c#L83-L175>


### `cifs_server_dbg_func()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/cifs_debug.h#L98-L110>

Issue addressed in [cifs: fix potential use-after-free bugs in TCP\_Server\_Info::hostname](#org4884c9d).


### `cifs_server_dbg()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/cifs_debug.h#L160-L161>

Unreachable code, no need for protection (why even there?).


### `__smb_send_rqst()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/transport.c#L454-L455>

Already protected, although higher up the callers tree:

1.  `__smb_send_rqst()` no protection
    1.  `smb_send_rqst()` (`fs/cifs/transport.c`) no protection
        1.  `compound_send_recv()` (`fs/cifs/transport.c`) protected by `server->srv_mutex`
        2.  `cifs_call_async()` (`fs/cifs/transport.c`) protected by `server->srv_mutex`
    2.  `smb_send()` (`fs/cifs/transport.c`) no protection
        1.  `ip_rfc1001_connect()` (`fs/cifs/connect.c`) no protection
            1.  `generic_ip_connect()` (`fs/cifs/connect.c`) no protection
                1.  `cifs_reconnect()` (`fs/cifs/connect.c`) protected by `server->srv_mutex`
                2.  `ip_connect()` (`fs/cifs/connect.c`) no protection
                    1.  `cifs_get_tcp_session()` (`fs/cifs/connect.c`) no protection, but in this context it's not needed, see
        2.  `send_nt_cancel()` (`fs/cifs/smb1ops.c`) protected by `server->srv_mutex`
        3.  `SendReceive()` (`fs/cifs/transport.c`) protected by `server->srv_mutex`
        4.  `SendReceiveBlockingLock()` (`fs/cifs/transport.c`) protected by `server->srv_mutex`


<a id="orgc309ac3"></a>

### `wait_for_free_credits()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/transport.c#L572-L573>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/transport.c#L612-L615>

This `hostname` usage doesn't seem to be protected, neither in `wait_for_free_credits()` nor in any place up the callers tree:

1.  `wait_for_free_credits()` (`fs/cifs/transport.c`) no protection
    1.  `wait_for_compound_request()` (`fs/cifs/transport.c`) no protection
        1.  `compound_send_recv()` (`fs/cifs/transport.c`) no protection and unlikely to have any up the callers tree, because `srv_mutex` mutex used already
    2.  `wait_for_free_request()` (`fs/cifs/transport.c`) no protection
        1.  `cifs_call_async()` (`fs/cifs/transport.c`) no protection and unlikely to have any up the callers tree, because `srv_mutex` mutex used already
        2.  `SendReceive()` (`fs/cifs/transport.c`) no protection and unlikely to have any up the callers tree, because `srv_mutex` mutex used already
        3.  `SendReceiveBlockingLock()` (`fs/cifs/transport.c`) no protection and unlikely to have any up the callers tree, because `srv_mutex` mutex used already

These usages aren't protected in the upstream either

<https://github.com/ctrliq/kernel-src-tree/blob/9147566d801602c9e7fc7f85e989735735bf38ba/fs/smb/client/transport.c#L423-L575>

This might be a bug, especially given that the sibling `TCP_Server_Info` field - `tcpStatus` - is being protected by `srv_lock`, eg.

<https://github.com/ctrliq/kernel-src-tree/blob/9147566d801602c9e7fc7f85e989735735bf38ba/fs/smb/client/transport.c#L471-L476>

No need to outrun the upstream though. Not investigated further.


### `smb2_add_credits()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/smb2ops.c#L87-L88>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/smb2ops.c#L137-L138>

See [wait\_for\_free\_credits()](#orgc309ac3).


### `cifs_get_tcp_session()`

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L1314-L1318>

<https://github.com/ctrliq/kernel-src-tree/blob/a3817092e5b01a3e05dc2e07781f5b5733b2521c/fs/cifs/connect.c#L1433>

No protections in the most recent `kernel-mainline` either (`TCP_Server_Info` object creation subroutine, perhaps just no need for protection yet).


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts8_6-CVE-2023-53751]	_kabi_check_kernel__x86_64--test--ciqlts8_6-CVE-2023-53751
    + dist_git_version=el-8.6
    + local_version=ciqlts8_6-CVE-2023-53751
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts8_6
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-8.6
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-2023-53751
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-8.6/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts8_6 ''\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-2023-53751/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2023-53751/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/26392002/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/26392003/kselftests--ciqlts8_6--run1.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2023-53751&#x2013;run1.log](<https://github.com/user-attachments/files/26392004/kselftests--ciqlts8_6-CVE-2023-53751--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2023-53751&#x2013;run2.log](<https://github.com/user-attachments/files/26392005/kselftests--ciqlts8_6-CVE-2023-53751--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff  kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6-CVE-2023-53751--run1.log
    Status2   kselftests--ciqlts8_6-CVE-2023-53751--run2.log
    
    TestCase                                     Status0  Status1  Status2  Summary
    android:run.sh                               skip     skip     skip     same
    bpf:get_cgroup_id_user                       pass     pass     pass     same
    bpf:test_bpftool.sh                          pass     pass     pass     same
    bpf:test_bpftool_build.sh                    pass     pass     pass     same
    bpf:test_bpftool_metadata.sh                 pass     pass     pass     same
    bpf:test_cgroup_storage                      pass     pass     pass     same
    bpf:test_dev_cgroup                          pass     pass     pass     same
    bpf:test_doc_build.sh                        pass     pass     pass     same
    bpf:test_flow_dissector.sh                   pass     pass     pass     same
    bpf:test_lirc_mode2.sh                       pass     pass     pass     same
    bpf:test_lpm_map                             pass     pass     pass     same
    bpf:test_lru_map                             pass     pass     pass     same
    bpf:test_lwt_ip_encap.sh                     pass     pass     pass     same
    bpf:test_lwt_seg6local.sh                    pass     pass     pass     same
    bpf:test_netcnt                              pass     pass     pass     same
    bpf:test_offload.py                          fail     fail     fail     same
    bpf:test_skb_cgroup_id.sh                    pass     pass     pass     same
    bpf:test_sock                                pass     pass     pass     same
    bpf:test_sock_addr.sh                        pass     pass     pass     same
    bpf:test_sysctl                              pass     pass     pass     same
    bpf:test_tag                                 pass     pass     pass     same
    bpf:test_tc_edt.sh                           pass     pass     pass     same
    bpf:test_tc_tunnel.sh                        pass     pass     pass     same
    bpf:test_tcp_check_syncookie.sh              pass     pass     pass     same
    bpf:test_tcpnotify_user                      pass     pass     pass     same
    bpf:test_tunnel.sh                           pass     pass     pass     same
    bpf:test_verifier                            pass     pass     pass     same
    bpf:test_verifier_log                        pass     pass     pass     same
    bpf:test_xdp_meta.sh                         pass     pass     pass     same
    bpf:test_xdp_redirect.sh                     pass     pass     pass     same
    bpf:test_xdp_veth.sh                         pass     pass     pass     same
    bpf:test_xdp_vlan_mode_generic.sh            pass     pass     pass     same
    bpf:test_xdp_vlan_mode_native.sh             pass     pass     pass     same
    bpf:test_xdping.sh                           pass     pass     pass     same
    bpf:urandom_read                             pass     pass     pass     same
    breakpoints:breakpoint_test                  pass     pass     pass     same
    capabilities:test_execve                     pass     pass     pass     same
    core:close_range_test                        pass     pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh               pass     pass     pass     same
    cpufreq:main.sh                              fail     fail     fail     same
    exec:execveat                                pass     pass     pass     same
    firmware:fw_run_tests.sh                     skip     skip     skip     same
    fpu:run_test_fpu.sh                          skip     skip     skip     same
    fpu:test_fpu                                 pass     pass     pass     same
    ftrace:ftracetest                            fail     fail     fail     same
    futex:run.sh                                 pass     pass     pass     same
    gpio:gpio-mockup.sh                          fail     fail     fail     same
    intel_pstate:run.sh                          pass     pass     pass     same
    ipc:msgque                                   pass     pass     pass     same
    kcmp:kcmp_test                               pass     pass     pass     same
    kexec:test_kexec_file_load.sh                skip     skip     skip     same
    kexec:test_kexec_load.sh                     skip     skip     skip     same
    kvm:access_tracking_perf_test                fail     fail     fail     same
    kvm:amx_test                                 fail     fail     fail     same
    kvm:cr4_cpuid_sync_test                      fail     fail     fail     same
    kvm:debug_regs                               fail     fail     fail     same
    kvm:demand_paging_test                       pass     pass     pass     same
    kvm:dirty_log_perf_test                      pass     pass     pass     same
    kvm:dirty_log_test                           fail     fail     fail     same
    kvm:emulator_error_test                      fail     fail     fail     same
    kvm:evmcs_test                               fail     fail     fail     same
    kvm:get_cpuid_test                           fail     fail     fail     same
    kvm:get_msr_index_features                   fail     fail     fail     same
    kvm:hardware_disable_test                    pass     pass     pass     same
    kvm:hyperv_clock                             fail     fail     fail     same
    kvm:hyperv_cpuid                             fail     fail     fail     same
    kvm:hyperv_features                          fail     fail     fail     same
    kvm:kvm_binary_stats_test                    pass     pass     pass     same
    kvm:kvm_create_max_vcpus                     skip     skip     skip     same
    kvm:kvm_page_table_test                      pass     pass     pass     same
    kvm:kvm_pv_test                              fail     fail     fail     same
    kvm:memslot_modification_stress_test         pass     pass     pass     same
    kvm:memslot_perf_test                        fail     fail     fail     same
    kvm:mmio_warning_test                        fail     fail     fail     same
    kvm:mmu_role_test                            fail     fail     fail     same
    kvm:platform_info_test                       fail     fail     fail     same
    kvm:rseq_test                                fail     fail     fail     same
    kvm:set_boot_cpu_id                          fail     fail     fail     same
    kvm:set_memory_region_test                   pass     pass     pass     same
    kvm:set_sregs_test                           fail     fail     fail     same
    kvm:smm_test                                 fail     fail     fail     same
    kvm:state_test                               fail     fail     fail     same
    kvm:steal_time                               pass     pass     pass     same
    kvm:svm_int_ctl_test                         fail     fail     fail     same
    kvm:svm_vmcall_test                          fail     fail     fail     same
    kvm:sync_regs_test                           fail     fail     fail     same
    kvm:tsc_msrs_test                            fail     fail     fail     same
    kvm:userspace_msr_exit_test                  fail     fail     fail     same
    kvm:vmx_apic_access_test                     fail     fail     fail     same
    kvm:vmx_close_while_nested_test              fail     fail     fail     same
    kvm:vmx_dirty_log_test                       fail     fail     fail     same
    kvm:vmx_nested_tsc_scaling_test              fail     fail     fail     same
    kvm:vmx_pmu_msrs_test                        fail     fail     fail     same
    kvm:vmx_preemption_timer_test                fail     fail     fail     same
    kvm:vmx_set_nested_state_test                fail     fail     fail     same
    kvm:vmx_tsc_adjust_test                      fail     fail     fail     same
    kvm:xapic_ipi_test                           fail     fail     fail     same
    kvm:xen_shinfo_test                          fail     fail     fail     same
    kvm:xen_vmcall_test                          fail     fail     fail     same
    kvm:xss_msr_test                             fail     fail     fail     same
    lib:bitmap.sh                                skip     skip     skip     same
    lib:prime_numbers.sh                         skip     skip     skip     same
    lib:printf.sh                                skip     skip     skip     same
    lib:scanf.sh                                 fail     fail     fail     same
    livepatch:test-callbacks.sh                  pass     pass     pass     same
    livepatch:test-ftrace.sh                     pass     pass     pass     same
    livepatch:test-livepatch.sh                  pass     pass     pass     same
    livepatch:test-shadow-vars.sh                pass     pass     pass     same
    livepatch:test-state.sh                      pass     pass     pass     same
    membarrier:membarrier_test_multi_thread      pass     pass     pass     same
    membarrier:membarrier_test_single_thread     pass     pass     pass     same
    memfd:memfd_test                             pass     pass     pass     same
    memfd:run_fuse_test.sh                       fail     fail     fail     same
    memfd:run_hugetlbfs_test.sh                  pass     pass     pass     same
    memory-hotplug:mem-on-off-test.sh            pass     pass     pass     same
    mount:run_tests.sh                           pass     pass     pass     same
    net/forwarding:bridge_port_isolation.sh      pass     pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh          pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh          fail     fail     fail     same
    net/forwarding:bridge_vlan_unaware.sh        pass     pass     pass     same
    net/forwarding:ethtool.sh                    fail     fail     fail     same
    net/forwarding:gre_multipath.sh              fail     fail     fail     same
    net/forwarding:ip6_forward_instats_vrf.sh    fail     fail     fail     same
    net/forwarding:ipip_flat_gre.sh              pass     pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh          pass     pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh         pass     pass     pass     same
    net/forwarding:ipip_hier_gre.sh              pass     pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh          pass     pass     pass     same
    net/forwarding:loopback.sh                   skip     skip     skip     same
    net/forwarding:mirror_gre.sh                 fail     fail     fail     same
    net/forwarding:mirror_gre_bound.sh           pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh       pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh       pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh   pass     pass     pass     same
    net/forwarding:mirror_gre_changes.sh         fail     fail     fail     same
    net/forwarding:mirror_gre_flower.sh          fail     fail     fail     same
    net/forwarding:mirror_gre_lag_lacp.sh        pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh           pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh              pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh            pass     pass     pass     same
    net/forwarding:mirror_vlan.sh                pass     pass     pass     same
    net/forwarding:router.sh                     fail     fail     fail     same
    net/forwarding:router_bridge.sh              pass     pass     pass     same
    net/forwarding:router_bridge_vlan.sh         pass     pass     pass     same
    net/forwarding:router_broadcast.sh           fail     fail     fail     same
    net/forwarding:router_multicast.sh           fail     fail     fail     same
    net/forwarding:router_multipath.sh           fail     fail     fail     same
    net/forwarding:router_vid_1.sh               pass     pass     pass     same
    net/forwarding:tc_chains.sh                  pass     pass     pass     same
    net/forwarding:tc_flower.sh                  pass     pass     pass     same
    net/forwarding:tc_flower_router.sh           pass     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh              pass     pass     pass     same
    net/forwarding:tc_shblocks.sh                pass     pass     pass     same
    net/forwarding:tc_vlan_modify.sh             pass     pass     pass     same
    net/forwarding:vxlan_asymmetric.sh           pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh  pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh  pass     pass     pass     same
    net/forwarding:vxlan_symmetric.sh            pass     pass     pass     same
    net/mptcp:diag.sh                            pass     pass     pass     same
    net/mptcp:mptcp_connect.sh                   pass     pass     pass     same
    net/mptcp:mptcp_sockopt.sh                   pass     pass     pass     same
    net/mptcp:pm_netlink.sh                      pass     pass     pass     same
    net:bareudp.sh                               pass     pass     pass     same
    net:devlink_port_split.py                    pass     pass     pass     same
    net:drop_monitor_tests.sh                    skip     skip     skip     same
    net:fcnal-test.sh                            pass     pass     pass     same
    net:fib-onlink-tests.sh                      pass     pass     pass     same
    net:fib_rule_tests.sh                        fail     fail     fail     same
    net:fib_tests.sh                             pass     pass     pass     same
    net:gre_gso.sh                               pass     pass     pass     same
    net:icmp_redirect.sh                         pass     pass     pass     same
    net:ip6_gre_headroom.sh                      pass     pass     pass     same
    net:ipv6_flowlabel.sh                        pass     pass     pass     same
    net:l2tp.sh                                  pass     pass     pass     same
    net:msg_zerocopy.sh                          fail     fail     fail     same
    net:netdevice.sh                             pass     pass     pass     same
    net:pmtu.sh                                  pass     pass     pass     same
    net:psock_snd.sh                             fail     fail     fail     same
    net:reuseaddr_conflict                       pass     pass     pass     same
    net:reuseport_bpf                            pass     pass     pass     same
    net:reuseport_bpf_cpu                        pass     pass     pass     same
    net:reuseport_bpf_numa                       pass     pass     pass     same
    net:reuseport_dualstack                      pass     pass     pass     same
    net:rtnetlink.sh                             skip     skip     skip     same
    net:run_afpackettests                        pass     pass     pass     same
    net:run_netsocktests                         pass     pass     pass     same
    net:rxtimestamp.sh                           pass     pass     pass     same
    net:so_txtime.sh                             fail     fail     fail     same
    net:test_bpf.sh                              pass     pass     pass     same
    net:test_vxlan_fdb_changelink.sh             pass     pass     pass     same
    net:tls                                      pass     pass     pass     same
    net:traceroute.sh                            pass     pass     pass     same
    net:udpgro.sh                                fail     fail     fail     same
    net:udpgro_bench.sh                          fail     fail     fail     same
    net:udpgso.sh                                pass     pass     pass     same
    net:veth.sh                                  fail     fail     fail     same
    net:vrf-xfrm-tests.sh                        pass     pass     pass     same
    netfilter:conntrack_icmp_related.sh          fail     fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh         fail     fail     fail     same
    netfilter:ipvs.sh                            skip     skip     skip     same
    netfilter:nft_flowtable.sh                   fail     fail     fail     same
    netfilter:nft_meta.sh                        pass     pass     pass     same
    netfilter:nft_nat.sh                         skip     skip     skip     same
    netfilter:nft_queue.sh                       skip     skip     skip     same
    nsfs:owner                                   pass     pass     pass     same
    nsfs:pidns                                   pass     pass     pass     same
    proc:fd-001-lookup                           pass     pass     pass     same
    proc:fd-002-posix-eq                         pass     pass     pass     same
    proc:fd-003-kthread                          pass     pass     pass     same
    proc:proc-loadavg-001                        pass     pass     pass     same
    proc:proc-self-map-files-001                 pass     pass     pass     same
    proc:proc-self-map-files-002                 fail     fail     fail     same
    proc:proc-self-syscall                       pass     pass     pass     same
    proc:proc-self-wchan                         pass     pass     pass     same
    proc:proc-uptime-001                         pass     pass     pass     same
    proc:proc-uptime-002                         pass     pass     pass     same
    proc:read                                    pass     pass     pass     same
    proc:setns-dcache                            fail     fail     fail     same
    pstore:pstore_post_reboot_tests              skip     skip     skip     same
    pstore:pstore_tests                          fail     fail     fail     same
    ptrace:peeksiginfo                           pass     pass     pass     same
    ptrace:vmaccess                              fail     fail     fail     same
    rseq:basic_percpu_ops_test                   pass     pass     pass     same
    rseq:basic_test                              pass     pass     pass     same
    rseq:param_test                              pass     pass     pass     same
    rseq:param_test_benchmark                    pass     pass     pass     same
    rseq:param_test_compare_twice                pass     pass     pass     same
    rseq:run_param_test.sh                       fail     fail     fail     same
    sgx:test_sgx                                 fail     fail     fail     same
    sigaltstack:sas                              pass     pass     pass     same
    size:get_size                                pass     pass     pass     same
    splice:default_file_splice_read.sh           pass     pass     pass     same
    static_keys:test_static_keys.sh              skip     skip     skip     same
    tc-testing:tdc.sh                            pass     pass     pass     same
    timens:clock_nanosleep                       pass     pass     pass     same
    timens:exec                                  pass     pass     pass     same
    timens:procfs                                pass     pass     pass     same
    timens:timens                                pass     pass     pass     same
    timens:timer                                 pass     pass     pass     same
    timens:timerfd                               pass     pass     pass     same
    timers:inconsistency-check                   fail     fail     fail     same
    timers:mqueue-lat                            pass     pass     pass     same
    timers:nanosleep                             pass     pass     pass     same
    timers:nsleep-lat                            fail     fail     fail     same
    timers:posix_timers                          pass     pass     pass     same
    timers:rtcpie                                pass     pass     pass     same
    timers:set-timer-lat                         fail     fail     fail     same
    timers:threadtest                            pass     pass     pass     same
    tpm2:test_smoke.sh                           fail     fail     fail     same
    tpm2:test_space.sh                           fail     fail     fail     same
    vm:run_vmtests                               fail     fail     fail     same
    x86:amx_64                                   fail     fail     fail     same
    x86:check_initial_reg_state_64               pass     pass     pass     same
    x86:corrupt_xstate_header_64                 pass     pass     pass     same
    x86:fsgsbase_64                              pass     pass     pass     same
    x86:fsgsbase_restore_64                      pass     pass     pass     same
    x86:ioperm_64                                pass     pass     pass     same
    x86:iopl_64                                  pass     pass     pass     same
    x86:mov_ss_trap_64                           pass     pass     pass     same
    x86:mpx-mini-test_64                         fail     fail     fail     same
    x86:protection_keys_64                       pass     pass     pass     same
    x86:sigaltstack_64                           pass     pass     pass     same
    x86:sigreturn_64                             pass     pass     pass     same
    x86:single_step_syscall_64                   pass     pass     pass     same
    x86:syscall_nt_64                            pass     pass     pass     same
    x86:sysret_rip_64                            pass     pass     pass     same
    x86:sysret_ss_attrs_64                       pass     pass     pass     same
    x86:test_mremap_vdso_64                      pass     pass     pass     same
    x86:test_vdso_64                             pass     pass     pass     same
    x86:test_vsyscall_64                         pass     pass     pass     same
    zram:zram.sh                                 pass     pass     pass     same


# Specific sanity tests: passed

The patched kernel was compiled with these additional options:

    CONFIG_CIFS_DEBUG2=y
    CONFIG_DEBUG_MUTEXES=y
    CONFIG_DEBUG_SPINLOCK=y
    CONFIG_RH_KABI_SIZE_ALIGN_CHECKS=n

The aim was to run at least some of the modified code paths and scan for the possible locking problems. Options `CONFIG_DEBUG_SPINLOCK=y` and `CONFIG_DEBUG_MUTEXES=y` enabled reporting common locking issues. Option `CONFIG_CIFS_DEBUG2=y` enabled extensive `cifs` logging, allowing for easier tracking of the walked code paths. Option `CONFIG_RH_KABI_SIZE_ALIGN_CHECKS=n` was necessary for the mutex debugging option.

Additional runtime setup of the LTS 8.6 machine:

    echo 7 > /proc/fs/cifs/cifsFYI

See `Documentation/filesystems/cifs/README`: 

<https://github.com/ctrliq/kernel-src-tree/blob/81026fbf043acfcce950cb0f559853d89701ab36/Documentation/filesystems/cifs/README#L686-L689>

Also (see <https://wiki.samba.org/index.php/LinuxCIFS_troubleshooting>):

    echo 'module cifs +p' > /sys/kernel/debug/dynamic_debug/control
    echo 'file fs/cifs/* +p' > /sys/kernel/debug/dynamic_debug/control

The LTS 8.6 machine was set up as the `cifs` client, while the hosting Rocky 9 machine as `cifs` server.

Server configuration:

    # mkdir -p /sambashare
    # chmod 2770 /sambashare/
    # semanage fcontext -at samba_share_t '/sambashare(/.*)?'
    # restorecon -vvFR /sambashare
    # dnf install samba samba-common -y
    # systemctl restart smb
    # systemctl restart nmb
    # groupadd sales
    # chgrp sales /sambashare/
    # useradd -s /sbin/nologin -G sales calvin
    # smbpasswd -a calvin   # redhat
    # echo -e "[smbshare]
    \tpath = /sambashare
    \twrite list = @sales
    " >> /etc/samba/smb.conf
    # systemctl restart smb
    # systemctl restart nmb
    # systemctl stop firewalld

Client configuration:

    # dnf install cifs-utils -y
    # mkdir sales
    # echo "username=calvin
    password=redhat
    " > smb-multiuser.txt
    # mount -t cifs //192.168.122.1/smbshare sales -o credentials=smb-multiuser.txt,multiuser,sec=ntlmssp

A few moderately large files (~100 MB) were transferred from the server to the client and vice-versa without any issue. Next, a link failure was emulated by shutting down server's network interface to trigger reconnection attempt on the client's side. After a few minutes it was brought back. This resulted in the following logs on the LTS 8.6 machine:

    [ 2134.097279] CIFS: fs/cifs/smb2pdu.c: In echo request
    [ 2134.100057] CIFS: fs/cifs/transport.c: Sending smb: smb_len=72
    [ 2134.103230] CIFS: fs/cifs/connect.c: \\192.168.122.1 send echo request: rc = 0
    [ 2195.537730] CIFS: fs/cifs/smb2pdu.c: In echo request
    [ 2195.540974] CIFS: fs/cifs/smb2pdu.c: Echo request failed: -11
    [ 2195.544612] CIFS: fs/cifs/connect.c: \\192.168.122.1 send echo request: rc = -11
    [ 2256.978215] CIFS: fs/cifs/smb2pdu.c: In echo request
    [ 2256.981436] CIFS: fs/cifs/smb2pdu.c: Echo request failed: -11
    [ 2256.985065] CIFS: fs/cifs/connect.c: \\192.168.122.1 send echo request: rc = -11
    [ 2259.028296] CIFS: VFS: \\192.168.122.1 has not responded in 180 seconds. Reconnecting...
    [ 2259.033612] CIFS: fs/cifs/connect.c: cifs_reconnect: will retry 1 target(s)
    [ 2259.038125] CIFS: fs/cifs/connect.c: Mark tcp session as need reconnect
    [ 2259.042281] CIFS: fs/cifs/connect.c: cifs_reconnect: marking sessions and tcons for reconnect
    [ 2259.046039] CIFS: fs/cifs/connect.c: cifs_reconnect: tearing down socket
    [ 2259.048943] CIFS: fs/cifs/connect.c: State: 0x3 Flags: 0x0
    [ 2259.051361] CIFS: fs/cifs/connect.c: Post shutdown state: 0x3 Flags: 0x0
    [ 2259.053690] CIFS: fs/cifs/connect.c: cifs_reconnect: moving mids to private list
    [ 2259.055879] CIFS: fs/cifs/connect.c: cifs_reconnect: issuing mid callbacks
    [ 2259.057912] CIFS: fs/cifs/misc.c: Null buffer passed to cifs_small_buf_release
    [ 2259.060059] CIFS: fs/cifs/dns_resolve.c: dns_resolve_server_name_to_ip: probably server name is whole unc: \\192.168.122.1
    [ 2259.062992] CIFS: address conversion returned 1 for 192.168.122.1
    [ 2259.064279] CIFS: fs/cifs/dns_resolve.c: dns_resolve_server_name_to_ip: unc is IP, skipping dns upcall: 192.168.122.1
    [ 2259.066486] CIFS: address conversion returned 1 for 192.168.122.1
    [ 2259.067771] CIFS: fs/cifs/connect.c: generic_ip_connect: connecting to 192.168.122.1:445
    [ 2259.069483] CIFS: fs/cifs/connect.c: Socket created
    [ 2259.070517] CIFS: fs/cifs/connect.c: sndbuf 16384 rcvbuf 87380 rcvtimeo 0x1b58
    [ 2260.050335] CIFS: fs/cifs/connect.c: Error -113 connecting to server
    [ 2260.054542] CIFS: fs/cifs/connect.c: reconnect error -113
    [ 2263.122273] CIFS: fs/cifs/dns_resolve.c: dns_resolve_server_name_to_ip: probably server name is whole unc: \\192.168.122.1
    [ 2263.129476] CIFS: address conversion returned 1 for 192.168.122.1
    [ 2263.133481] CIFS: fs/cifs/dns_resolve.c: dns_resolve_server_name_to_ip: unc is IP, skipping dns upcall: 192.168.122.1
    [ 2263.139714] CIFS: address conversion returned 1 for 192.168.122.1
    [...]
    [ 2318.560957] CIFS: address conversion returned 1 for 192.168.122.1
    [ 2318.563184] CIFS: fs/cifs/connect.c: generic_ip_connect: connecting to 192.168.122.1:445
    [ 2318.566295] CIFS: fs/cifs/connect.c: Socket created
    [ 2318.567947] CIFS: fs/cifs/connect.c: sndbuf 16384 rcvbuf 87380 rcvtimeo 0x1b58
    [ 2318.570132] CIFS: fs/cifs/smb2ops.c: set credits to 1 due to smb2 reconnect
    [ 2318.572192] CIFS: fs/cifs/smb2pdu.c: In echo request
    [ 2318.573608] CIFS: fs/cifs/connect.c: \\192.168.122.1 send echo request: rc = 0
    [ 2318.575717] CIFS: fs/cifs/smb2pdu.c: Need negotiate, reconnecting tcons
    [ 2318.577626] CIFS: fs/cifs/smb2pdu.c: Negotiate protocol
    [ 2318.578773] CIFS: fs/cifs/transport.c: Sending smb: smb_len=236
    [ 2318.582771] CIFS: fs/cifs/connect.c: RFC1002 header 0x10c
    [ 2318.583936] CIFS: fs/cifs/smb2misc.c: SMB2 data length 74 offset 128
    [ 2318.585227] CIFS: fs/cifs/smb2misc.c: SMB2 len 202
    [ 2318.586214] CIFS: fs/cifs/smb2misc.c: length of negcontexts 60 pad 6
    [ 2318.587428] CIFS: fs/cifs/transport.c: cifs_sync_mid_result: cmd=0 mid=0 state=64
    [ 2318.588694] CIFS: fs/cifs/misc.c: Null buffer passed to cifs_small_buf_release
    [ 2318.590119] CIFS: fs/cifs/smb2pdu.c: mode 0x1
    [ 2318.590973] CIFS: fs/cifs/smb2pdu.c: negotiated smb3.1.1 dialect
    [ 2318.592086] CIFS: fs/cifs/asn1.c: OID len = 10 oid = 0x1 0x3 0x6 0x1
    [ 2318.593219] CIFS: fs/cifs/smb2pdu.c: decoding 2 negotiate contexts
    [ 2318.594314] CIFS: fs/cifs/smb2pdu.c: decode SMB3.11 encryption neg context of len 4
    [ 2318.595617] CIFS: fs/cifs/smb2pdu.c: SMB311 cipher type:2
    [ 2318.596541] CIFS: fs/cifs/connect.c: Free previous auth_key.response = 0000000042d1e2d6
    [ 2318.597901] CIFS: fs/cifs/connect.c: Security Mode: 0x1 Capabilities: 0x300047 TimeAdjust: 0
    [ 2318.599291] CIFS: fs/cifs/smb2pdu.c: Session Setup
    [ 2318.600089] CIFS: fs/cifs/smb2pdu.c: sess setup type 4
    [ 2318.600952] CIFS: fs/cifs/transport.c: Sending smb: smb_len=124
    [ 2318.602307] CIFS: fs/cifs/connect.c: RFC1002 header 0xe8
    [ 2318.603201] CIFS: fs/cifs/smb2misc.c: SMB2 data length 160 offset 72
    [ 2318.604256] CIFS: fs/cifs/smb2misc.c: SMB2 len 232
    [ 2318.605064] CIFS: fs/cifs/transport.c: cifs_sync_mid_result: cmd=1 mid=1 state=64
    [ 2318.606304] CIFS: Status code returned 0xc0000016 STATUS_MORE_PROCESSING_REQUIRED
    [ 2318.607562] CIFS: fs/cifs/smb2maperror.c: Mapping SMB2 status code 0xc0000016 to POSIX err -5
    [ 2318.608918] CIFS: fs/cifs/misc.c: Null buffer passed to cifs_small_buf_release
    [ 2318.610069] CIFS: fs/cifs/smb2pdu.c: rawntlmssp session setup challenge phase
    [ 2318.611226] CIFS: fs/cifs/transport.c: Sending smb: smb_len=316
    [ 2318.616604] CIFS: fs/cifs/connect.c: RFC1002 header 0x48
    [ 2318.617669] CIFS: fs/cifs/smb2misc.c: SMB2 data length 0 offset 72
    [ 2318.618750] CIFS: fs/cifs/smb2misc.c: SMB2 len 73
    [ 2318.619571] CIFS: fs/cifs/smb2misc.c: Calculated size 73 length 72 mismatch mid 2
    [ 2318.620880] CIFS: fs/cifs/transport.c: cifs_sync_mid_result: cmd=1 mid=2 state=64
    [ 2318.622210] CIFS: fs/cifs/misc.c: Null buffer passed to cifs_small_buf_release
    [ 2318.623522] CIFS: fs/cifs/smb2pdu.c: SMB2/3 session established successfully
    [ 2318.624780] CIFS: fs/cifs/smb2pdu.c: TCON
    [ 2318.625518] CIFS: fs/cifs/transport.c: Sending smb: smb_len=126
    [ 2318.627342] CIFS: fs/cifs/connect.c: RFC1002 header 0x50
    [ 2318.628349] CIFS: fs/cifs/smb2misc.c: SMB2 len 80
    [ 2318.629228] CIFS: fs/cifs/smb2ops.c: add 64 credits total=195
    [ 2318.630291] CIFS: fs/cifs/transport.c: cifs_sync_mid_result: cmd=3 mid=3 state=64
    [ 2318.631683] CIFS: fs/cifs/misc.c: Null buffer passed to cifs_small_buf_release
    [ 2318.632924] CIFS: fs/cifs/smb2pdu.c: connection to disk share
    [ 2318.633987] CIFS: fs/cifs/smb2pdu.c: reconnect tcon rc = 0
    [ 2318.634899] CIFS: fs/cifs/connect.c: cifs_put_tcon: tc_count=2
    [ 2318.635862] CIFS: fs/cifs/smb2pdu.c: TCON
    [ 2318.636560] CIFS: fs/cifs/transport.c: Sending smb: smb_len=118
    [ 2318.638008] CIFS: fs/cifs/connect.c: RFC1002 header 0x50
    [ 2318.638921] CIFS: fs/cifs/smb2misc.c: SMB2 len 80
    [ 2318.639703] CIFS: fs/cifs/smb2ops.c: add 64 credits total=258
    [ 2318.640716] CIFS: fs/cifs/transport.c: cifs_sync_mid_result: cmd=3 mid=4 state=64
    [ 2318.641961] CIFS: fs/cifs/misc.c: Null buffer passed to cifs_small_buf_release
    [ 2318.643222] CIFS: fs/cifs/smb2pdu.c: connection to pipe share
    [ 2318.644232] CIFS: fs/cifs/smb2pdu.c: reconnect tcon rc = 0
    [ 2318.645220] CIFS: fs/cifs/connect.c: cifs_put_smb_ses: ses_count=2
    [ 2318.646322] CIFS: fs/cifs/connect.c: cifs_put_smb_ses: ses_count=2
    [ 2318.647437] CIFS: fs/cifs/connect.c: cifs_put_smb_ses: ses ipc: \\192.168.122.1\IPC$
    [ 2318.648788] CIFS: fs/cifs/smb2pdu.c: Reconnecting tcons finished

This message

    CIFS: fs/cifs/connect.c: cifs_reconnect: will retry 1 target(s)

is printed by

<https://github.com/ctrliq/kernel-src-tree/blob/81026fbf043acfcce950cb0f559853d89701ab36/fs/cifs/connect.c#L222-L223>

in the `cifs_reconnect()` function addressed by the CVE-2023-53751 fix. Unfortunately it didn't trigger the `reconn_set_next_dfs_target()` call where `server->hostname` change occurs.

