### PR TITLE
CLK 6.12 Namespacing

### DIFF
--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -40,6 +40,9 @@ jobs:
           git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
           ./ciq/SOURCES/generate_tarball.sh
 
+      - name: Bundle bindgen
+        run: ./ciq/SOURCES/bundle_bindgen.sh ./ciq/SOURCES
+
       - name: Build SRPM
         run: |
           mkdir -p ../build_files
@@ -47,7 +50,7 @@ jobs:
           su mockbuild -c "mock -v -r ${{ matrix.mock_config }} --resultdir=$(pwd)/../build_files \
             --buildsrpm \
             --sources=$(pwd)/ciq/SOURCES \
-            --spec=$(pwd)/ciq/SPECS/kernel.spec"
+            --spec=$(pwd)/ciq/SPECS/kernel-clk6.12.spec"
 
       - name: Build RPM
         run: |

--- a/ciq/SOURCES/bundle_bindgen.sh
+++ b/ciq/SOURCES/bundle_bindgen.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Bundle the bindgen-cli source code to be included in the kernel build.
+# https://crates.io/crates/bindgen-cli
+#
+# The bindgen tool, required to build Rust code in the Linux kernel, is
+# currently only packaged in Fedora/ELN. In order to build CLK kernels
+# on Rocky Linux we need to build bindgen as part of the kernel build.
+
+SOURCES=$1
+
+BINDGEN_CLI=bindgen-cli
+BINDGEN_CLI_VERSION="0.71.1"
+BINDGEN_CLI_CRATE=bindgen-cli.crate
+CRATESIO_API_ENDPOINT=https://crates.io/api/v1/crates/bindgen-cli/${BINDGEN_CLI_VERSION}/download
+
+curl -sL $CRATESIO_API_ENDPOINT -o $SOURCES/$BINDGEN_CLI_CRATE
+tar -xf $SOURCES/$BINDGEN_CLI_CRATE -C $SOURCES
+mv $SOURCES/$BINDGEN_CLI-$BINDGEN_CLI_VERSION $SOURCES/$BINDGEN_CLI
+
+# vendor bindgen-cli
+cd $SOURCES/$BINDGEN_CLI
+mkdir .cargo
+cat > .cargo/config.toml <<EOF
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
+
+cargo vendor --locked --quiet
+
+cd ..
+tar czf $BINDGEN_CLI.tar.gz $BINDGEN_CLI
+
+# clean up
+rm -f $SOURCES/$BINDGEN_CLI_CRATE
+rm -rf $SOURCES/$BINDGEN_CLI

--- a/ciq/SOURCES/generate_tarball.sh
+++ b/ciq/SOURCES/generate_tarball.sh
@@ -8,7 +8,7 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DISTGIT_ROOT="$(dirname "$SCRIPT_DIR")"
 SOURCE_DIR="$DISTGIT_ROOT/SOURCES"
-SPEC_FILE="$DISTGIT_ROOT/SPECS/kernel.spec"
+SPEC_FILE="$DISTGIT_ROOT/SPECS/kernel-clk6.12.spec"
 
 # Extract version information from spec file
 TARFILE_RELEASE=$(grep '^%define tarfile_release' "$SPEC_FILE" | awk '{print $3}')

--- a/ciq/SOURCES/generate_tarball.sh
+++ b/ciq/SOURCES/generate_tarball.sh
@@ -11,18 +11,22 @@ SOURCE_DIR="$DISTGIT_ROOT/SOURCES"
 SPEC_FILE="$DISTGIT_ROOT/SPECS/kernel-clk6.12.spec"
 
 # Extract version information from spec file
-TARFILE_RELEASE=$(grep '^%define tarfile_release' "$SPEC_FILE" | awk '{print $3}')
-SPEC_VERSION=$(grep '^%define specversion' "$SPEC_FILE" | awk '{print $3}')
+KERNEL_MAJOR_MINOR=$(grep '^%define kernel_major_minor' "$SPEC_FILE" | awk '{print $3}')
+KERNEL_PATCH=$(grep '^%define kernel_patch' "$SPEC_FILE" | awk '{print $3}')
+BUILDID=$(grep '^%define buildid' "$SPEC_FILE" | awk '{print $3}')
+PKGRELEASE=$(grep '^%define pkgrelease' "$SPEC_FILE" | awk '{print $3}')
+EL_VERSION=$(grep '^%define el_version' "$SPEC_FILE" | awk '{print $3}')
 
-if [ -z "$TARFILE_RELEASE" ]; then
-    echo "Error: Could not extract tarfile_release from $SPEC_FILE"
+if [ -z "$KERNEL_MAJOR_MINOR" ] || [ -z "$KERNEL_PATCH" ] || [ -z "$PKGRELEASE" ] || [ -z "$EL_VERSION" ]; then
+    echo "Error: Could not extract kernel version from $SPEC_FILE"
     exit 1
 fi
 
-if [ -z "$SPEC_VERSION" ]; then
-    echo "Error: Could not extract specversion from $SPEC_FILE"
-    exit 1
-fi
+# Resolve macros in pkgrelease
+PKGRELEASE=$(echo "$PKGRELEASE" | sed "s/%{?buildid}/${BUILDID}/")
+
+SPEC_VERSION="${KERNEL_MAJOR_MINOR}.${KERNEL_PATCH}"
+TARFILE_RELEASE="${SPEC_VERSION}-${PKGRELEASE}.el${EL_VERSION}"
 
 # Get current git tag and extract version
 CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null)

--- a/ciq/SOURCES/merge.py
+++ b/ciq/SOURCES/merge.py
@@ -1,3 +1,88 @@
-#!/usr/bin/env python3
-print("merge.py stub: no merge performed")
+#!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0
+# Author: Clark Williams <williams@redhat.com>
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# merge.py - a direct replacement for merge.pl in the redhat/configs directory
+#
+# invocation:   python merge.py overrides baseconfig [arch]
+#
+# This script merges two kernel configuration files, an override file and a
+# base config file and writes the results to stdout.
+#
+# The script reads the overrides into a dictionary, then reads the baseconfig
+# file, looking for overrides and replacing any found, then printing the result
+# to stdout. Finally any remaining (new) configs in the override are appended to the
+# end of the output
 
+import sys
+import re
+import os.path
+
+def usage(msg):
+    '''print a usage message and exit'''
+    sys.stderr.write(msg + "\n")
+    sys.stderr.write("usage: merge.py overrides baseconfig [arch]\n")
+    sys.exit(1)
+
+isset = re.compile(r'^(CONFIG_\w+)=')
+notset = re.compile(r'^#\s+(CONFIG_\w+)\s+is not set')
+
+# search an input line for a config (set or notset) pattern
+# if we get a match return the config that is being changed
+def find_config(line):
+    '''find a configuration line in the input and return the config name'''
+    m = isset.match(line)
+    if (m is not None):
+        return m.group(1)
+
+    m = notset.match(line)
+    if (m is not None):
+        return m.group(1)
+
+    return None
+
+#########################################################
+
+if len(sys.argv) < 3:
+    usage("must have two input files")
+
+override_file = sys.argv[1]
+baseconfig_file = sys.argv[2]
+
+if not os.path.exists(override_file):
+    usage(f"overrides config file {override_file:s} does not exist!")
+
+if not os.path.exists(baseconfig_file):
+    usage(f"base configs file {baseconfig_file:s} does not exist")
+
+if len(sys.argv) == 4:
+    print(f"# {sys.argv[3]:s}")
+
+# read each line of the override file and store any configuration values
+# in the overrides dictionary, keyed by the configuration name.
+overrides = {}
+with open(override_file, "rt", encoding="utf-8") as f:
+    for line in [l.strip() for l in f.readlines()]:
+        c = find_config(line)
+        if c and c not in overrides:
+            overrides[c] = line
+
+# now read and print the base config, checking each line
+# that defines a config value and printing the override if
+# it exists
+with open(baseconfig_file, "rt", encoding="utf-8") as f:
+    for line in [ l.strip() for l in f.readlines() ]:
+        c = find_config(line)
+        if c and c in overrides:
+            print(overrides[c])
+            del overrides[c]
+        else:
+            print(line)
+
+# print out the remaining configs (new values)
+# from the overrides file
+for v in overrides.values():
+    print (v)
+
+sys.exit(0)

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -3567,11 +3567,14 @@ DEFAULTKERNEL=kernel-%{pkg_suffix}-core
 EOF
 
 %posttrans default
-# Set this kernel version as the boot default after all transactions complete
-if [ -f /boot/vmlinuz-%{KVERREL} ]; then
-    grubby --set-default=/boot/vmlinuz-%{KVERREL} ||
+# Use a glob -- this is a noarch package so %{_target_cpu} expands to "noarch"
+# at build time, not the actual installed arch.
+for vmlinuz in /boot/vmlinuz-%{specversion}-%{release}.*+%{pkg_suffix}; do
+    [ -f "$vmlinuz" ] || continue
+    grubby --set-default="$vmlinuz" ||
         echo "warning: failed to set kernel-%{pkg_suffix} as boot default" >&2
-fi
+    break
+done
 
 #
 # This macro defines a %%post script for a kernel*-devel package.

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -2385,8 +2385,8 @@ BuildKernel() {
     # NOTENOTE: checksums to the rpm metadata provides list.
     # NOTENOTE: if you change the symvers name, update the backend too
     %{log_msg "GENERATING kernel ABI metadata"}
-    %compression --stdout %compression_flags < Module.symvers > $RPM_BUILD_ROOT/boot/symvers-$KernelVer.%compext
-    cp $RPM_BUILD_ROOT/boot/symvers-$KernelVer.%compext $RPM_BUILD_ROOT/lib/modules/$KernelVer/symvers.%compext
+    gzip -c9 < Module.symvers > $RPM_BUILD_ROOT/boot/symvers-$KernelVer.gz
+    cp $RPM_BUILD_ROOT/boot/symvers-$KernelVer.gz $RPM_BUILD_ROOT/lib/modules/$KernelVer/symvers.gz
 
    %{log_msg "Cleanup Makefiles/Kconfig files"}
     # then drop all but the needed Makefiles/Kconfig files
@@ -3619,10 +3619,10 @@ fi\
 %endif\
 rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{KVERREL}%{?-v:+%{-v*}}\
 /bin/kernel-install add %{KVERREL}%{?-v:+%{-v*}} /lib/modules/%{KVERREL}%{?-v:+%{-v*}}/vmlinuz%{?-u:-%{-u*}.efi} || exit $?\
-if [[ ! -e "/boot/symvers-%{KVERREL}%{?-v:+%{-v*}}.%compext" ]]; then\
-    cp "/lib/modules/%{KVERREL}%{?-v:+%{-v*}}/symvers.%compext" "/boot/symvers-%{KVERREL}%{?-v:+%{-v*}}.%compext"\
+if [[ ! -e "/boot/symvers-%{KVERREL}%{?-v:+%{-v*}}.gz" ]]; then\
+    cp "/lib/modules/%{KVERREL}%{?-v:+%{-v*}}/symvers.gz" "/boot/symvers-%{KVERREL}%{?-v:+%{-v*}}.gz"\
     if command -v restorecon &>/dev/null; then\
-        restorecon "/boot/symvers-%{KVERREL}%{?-v:+%{-v*}}.%compext"\
+        restorecon "/boot/symvers-%{KVERREL}%{?-v:+%{-v*}}.gz"\
     fi\
 fi\
 %{nil}
@@ -3954,10 +3954,10 @@ fi\
 %ghost /boot/System.map-%{KVERREL}%{?3:+%{3}}\
 %dir /lib/modules\
 %dir /lib/modules/%{KVERREL}%{?3:+%{3}}\
-/lib/modules/%{KVERREL}%{?3:+%{3}}/symvers.%compext\
+/lib/modules/%{KVERREL}%{?3:+%{3}}/symvers.gz\
 /lib/modules/%{KVERREL}%{?3:+%{3}}/config\
 /lib/modules/%{KVERREL}%{?3:+%{3}}/modules.builtin*\
-%ghost %attr(0644, root, root) /boot/symvers-%{KVERREL}%{?3:+%{3}}.%compext\
+%ghost %attr(0600, root, root) /boot/symvers-%{KVERREL}%{?3:+%{3}}.gz\
 %ghost %attr(0600, root, root) /boot/initramfs-%{KVERREL}%{?3:+%{3}}.img\
 %ghost %attr(0644, root, root) /boot/config-%{KVERREL}%{?3:+%{3}}\
 %{expand:%%files -f kernel-%{?3:%{3}-}modules-core.list %{?3:%{3}-}modules-core}\
@@ -4012,7 +4012,7 @@ fi\
 %dir /lib/modules\
 %dir /lib/modules/%{KVERREL}%{?3:+%{3}}\
 /lib/modules/%{KVERREL}%{?3:+%{3}}/System.map\
-/lib/modules/%{KVERREL}%{?3:+%{3}}/symvers.%compext\
+/lib/modules/%{KVERREL}%{?3:+%{3}}/symvers.gz\
 /lib/modules/%{KVERREL}%{?3:+%{3}}/config\
 /lib/modules/%{KVERREL}%{?3:+%{3}}/modules.builtin*\
 %attr(0644, root, root) /lib/modules/%{KVERREL}%{?3:+%{3}}/%{?-k:%{-k*}}%{!?-k:vmlinuz}-virt.efi\

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -133,9 +133,10 @@ Summary: The Linux kernel
 # genspec.sh variables
 #
 
+# suffix for CLK kernel packages
+%global pkg_suffix clk%{patchversion}
 # kernel package name
-%global package_name kernel
-%global gemini 0
+%global package_name kernel-%{pkg_suffix}
 # Include Fedora files
 %global include_fedora 0
 # Include RHEL files
@@ -656,9 +657,9 @@ ExclusiveArch: noarch i386 i686 x86_64 s390x aarch64 ppc64le
 %endif
 ExclusiveOS: Linux
 %ifnarch %{nobuildarches}
-Requires: kernel-core-uname-r = %{KVERREL}
-Requires: kernel-modules-uname-r = %{KVERREL}
-Requires: kernel-modules-core-uname-r = %{KVERREL}
+Requires: %{name}-core-uname-r = %{KVERREL}
+Requires: %{name}-modules-uname-r = %{KVERREL}
+Requires: %{name}-modules-core-uname-r = %{KVERREL}
 Provides: installonlypkg(kernel)
 %endif
 
@@ -1081,6 +1082,8 @@ AutoProv: yes\
 %package doc
 Summary: Various documentation bits found in the kernel source
 Group: Documentation
+Provides: kernel-doc = %{specrpmversion}-%{release}
+Conflicts: kernel-doc
 %description doc
 This package contains documentation files from the kernel
 source. Various bits of information about the Linux kernel and the
@@ -1094,10 +1097,8 @@ options that can be passed to Linux kernel modules at load time.
 Summary: Header files for the Linux kernel for use by glibc
 Obsoletes: glibc-kernheaders < 3.0-46
 Provides: glibc-kernheaders = 3.0-46
-%if 0%{?gemini}
-Provides: kernel-headers = %{specversion}-%{release}
-Obsoletes: kernel-headers < %{specversion}
-%endif
+Provides: kernel-headers = %{specrpmversion}-%{release}
+Conflicts: kernel-headers
 %description headers
 Kernel-headers includes the C header files that specify the interface
 between the Linux kernel and userspace libraries and programs.  The
@@ -1107,10 +1108,8 @@ glibc package.
 
 %package cross-headers
 Summary: Header files for the Linux kernel for use by cross-glibc
-%if 0%{?gemini}
-Provides: kernel-cross-headers = %{specversion}-%{release}
-Obsoletes: kernel-cross-headers < %{specversion}
-%endif
+Provides: kernel-cross-headers = %{specrpmversion}-%{release}
+Conflicts: kernel-cross-headers
 %description cross-headers
 Kernel-cross-headers includes the C header files that specify the interface
 between the Linux kernel and userspace libraries and programs.  The
@@ -1121,95 +1120,101 @@ cross-glibc package.
 %package debuginfo-common-%{_target_cpu}
 Summary: Kernel source files used by %{name}-debuginfo packages
 Provides: installonlypkg(kernel)
+Provides: kernel-debuginfo-common-%{_target_cpu} = %{specrpmversion}-%{release}
+Conflicts: kernel-debuginfo-common-%{_target_cpu}
 %description debuginfo-common-%{_target_cpu}
 This package is required by %{name}-debuginfo subpackages.
 It provides the kernel source files common to all builds.
 
 %if %{with_perf}
-%package -n perf
-%if 0%{gemini}
-Epoch: %{gemini}
-%endif
+%package -n perf-%{pkg_suffix}
 Summary: Performance monitoring for the Linux kernel
+Provides: perf = %{specrpmversion}-%{release}
+Conflicts: perf
 Requires: bzip2
-%description -n perf
+%description -n perf-%{pkg_suffix}
 This package contains the perf tool, which enables performance monitoring
 of the Linux kernel.
 
-%package -n perf-debuginfo
-%if 0%{gemini}
-Epoch: %{gemini}
-%endif
+%package -n perf-%{pkg_suffix}-debuginfo
 Summary: Debug information for package perf
+Provides: perf-debuginfo = %{specrpmversion}-%{release}
+Conflicts: perf-debuginfo
 Requires: %{name}-debuginfo-common-%{_target_cpu} = %{specrpmversion}-%{release}
 AutoReqProv: no
-%description -n perf-debuginfo
+%description -n perf-%{pkg_suffix}-debuginfo
 This package provides debug information for the perf package.
 
 # Note that this pattern only works right to match the .build-id
 # symlinks because of the trailing nonmatching alternation and
 # the leading .*, because of find-debuginfo.sh's buggy handling
 # of matching the pattern against the symlinks file.
-%{expand:%%global _find_debuginfo_opts %{?_find_debuginfo_opts} -p '.*%%{_bindir}/perf(\.debug)?|.*%%{_libexecdir}/perf-core/.*|.*%%{_libdir}/libperf-jvmti.so(\.debug)?|XXX' -o perf-debuginfo.list}
+%{expand:%%global _find_debuginfo_opts %{?_find_debuginfo_opts} -p '.*%%{_bindir}/perf(\.debug)?|.*%%{_libexecdir}/perf-core/.*|.*%%{_libdir}/libperf-jvmti.so(\.debug)?|XXX' -o perf-%{pkg_suffix}-debuginfo.list}
 
-%package -n python3-perf
-%if 0%{gemini}
-Epoch: %{gemini}
-%endif
+%package -n python3-perf-%{pkg_suffix}
 Summary: Python bindings for apps which will manipulate perf events
-%description -n python3-perf
+Provides: python3-perf = %{specrpmversion}-%{release}
+Conflicts: python3-perf
+%description -n python3-perf-%{pkg_suffix}
 The python3-perf package contains a module that permits applications
 written in the Python programming language to use the interface
 to manipulate perf events.
 
-%package -n python3-perf-debuginfo
-%if 0%{gemini}
-Epoch: %{gemini}
-%endif
+%package -n python3-perf-%{pkg_suffix}-debuginfo
 Summary: Debug information for package perf python bindings
+Provides: python3-perf-debuginfo = %{specrpmversion}-%{release}
+Conflicts: python3-perf-debuginfo
 Requires: %{name}-debuginfo-common-%{_target_cpu} = %{specrpmversion}-%{release}
 AutoReqProv: no
-%description -n python3-perf-debuginfo
+%description -n python3-perf-%{pkg_suffix}-debuginfo
 This package provides debug information for the perf python bindings.
 
 # the python_sitearch macro should already be defined from above
-%{expand:%%global _find_debuginfo_opts %{?_find_debuginfo_opts} -p '.*%%{python3_sitearch}/perf.*so(\.debug)?|XXX' -o python3-perf-debuginfo.list}
+%{expand:%%global _find_debuginfo_opts %{?_find_debuginfo_opts} -p '.*%%{python3_sitearch}/perf.*so(\.debug)?|XXX' -o python3-perf-%{pkg_suffix}-debuginfo.list}
 
 # with_perf
 %endif
 
 %if %{with_libperf}
-%package -n libperf
+%package -n libperf-%{pkg_suffix}
 Summary: The perf library from kernel source
-%description -n libperf
+Provides: libperf = %{specrpmversion}-%{release}
+Conflicts: libperf
+%description -n libperf-%{pkg_suffix}
 This package contains the kernel source perf library.
 
-%package -n libperf-devel
+%package -n libperf-%{pkg_suffix}-devel
 Summary: Developement files for the perf library from kernel source
-Requires: libperf = %{version}-%{release}
-%description -n libperf-devel
+Provides: libperf-devel = %{specrpmversion}-%{release}
+Conflicts: libperf-devel
+Requires: libperf-%{pkg_suffix} = %{version}-%{release}
+%description -n libperf-%{pkg_suffix}-devel
 This package includes libraries and header files needed for development
 of applications which use perf library from kernel source.
 
-%package -n libperf-debuginfo
+%package -n libperf-%{pkg_suffix}-debuginfo
 Summary: Debug information for package libperf
+Provides: libperf-debuginfo = %{specrpmversion}-%{release}
+Conflicts: libperf-debuginfo
 Group: Development/Debug
 Requires: %{name}-debuginfo-common-%{_target_cpu} = %{version}-%{release}
 AutoReqProv: no
-%description -n libperf-debuginfo
+%description -n libperf-%{pkg_suffix}-debuginfo
 This package provides debug information for the libperf package.
 
 # Note that this pattern only works right to match the .build-id
 # symlinks because of the trailing nonmatching alternation and
 # the leading .*, because of find-debuginfo.sh's buggy handling
 # of matching the pattern against the symlinks file.
-%{expand:%%global _find_debuginfo_opts %{?_find_debuginfo_opts} -p '.*%%{_libdir}/libperf.so.*(\.debug)?|XXX' -o libperf-debuginfo.list}
+%{expand:%%global _find_debuginfo_opts %{?_find_debuginfo_opts} -p '.*%%{_libdir}/libperf.so.*(\.debug)?|XXX' -o libperf-%{pkg_suffix}-debuginfo.list}
 # with_libperf
 %endif
 
 %if %{with_tools}
 %package -n %{package_name}-tools
 Summary: Assortment of tools for the Linux kernel
+Provides: kernel-tools = %{specrpmversion}-%{release}
+Conflicts: kernel-tools
 %ifarch %{cpupowerarchs}
 Provides:  cpupowerutils = 1:009-0.6.p1
 Obsoletes: cpupowerutils < 1:009-0.6.p1
@@ -1227,12 +1232,16 @@ and the supporting documentation.
 
 %package -n %{package_name}-tools-libs
 Summary: Libraries for the kernels-tools
+Provides: kernel-tools-libs = %{specrpmversion}-%{release}
+Conflicts: kernel-tools-libs
 %description -n %{package_name}-tools-libs
 This package contains the libraries built from the tools/ directory
 from the kernel source.
 
 %package -n %{package_name}-tools-libs-devel
 Summary: Assortment of tools for the Linux kernel
+Provides: kernel-tools-libs-devel = %{specrpmversion}-%{release}
+Conflicts: kernel-tools-libs-devel
 Requires: %{package_name}-tools = %{version}-%{release}
 %ifarch %{cpupowerarchs}
 Provides:  cpupowerutils-devel = 1:009-0.6.p1
@@ -1257,22 +1266,23 @@ This package provides debug information for package %{package_name}-tools.
 # of matching the pattern against the symlinks file.
 %{expand:%%global _find_debuginfo_opts %{?_find_debuginfo_opts} -p '.*%%{_bindir}/bootconfig(\.debug)?|.*%%{_bindir}/centrino-decode(\.debug)?|.*%%{_bindir}/powernow-k8-decode(\.debug)?|.*%%{_bindir}/cpupower(\.debug)?|.*%%{_libdir}/libcpupower.*|.*%%{_bindir}/turbostat(\.debug)?|.*%%{_bindir}/x86_energy_perf_policy(\.debug)?|.*%%{_bindir}/tmon(\.debug)?|.*%%{_bindir}/lsgpio(\.debug)?|.*%%{_bindir}/gpio-hammer(\.debug)?|.*%%{_bindir}/gpio-event-mon(\.debug)?|.*%%{_bindir}/gpio-watch(\.debug)?|.*%%{_bindir}/iio_event_monitor(\.debug)?|.*%%{_bindir}/iio_generic_buffer(\.debug)?|.*%%{_bindir}/lsiio(\.debug)?|.*%%{_bindir}/intel-speed-select(\.debug)?|.*%%{_bindir}/page_owner_sort(\.debug)?|.*%%{_bindir}/slabinfo(\.debug)?|.*%%{_sbindir}/intel_sdsi(\.debug)?|XXX' -o %{package_name}-tools-debuginfo.list}
 
-%package -n rtla
-%if 0%{gemini}
-Epoch: %{gemini}
-%endif
+%package -n rtla-%{pkg_suffix}
 Summary: Real-Time Linux Analysis tools
+Provides: rtla = %{specrpmversion}-%{release}
+Conflicts: rtla
 Requires: libtraceevent
 Requires: libtracefs
-%description -n rtla
+%description -n rtla-%{pkg_suffix}
 The rtla meta-tool includes a set of commands that aims to analyze
 the real-time properties of Linux. Instead of testing Linux as a black box,
 rtla leverages kernel tracing capabilities to provide precise information
 about the properties and root causes of unexpected results.
 
-%package -n rv
+%package -n rv-%{pkg_suffix}
 Summary: RV: Runtime Verification
-%description -n rv
+Provides: rv = %{specrpmversion}-%{release}
+Conflicts: rv
+%description -n rv-%{pkg_suffix}
 Runtime Verification (RV) is a lightweight (yet rigorous) method that
 complements classical exhaustive verification techniques (such as model
 checking and theorem proving) with a more practical approach for
@@ -1287,6 +1297,8 @@ analysing the logical and timing behavior of Linux.
 
 %package selftests-internal
 Summary: Kernel samples and selftests
+Provides: kernel-selftests-internal = %{specrpmversion}-%{release}
+Conflicts: kernel-selftests-internal
 Requires: binutils, bpftool, iproute-tc, nmap-ncat, python3, fuse-libs, keyutils
 %description selftests-internal
 Kernel sample programs and selftests.
@@ -1353,7 +1365,7 @@ Requires: flex\
 Requires: make\
 Requires: gcc\
 %if %{-m:1}%{!-m:0}\
-Requires: kernel-devel-uname-r = %{KVERREL}%{uname_variant %{?1:%{1}}}\
+Requires: %{name}-devel-uname-r = %{KVERREL}%{uname_variant %{?1:%{1}}}\
 %endif\
 %description %{?1:%{1}-}devel\
 This package provides kernel headers and makefiles sufficient to build modules\
@@ -1399,7 +1411,7 @@ Provides: kernel%{?1:-%{1}}-modules-internal-%{_target_cpu} = %{specrpmversion}-
 Provides: kernel%{?1:-%{1}}-modules-internal = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
 Provides: kernel%{?1:-%{1}}-modules-internal-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: kernel%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 AutoReq: no\
@@ -1420,11 +1432,11 @@ Provides: kernel%{?1:-%{1}}-modules-extra-%{_target_cpu} = %{specrpmversion}-%{r
 Provides: kernel%{?1:-%{1}}-modules-extra = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
 Provides: kernel%{?1:-%{1}}-modules-extra-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: kernel%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 %if %{-m:1}%{!-m:0}\
-Requires: kernel-modules-extra-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
+Requires: %{name}-modules-extra-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
 %endif\
 AutoReq: no\
 AutoProv: yes\
@@ -1444,10 +1456,10 @@ Provides: kernel-modules-%{_target_cpu} = %{specrpmversion}-%{release}%{uname_su
 Provides: kernel-modules = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
 Provides: kernel%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 %if %{-m:1}%{!-m:0}\
-Requires: kernel-modules-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
+Requires: %{name}-modules-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
 %endif\
 AutoReq: no\
 AutoProv: yes\
@@ -1467,9 +1479,9 @@ Provides: kernel-modules-core-%{_target_cpu} = %{specrpmversion}-%{release}%{una
 Provides: kernel-modules-core = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
 Provides: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 %if %{-m:1}%{!-m:0}\
-Requires: kernel-modules-core-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
+Requires: %{name}-modules-core-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
 %endif\
 AutoReq: no\
 AutoProv: yes\
@@ -1484,9 +1496,9 @@ This package provides essential kernel modules for the %{?2:%{2}-}core kernel pa
 %define kernel_meta_package() \
 %package %{1}\
 summary: kernel meta-package for the %{1} kernel\
-Requires: kernel-%{1}-core-uname-r = %{KVERREL}%{uname_suffix %{1}}\
-Requires: kernel-%{1}-modules-uname-r = %{KVERREL}%{uname_suffix %{1}}\
-Requires: kernel-%{1}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{1}}\
+Requires: %{name}-%{1}-core-uname-r = %{KVERREL}%{uname_suffix %{1}}\
+Requires: %{name}-%{1}-modules-uname-r = %{KVERREL}%{uname_suffix %{1}}\
+Requires: %{name}-%{1}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{1}}\
 %if "%{1}" == "rt" || "%{1}" == "rt-debug"\
 Requires: realtime-setup\
 %endif\
@@ -1504,7 +1516,7 @@ The meta-package for the %{1} kernel\
 %package %{?1:%{1}-}kvm\
 Summary: KVM modules for package kernel%{?1:-%{1}}\
 Group: System Environment/Kernel\
-Requires: kernel-uname-r = %{KVERREL}%{uname_suffix %{?1:%{1}}}\
+Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:%{1}}}\
 Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
 Provides: kernel%{?1:-%{1}}-kvm-%{_target_cpu} = %{version}-%{release}\
@@ -1525,8 +1537,8 @@ Summary: %{variant_summary}\
 Provides: kernel-%{?1:%{1}-}core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel)\
 %if %{-m:1}%{!-m:0}\
-Requires: kernel-core-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
-Requires: kernel-%{?1:%{1}-}-modules-core-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
+Requires: %{name}-core-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
+Requires: %{name}-%{?1:%{1}-}-modules-core-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
 %endif\
 %{expand:%%kernel_reqprovconf %{?1:%{1}} %{-o:%{-o}}}\
 %if %{?1:1} %{!?1:0} \
@@ -1588,7 +1600,7 @@ Provides: kernel%{?1:-%{1}}-modules-partner-%{_target_cpu} = %{specrpmversion}-%
 Provides: kernel%{?1:-%{1}}-modules-partner = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
 Provides: kernel%{?1:-%{1}}-modules-partner-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: kernel%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 AutoReq: no\
@@ -1908,7 +1920,7 @@ cp %{SOURCE3001} partial-kernel-local-snip.config
 cp %{SOURCE3001} partial-kernel-local-debug-snip.config
 for config in ../ciq/configs/kernel-*.config; do
     arch=$(echo $config | sed -n 's/.*kernel-\(.*\)\.config/\1/p')
-    cp $config kernel-%{specversion}-$arch.config
+    cp $config %{name}-%{specversion}-$arch.config
 done
 
 
@@ -2112,7 +2124,7 @@ InitBuildVars() {
     Variant=$1
 
     # Pick the right kernel config file
-    Config=%{name}-%{_target_cpu}${Variant:+-${Variant}}.config
+    Config=kernel-%{_target_cpu}${Variant:+-${Variant}}.config
     DevelDir=/usr/src/kernels/%{KVERREL}${Variant:++${Variant}}
 
     KernelVer=%{specversion}-%{release}.%{_target_cpu}${Variant:++${Variant}}
@@ -3767,7 +3779,7 @@ fi\
 %endif
 
 %if %{with_perf}
-%files -n perf
+%files -n perf-%{pkg_suffix}
 %{_bindir}/perf
 %{_libdir}/libperf-jvmti.so
 %dir %{_libexecdir}/perf-core
@@ -3779,23 +3791,23 @@ fi\
 %{_docdir}/perf-tip/tips.txt
 %{_includedir}/perf/perf_dlfilter.h
 
-%files -n python3-perf
+%files -n python3-perf-%{pkg_suffix}
 %{python3_sitearch}/*
 
 %if %{with_debuginfo}
-%files -f perf-debuginfo.list -n perf-debuginfo
+%files -f perf-%{pkg_suffix}-debuginfo.list -n perf-%{pkg_suffix}-debuginfo
 
-%files -f python3-perf-debuginfo.list -n python3-perf-debuginfo
+%files -f python3-perf-%{pkg_suffix}-debuginfo.list -n python3-perf-%{pkg_suffix}-debuginfo
 %endif
 # with_perf
 %endif
 
 %if %{with_libperf}
-%files -n libperf
+%files -n libperf-%{pkg_suffix}
 %{_libdir}/libperf.so.0
 %{_libdir}/libperf.so.0.0.1
 
-%files -n libperf-devel
+%files -n libperf-%{pkg_suffix}-devel
 %{_libdir}/libperf.so
 %{_libdir}/pkgconfig/libperf.pc
 %{_includedir}/internal/*.h
@@ -3817,7 +3829,7 @@ fi\
 %{_docdir}/libperf/html/libperf-sampling.html
 
 %if %{with_debuginfo}
-%files -f libperf-debuginfo.list -n libperf-debuginfo
+%files -f libperf-%{pkg_suffix}-debuginfo.list -n libperf-%{pkg_suffix}-debuginfo
 %endif
 
 # with_libperf
@@ -3878,7 +3890,7 @@ fi\
 %{_includedir}/powercap.h
 %endif
 
-%files -n rtla
+%files -n rtla-%{pkg_suffix}
 %{_bindir}/rtla
 %{_bindir}/hwnoise
 %{_bindir}/osnoise
@@ -3892,7 +3904,7 @@ fi\
 %{_mandir}/man1/rtla-timerlat.1.gz
 %{_mandir}/man1/rtla.1.gz
 
-%files -n rv
+%files -n rv-%{pkg_suffix}
 %{_bindir}/rv
 %{_mandir}/man1/rv-list.1.gz
 %{_mandir}/man1/rv-mon-wip.1.gz

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -663,6 +663,7 @@ Requires: %{name}-core-uname-r = %{KVERREL}
 Requires: %{name}-modules-uname-r = %{KVERREL}
 Requires: %{name}-modules-core-uname-r = %{KVERREL}
 Provides: installonlypkg(kernel)
+Provides: kernel = %{specversion}-%{pkg_release}
 %endif
 
 

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -334,7 +334,7 @@ Summary: The Linux kernel
 %define make_target bzImage
 %define image_install_path boot
 
-%define KVERREL %{specversion}-%{release}.%{_target_cpu}
+%define KVERREL %{specversion}-%{release}.%{_target_cpu}+%{pkg_suffix}
 %define KVERREL_RE %(echo %KVERREL | sed 's/+/[+]/g')
 %define hdrarch %_target_cpu
 %define asmarch %_target_cpu
@@ -2127,13 +2127,13 @@ InitBuildVars() {
     Config=kernel-%{_target_cpu}${Variant:+-${Variant}}.config
     DevelDir=/usr/src/kernels/%{KVERREL}${Variant:++${Variant}}
 
-    KernelVer=%{specversion}-%{release}.%{_target_cpu}${Variant:++${Variant}}
+    KernelVer=%{specversion}-%{release}.%{_target_cpu}+%{pkg_suffix}${Variant:++${Variant}}
 
     %{log_msg "InitBuildVars: Update Makefile"}
     # make sure EXTRAVERSION says what we want it to say
     # Trim the release if this is a CI build, since KERNELVERSION is limited to 64 characters
     ShortRel=$(perl -e "print \"%{release}\" =~ s/\.pr\.[0-9A-Fa-f]{32}//r")
-    perl -p -i -e "s/^EXTRAVERSION.*/EXTRAVERSION = -${ShortRel}.%{_target_cpu}${Variant:++${Variant}}/" Makefile
+    perl -p -i -e "s/^EXTRAVERSION.*/EXTRAVERSION = -${ShortRel}.%{_target_cpu}+%{pkg_suffix}${Variant:++${Variant}}/" Makefile
 
     # if pre-rc1 devel kernel, must fix up PATCHLEVEL for our versioning scheme
     # if we are post rc1 this should match anyway so this won't matter

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -1057,6 +1057,7 @@ The kernel meta package
 %define kernel_reqprovconf(o) \
 %if %{-o:0}%{!-o:1}\
 Provides: kernel = %{specversion}-%{pkg_release}\
+Provides: %{name} = %{specversion}-%{pkg_release}\
 %endif\
 Provides: %{name}-%{_target_cpu} = %{specversion}-%{pkg_release}%{uname_suffix %{?1:+%{1}}}\
 Provides: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
@@ -1371,6 +1372,7 @@ Summary: Development package for building kernel modules to match the %{?2:%{2} 
 Provides: %{name}%{?1:-%{1}}-devel-%{_target_cpu} = %{specversion}-%{release}\
 Provides: %{name}-devel-%{_target_cpu} = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: kernel-devel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}-devel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel)\
 AutoReqProv: no\
 Requires(pre): findutils\

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -2154,7 +2154,7 @@ InitBuildVars() {
     Variant=$1
 
     # Pick the right kernel config file
-    Config=kernel-%{_target_cpu}${Variant:+-${Variant}}.config
+    Config=%{name}-%{specversion}-%{_target_cpu}${Variant:+-${Variant}}.config
     DevelDir=/usr/src/kernels/%{KVERREL}${Variant:++${Variant}}
 
     KernelVer=%{specversion}-%{release}.%{_target_cpu}+%{pkg_suffix}${Variant:++${Variant}}

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -1102,7 +1102,6 @@ options that can be passed to Linux kernel modules at load time.
 Summary: Header files for the Linux kernel for use by glibc
 Obsoletes: glibc-kernheaders < 3.0-46
 Provides: glibc-kernheaders = 3.0-46
-Provides: kernel-headers = %{specversion}-%{release}
 Conflicts: kernel-headers
 %description headers
 Kernel-headers includes the C header files that specify the interface

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -1102,7 +1102,7 @@ options that can be passed to Linux kernel modules at load time.
 Summary: Header files for the Linux kernel for use by glibc
 Obsoletes: glibc-kernheaders < 3.0-46
 Provides: glibc-kernheaders = 3.0-46
-Conflicts: kernel-headers
+Provides: kernel-headers = %{specversion}-%{release}
 %description headers
 Kernel-headers includes the C header files that specify the interface
 between the Linux kernel and userspace libraries and programs.  The
@@ -1113,7 +1113,6 @@ glibc package.
 %package cross-headers
 Summary: Header files for the Linux kernel for use by cross-glibc
 Provides: kernel-cross-headers = %{specversion}-%{release}
-Conflicts: kernel-cross-headers
 %description cross-headers
 Kernel-cross-headers includes the C header files that specify the interface
 between the Linux kernel and userspace libraries and programs.  The
@@ -1371,6 +1370,8 @@ This is required to use SystemTap with %{name}%{?1:-%{1}}-%{KVERREL}.\
 Summary: Development package for building kernel modules to match the %{?2:%{2} }kernel\
 Provides: %{name}%{?1:-%{1}}-devel-%{_target_cpu} = %{specversion}-%{release}\
 Provides: %{name}-devel-%{_target_cpu} = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: kernel-devel = %{specversion}-%{release}\
+Provides: kernel-devel-%{_target_cpu} = %{specversion}-%{release}\
 Provides: kernel-devel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Provides: %{name}-devel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel)\

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -134,7 +134,7 @@ Summary: The Linux kernel
 #
 
 # suffix for CLK kernel packages
-%global pkg_suffix clk%{patchversion}
+%global pkg_suffix clk%{kernel_major_minor}
 # kernel package name
 %global package_name kernel-%{pkg_suffix}
 # Include Fedora files
@@ -161,17 +161,19 @@ Summary: The Linux kernel
 #  to build the base kernel using the debug configuration. (Specifying
 #  the --with-release option overrides this setting.)
 %define debugbuildsenabled 1
-%define buildid .1.0.0
-%define specrpmversion 6.12.78
-%define specversion 6.12.78
-%define patchversion 6.12
-%define pkgrelease 1.1.0.0
-%define kversion 6
-%define tarfile_release 6.12.78-1.1.0.0.el9_clk
+%define el_version 9
+%define kernel_major_minor 6.12
+%define kernel_patch 78
+%define buildid .1
+%define specversion %{kernel_major_minor}.%{kernel_patch}
+%define pkgrelease 1%{?buildid}
+%define kversion %{lua:print((rpm.expand("%{kernel_major_minor}"):match("^(%d+)")))}
+
+%define tarfile_release %{specversion}-%{pkgrelease}.el%{el_version}
 # This is needed to do merge window version magic
-%define patchlevel 12
+%define patchlevel %{lua:print((rpm.expand("%{kernel_major_minor}"):match("%.(%d+)$")))}
 # This allows pkg_release to have configurable %%{?dist} tag
-%define specrelease 1%{?buildid}%{?dist}
+%define specrelease %{pkgrelease}%{?dist}
 
 # If this variable is set to 1, a bpf selftests build failure will cause a
 # fatal kernel package build error
@@ -464,7 +466,7 @@ Summary: The Linux kernel
 %endif
 %endif
 
-%define all_configs %{name}-%{specrpmversion}-*.config
+%define all_configs %{name}-%{specversion}-*.config
 
 # don't build noarch kernels or headers (duh)
 %ifarch noarch
@@ -646,7 +648,7 @@ Summary: The Linux kernel
 Name: %{package_name}
 License: ((GPL-2.0-only WITH Linux-syscall-note) OR BSD-2-Clause) AND ((GPL-2.0-only WITH Linux-syscall-note) OR BSD-3-Clause) AND ((GPL-2.0-only WITH Linux-syscall-note) OR CDDL-1.0) AND ((GPL-2.0-only WITH Linux-syscall-note) OR Linux-OpenIB) AND ((GPL-2.0-only WITH Linux-syscall-note) OR MIT) AND ((GPL-2.0-or-later WITH Linux-syscall-note) OR BSD-3-Clause) AND ((GPL-2.0-or-later WITH Linux-syscall-note) OR MIT) AND 0BSD AND BSD-2-Clause AND (BSD-2-Clause OR Apache-2.0) AND BSD-3-Clause AND BSD-3-Clause-Clear AND CC0-1.0 AND GFDL-1.1-no-invariants-or-later AND GPL-1.0-or-later AND (GPL-1.0-or-later OR BSD-3-Clause) AND (GPL-1.0-or-later WITH Linux-syscall-note) AND GPL-2.0-only AND (GPL-2.0-only OR Apache-2.0) AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0-only OR BSD-3-Clause) AND (GPL-2.0-only OR CDDL-1.0) AND (GPL-2.0-only OR GFDL-1.1-no-invariants-or-later) AND (GPL-2.0-only OR GFDL-1.2-no-invariants-only) AND (GPL-2.0-only WITH Linux-syscall-note) AND GPL-2.0-or-later AND (GPL-2.0-or-later OR BSD-2-Clause) AND (GPL-2.0-or-later OR BSD-3-Clause) AND (GPL-2.0-or-later OR CC-BY-4.0) AND (GPL-2.0-or-later WITH GCC-exception-2.0) AND (GPL-2.0-or-later WITH Linux-syscall-note) AND ISC AND LGPL-2.0-or-later AND (LGPL-2.0-or-later OR BSD-2-Clause) AND (LGPL-2.0-or-later WITH Linux-syscall-note) AND LGPL-2.1-only AND (LGPL-2.1-only OR BSD-2-Clause) AND (LGPL-2.1-only WITH Linux-syscall-note) AND LGPL-2.1-or-later AND (LGPL-2.1-or-later WITH Linux-syscall-note) AND (Linux-OpenIB OR GPL-2.0-only) AND (Linux-OpenIB OR GPL-2.0-only OR BSD-2-Clause) AND Linux-man-pages-copyleft AND MIT AND (MIT OR Apache-2.0) AND (MIT OR GPL-2.0-only) AND (MIT OR GPL-2.0-or-later) AND (MIT OR LGPL-2.1-only) AND (MPL-1.1 OR GPL-2.0-only) AND (X11 OR GPL-2.0-only) AND (X11 OR GPL-2.0-or-later) AND Zlib AND (copyleft-next-0.3.1 OR GPL-2.0-or-later)
 URL: https://www.kernel.org/
-Version: %{specrpmversion}
+Version: %{specversion}
 Release: %{pkg_release}
 # DO NOT CHANGE THE 'ExclusiveArch' LINE TO TEMPORARILY EXCLUDE AN ARCHITECTURE BUILD.
 # SET %%nobuildarches (ABOVE) INSTEAD
@@ -670,9 +672,7 @@ Provides: installonlypkg(kernel)
 BuildRequires: kmod, bash, coreutils, tar, git-core, which
 BuildRequires: bzip2, xz, findutils, m4, perl-interpreter, perl-Carp, perl-devel, perl-generators, make, diffutils, gawk, %compression
 BuildRequires: gcc, binutils, redhat-rpm-config, hmaccalc, bison, flex, gcc-c++
-%if 0%{?fedora}
-BuildRequires: rust, rust-src, bindgen
-%endif
+BuildRequires: rust, rust-src, rustfmt, clippy
 BuildRequires: net-tools, hostname, bc, elfutils-devel
 BuildRequires: dwarves
 BuildRequires: python3
@@ -1030,11 +1030,14 @@ Source3002: Patchlist.changelog
 Source4000: README.rst
 Source4002: gating.yaml
 
+# Bundled bindgen-cli source (not packaged in Rocky 9.6)
+Source5000: bindgen-cli.tar.gz
+
 ## Patches needed for building this package
 
 %if !%{nopatches}
 
-Patch1: patch-%{patchversion}-redhat.patch
+Patch1: patch-%{kernel_major_minor}-redhat.patch
 %endif
 
 # empty final patch to facilitate testing of kernel patches
@@ -1055,9 +1058,9 @@ The kernel meta package
 %if %{-o:0}%{!-o:1}\
 Provides: kernel = %{specversion}-%{pkg_release}\
 %endif\
-Provides: kernel-%{_target_cpu} = %{specrpmversion}-%{pkg_release}%{uname_suffix %{?1:+%{1}}}\
-Provides: kernel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}-%{_target_cpu} = %{specversion}-%{pkg_release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires(pre): %{kernel_prereq}\
 Requires(pre): %{initrd_prereq}\
 Requires(pre): ((linux-firmware >= 20150904-56.git6ebf5d57) if linux-firmware)\
@@ -1082,7 +1085,7 @@ AutoProv: yes\
 %package doc
 Summary: Various documentation bits found in the kernel source
 Group: Documentation
-Provides: kernel-doc = %{specrpmversion}-%{release}
+Provides: kernel-doc = %{specversion}-%{release}
 Conflicts: kernel-doc
 %description doc
 This package contains documentation files from the kernel
@@ -1097,7 +1100,7 @@ options that can be passed to Linux kernel modules at load time.
 Summary: Header files for the Linux kernel for use by glibc
 Obsoletes: glibc-kernheaders < 3.0-46
 Provides: glibc-kernheaders = 3.0-46
-Provides: kernel-headers = %{specrpmversion}-%{release}
+Provides: kernel-headers = %{specversion}-%{release}
 Conflicts: kernel-headers
 %description headers
 Kernel-headers includes the C header files that specify the interface
@@ -1108,7 +1111,7 @@ glibc package.
 
 %package cross-headers
 Summary: Header files for the Linux kernel for use by cross-glibc
-Provides: kernel-cross-headers = %{specrpmversion}-%{release}
+Provides: kernel-cross-headers = %{specversion}-%{release}
 Conflicts: kernel-cross-headers
 %description cross-headers
 Kernel-cross-headers includes the C header files that specify the interface
@@ -1120,7 +1123,7 @@ cross-glibc package.
 %package debuginfo-common-%{_target_cpu}
 Summary: Kernel source files used by %{name}-debuginfo packages
 Provides: installonlypkg(kernel)
-Provides: kernel-debuginfo-common-%{_target_cpu} = %{specrpmversion}-%{release}
+Provides: kernel-debuginfo-common-%{_target_cpu} = %{specversion}-%{release}
 Conflicts: kernel-debuginfo-common-%{_target_cpu}
 %description debuginfo-common-%{_target_cpu}
 This package is required by %{name}-debuginfo subpackages.
@@ -1129,7 +1132,7 @@ It provides the kernel source files common to all builds.
 %if %{with_perf}
 %package -n perf-%{pkg_suffix}
 Summary: Performance monitoring for the Linux kernel
-Provides: perf = %{specrpmversion}-%{release}
+Provides: perf = %{specversion}-%{release}
 Conflicts: perf
 Requires: bzip2
 %description -n perf-%{pkg_suffix}
@@ -1138,9 +1141,9 @@ of the Linux kernel.
 
 %package -n perf-%{pkg_suffix}-debuginfo
 Summary: Debug information for package perf
-Provides: perf-debuginfo = %{specrpmversion}-%{release}
+Provides: perf-debuginfo = %{specversion}-%{release}
 Conflicts: perf-debuginfo
-Requires: %{name}-debuginfo-common-%{_target_cpu} = %{specrpmversion}-%{release}
+Requires: %{name}-debuginfo-common-%{_target_cpu} = %{specversion}-%{release}
 AutoReqProv: no
 %description -n perf-%{pkg_suffix}-debuginfo
 This package provides debug information for the perf package.
@@ -1153,7 +1156,7 @@ This package provides debug information for the perf package.
 
 %package -n python3-perf-%{pkg_suffix}
 Summary: Python bindings for apps which will manipulate perf events
-Provides: python3-perf = %{specrpmversion}-%{release}
+Provides: python3-perf = %{specversion}-%{release}
 Conflicts: python3-perf
 %description -n python3-perf-%{pkg_suffix}
 The python3-perf package contains a module that permits applications
@@ -1162,9 +1165,9 @@ to manipulate perf events.
 
 %package -n python3-perf-%{pkg_suffix}-debuginfo
 Summary: Debug information for package perf python bindings
-Provides: python3-perf-debuginfo = %{specrpmversion}-%{release}
+Provides: python3-perf-debuginfo = %{specversion}-%{release}
 Conflicts: python3-perf-debuginfo
-Requires: %{name}-debuginfo-common-%{_target_cpu} = %{specrpmversion}-%{release}
+Requires: %{name}-debuginfo-common-%{_target_cpu} = %{specversion}-%{release}
 AutoReqProv: no
 %description -n python3-perf-%{pkg_suffix}-debuginfo
 This package provides debug information for the perf python bindings.
@@ -1178,14 +1181,14 @@ This package provides debug information for the perf python bindings.
 %if %{with_libperf}
 %package -n libperf-%{pkg_suffix}
 Summary: The perf library from kernel source
-Provides: libperf = %{specrpmversion}-%{release}
+Provides: libperf = %{specversion}-%{release}
 Conflicts: libperf
 %description -n libperf-%{pkg_suffix}
 This package contains the kernel source perf library.
 
 %package -n libperf-%{pkg_suffix}-devel
 Summary: Developement files for the perf library from kernel source
-Provides: libperf-devel = %{specrpmversion}-%{release}
+Provides: libperf-devel = %{specversion}-%{release}
 Conflicts: libperf-devel
 Requires: libperf-%{pkg_suffix} = %{version}-%{release}
 %description -n libperf-%{pkg_suffix}-devel
@@ -1194,7 +1197,7 @@ of applications which use perf library from kernel source.
 
 %package -n libperf-%{pkg_suffix}-debuginfo
 Summary: Debug information for package libperf
-Provides: libperf-debuginfo = %{specrpmversion}-%{release}
+Provides: libperf-debuginfo = %{specversion}-%{release}
 Conflicts: libperf-debuginfo
 Group: Development/Debug
 Requires: %{name}-debuginfo-common-%{_target_cpu} = %{version}-%{release}
@@ -1211,9 +1214,9 @@ This package provides debug information for the libperf package.
 %endif
 
 %if %{with_tools}
-%package -n %{package_name}-tools
+%package tools
 Summary: Assortment of tools for the Linux kernel
-Provides: kernel-tools = %{specrpmversion}-%{release}
+Provides: kernel-tools = %{specversion}-%{release}
 Conflicts: kernel-tools
 %ifarch %{cpupowerarchs}
 Provides:  cpupowerutils = 1:009-0.6.p1
@@ -1223,24 +1226,24 @@ Provides:  cpufrequtils = 1:009-0.6.p1
 Obsoletes: cpufreq-utils < 1:009-0.6.p1
 Obsoletes: cpufrequtils < 1:009-0.6.p1
 Obsoletes: cpuspeed < 1:1.5-16
-Requires: %{package_name}-tools-libs = %{specrpmversion}-%{release}
+Requires: %{package_name}-tools-libs = %{specversion}-%{release}
 %endif
 %define __requires_exclude ^%{_bindir}/python
-%description -n %{package_name}-tools
+%description tools
 This package contains the tools/ directory from the kernel source
 and the supporting documentation.
 
-%package -n %{package_name}-tools-libs
+%package tools-libs
 Summary: Libraries for the kernels-tools
-Provides: kernel-tools-libs = %{specrpmversion}-%{release}
+Provides: kernel-tools-libs = %{specversion}-%{release}
 Conflicts: kernel-tools-libs
-%description -n %{package_name}-tools-libs
+%description tools-libs
 This package contains the libraries built from the tools/ directory
 from the kernel source.
 
-%package -n %{package_name}-tools-libs-devel
+%package tools-libs-devel
 Summary: Assortment of tools for the Linux kernel
-Provides: kernel-tools-libs-devel = %{specrpmversion}-%{release}
+Provides: kernel-tools-libs-devel = %{specversion}-%{release}
 Conflicts: kernel-tools-libs-devel
 Requires: %{package_name}-tools = %{version}-%{release}
 %ifarch %{cpupowerarchs}
@@ -1249,15 +1252,15 @@ Obsoletes: cpupowerutils-devel < 1:009-0.6.p1
 %endif
 Requires: %{package_name}-tools-libs = %{version}-%{release}
 Provides: %{package_name}-tools-devel
-%description -n %{package_name}-tools-libs-devel
+%description tools-libs-devel
 This package contains the development files for the tools/ directory from
 the kernel source.
 
-%package -n %{package_name}-tools-debuginfo
+%package tools-debuginfo
 Summary: Debug information for package %{package_name}-tools
 Requires: %{name}-debuginfo-common-%{_target_cpu} = %{version}-%{release}
 AutoReqProv: no
-%description -n %{package_name}-tools-debuginfo
+%description tools-debuginfo
 This package provides debug information for package %{package_name}-tools.
 
 # Note that this pattern only works right to match the .build-id
@@ -1268,7 +1271,7 @@ This package provides debug information for package %{package_name}-tools.
 
 %package -n rtla-%{pkg_suffix}
 Summary: Real-Time Linux Analysis tools
-Provides: rtla = %{specrpmversion}-%{release}
+Provides: rtla = %{specversion}-%{release}
 Conflicts: rtla
 Requires: libtraceevent
 Requires: libtracefs
@@ -1280,7 +1283,7 @@ about the properties and root causes of unexpected results.
 
 %package -n rv-%{pkg_suffix}
 Summary: RV: Runtime Verification
-Provides: rv = %{specrpmversion}-%{release}
+Provides: rv = %{specversion}-%{release}
 Conflicts: rv
 %description -n rv-%{pkg_suffix}
 Runtime Verification (RV) is a lightweight (yet rigorous) method that
@@ -1293,11 +1296,26 @@ analysing the logical and timing behavior of Linux.
 # with_tools
 %endif
 
+%package default
+Summary: Set kernel-%{pkg_suffix} as the default kernel
+Requires: %{package_name} = %{?epoch:%{epoch}:}%{specversion}-%{release}
+Requires(posttrans): %{package_name}-core = %{?epoch:%{epoch}:}%{specversion}-%{release}
+Provides: kernel-provider(default)
+Conflicts: kernel-provider(default)
+%description default
+This package sets kernel-%{pkg_suffix} as the default kernel for the system
+by modifying /etc/sysconfig/kernel. When installed, only new kernels of the
+kernel-%{pkg_suffix} variants will be set as the default kernel.
+
+WARNING: Installing this package takes ownership of /etc/sysconfig/kernel.
+Manual edits will be overwritten on reinstall. To manage this file yourself,
+remove this package first.
+
 %if %{with_selftests}
 
 %package selftests-internal
 Summary: Kernel samples and selftests
-Provides: kernel-selftests-internal = %{specrpmversion}-%{release}
+Provides: kernel-selftests-internal = %{specversion}-%{release}
 Conflicts: kernel-selftests-internal
 Requires: binutils, bpftool, iproute-tc, nmap-ncat, python3, fuse-libs, keyutils
 %description selftests-internal
@@ -1333,8 +1351,8 @@ Summary: gcov graph and source files for coverage data collection.\
 %define kernel_debuginfo_package() \
 %package %{?1:%{1}-}debuginfo\
 Summary: Debug information for package %{name}%{?1:-%{1}}\
-Requires: %{name}-debuginfo-common-%{_target_cpu} = %{specrpmversion}-%{release}\
-Provides: %{name}%{?1:-%{1}}-debuginfo-%{_target_cpu} = %{specrpmversion}-%{release}\
+Requires: %{name}-debuginfo-common-%{_target_cpu} = %{specversion}-%{release}\
+Provides: %{name}%{?1:-%{1}}-debuginfo-%{_target_cpu} = %{specversion}-%{release}\
 Provides: installonlypkg(kernel)\
 AutoReqProv: no\
 %description %{?1:%{1}-}debuginfo\
@@ -1350,8 +1368,8 @@ This is required to use SystemTap with %{name}%{?1:-%{1}}-%{KVERREL}.\
 %define kernel_devel_package(m) \
 %package %{?1:%{1}-}devel\
 Summary: Development package for building kernel modules to match the %{?2:%{2} }kernel\
-Provides: kernel%{?1:-%{1}}-devel-%{_target_cpu} = %{specrpmversion}-%{release}\
-Provides: kernel-devel-%{_target_cpu} = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-devel-%{_target_cpu} = %{specversion}-%{release}\
+Provides: %{name}-devel-%{_target_cpu} = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: kernel-devel-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel)\
 AutoReqProv: no\
@@ -1380,8 +1398,8 @@ against the %{?2:%{2} }kernel package.\
 %define kernel_devel_matched_package(m) \
 %package %{?1:%{1}-}devel-matched\
 Summary: Meta package to install matching core and devel packages for a given %{?2:%{2} }kernel\
-Requires: %{package_name}%{?1:-%{1}}-devel = %{specrpmversion}-%{release}\
-Requires: %{package_name}%{?1:-%{1}}-core = %{specrpmversion}-%{release}\
+Requires: %{package_name}%{?1:-%{1}}-devel = %{specversion}-%{release}\
+Requires: %{package_name}%{?1:-%{1}}-core = %{specversion}-%{release}\
 %description %{?1:%{1}-}devel-matched\
 This meta package is used to install matching core and devel packages for a given %{?2:%{2} }kernel.\
 %{nil}
@@ -1406,14 +1424,14 @@ This package provides *.ipa-clones files.\
 %package %{?1:%{1}-}modules-internal\
 Summary: Extra kernel modules to match the %{?2:%{2} }kernel\
 Group: System Environment/Kernel\
-Provides: kernel%{?1:-%{1}}-modules-internal-%{_target_cpu} = %{specrpmversion}-%{release}\
-Provides: kernel%{?1:-%{1}}-modules-internal-%{_target_cpu} = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
-Provides: kernel%{?1:-%{1}}-modules-internal = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-internal-%{_target_cpu} = %{specversion}-%{release}\
+Provides: %{name}%{?1:-%{1}}-modules-internal-%{_target_cpu} = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-internal = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
-Provides: kernel%{?1:-%{1}}-modules-internal-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-internal-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 AutoReq: no\
 AutoProv: yes\
 %description %{?1:%{1}-}modules-internal\
@@ -1427,14 +1445,14 @@ This package provides kernel modules for the %{?2:%{2} }kernel package for CIQ i
 %define kernel_modules_extra_package(m) \
 %package %{?1:%{1}-}modules-extra\
 Summary: Extra kernel modules to match the %{?2:%{2} }kernel\
-Provides: kernel%{?1:-%{1}}-modules-extra-%{_target_cpu} = %{specrpmversion}-%{release}\
-Provides: kernel%{?1:-%{1}}-modules-extra-%{_target_cpu} = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
-Provides: kernel%{?1:-%{1}}-modules-extra = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-extra-%{_target_cpu} = %{specversion}-%{release}\
+Provides: %{name}%{?1:-%{1}}-modules-extra-%{_target_cpu} = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-extra = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
-Provides: kernel%{?1:-%{1}}-modules-extra-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-extra-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 %if %{-m:1}%{!-m:0}\
 Requires: %{name}-modules-extra-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
 %endif\
@@ -1451,13 +1469,13 @@ This package provides less commonly used kernel modules for the %{?2:%{2} }kerne
 %define kernel_modules_package(m) \
 %package %{?1:%{1}-}modules\
 Summary: kernel modules to match the %{?2:%{2}-}core kernel\
-Provides: kernel%{?1:-%{1}}-modules-%{_target_cpu} = %{specrpmversion}-%{release}\
-Provides: kernel-modules-%{_target_cpu} = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
-Provides: kernel-modules = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-%{_target_cpu} = %{specversion}-%{release}\
+Provides: %{name}-modules-%{_target_cpu} = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}-modules = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
-Provides: kernel%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 %if %{-m:1}%{!-m:0}\
 Requires: %{name}-modules-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
 %endif\
@@ -1474,11 +1492,11 @@ This package provides commonly used kernel modules for the %{?2:%{2}-}core kerne
 %define kernel_modules_core_package(m) \
 %package %{?1:%{1}-}modules-core\
 Summary: Core kernel modules to match the %{?2:%{2}-}core kernel\
-Provides: kernel%{?1:-%{1}}-modules-core-%{_target_cpu} = %{specrpmversion}-%{release}\
-Provides: kernel-modules-core-%{_target_cpu} = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
-Provides: kernel-modules-core = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-core-%{_target_cpu} = %{specversion}-%{release}\
+Provides: %{name}-modules-core-%{_target_cpu} = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}-modules-core = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
-Provides: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 %if %{-m:1}%{!-m:0}\
 Requires: %{name}-modules-core-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
@@ -1534,7 +1552,7 @@ This package provides KVM modules for package kernel%{?1:-%{1}}.\
 %define kernel_variant_package(n:mo) \
 %package %{?1:%{1}-}core\
 Summary: %{variant_summary}\
-Provides: kernel-%{?1:%{1}-}core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}-%{?1:%{1}-}core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel)\
 %if %{-m:1}%{!-m:0}\
 Requires: %{name}-core-uname-r = %{KVERREL}%{uname_variant %{?1:+%{1}}}\
@@ -1563,8 +1581,8 @@ Requires: %{name}-%{?1:%{1}-}-modules-core-uname-r = %{KVERREL}%{uname_variant %
 %package %{?1:%{1}-}uki-virt\
 Summary: %{variant_summary} unified kernel image for virtual machines\
 Provides: installonlypkg(kernel)\
-Provides: kernel-%{?1:%{1}-}uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}-%{?1:%{1}-}uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires(pre): %{kernel_prereq}\
 %if 0%{?rhel}\
 Requires(pre): systemd >= 252-31\
@@ -1574,7 +1592,7 @@ Requires(pre): systemd >= 254-1\
 %package %{?1:%{1}-}uki-virt-addons\
 Summary: %{variant_summary} unified kernel image addons for virtual machines\
 Provides: installonlypkg(kernel)\
-Requires: kernel%{?1:-%{1}}-uki-virt = %{specrpmversion}-%{release}\
+Requires: kernel%{?1:-%{1}}-uki-virt = %{specversion}-%{release}\
 %if 0%{?rhel}\
 Requires(pre): systemd >= 252-31\
 %else \
@@ -1595,14 +1613,14 @@ Requires(pre): systemd >= 254-1\
 %package %{?1:%{1}-}modules-partner\
 Summary: Extra kernel modules to match the %{?2:%{2} }kernel\
 Group: System Environment/Kernel\
-Provides: kernel%{?1:-%{1}}-modules-partner-%{_target_cpu} = %{specrpmversion}-%{release}\
-Provides: kernel%{?1:-%{1}}-modules-partner-%{_target_cpu} = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
-Provides: kernel%{?1:-%{1}}-modules-partner = %{specrpmversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-partner-%{_target_cpu} = %{specversion}-%{release}\
+Provides: %{name}%{?1:-%{1}}-modules-partner-%{_target_cpu} = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-partner = %{specversion}-%{release}%{uname_suffix %{?1:+%{1}}}\
 Provides: installonlypkg(kernel-module)\
-Provides: kernel%{?1:-%{1}}-modules-partner-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Provides: %{name}%{?1:-%{1}}-modules-partner-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 Requires: %{name}-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
-Requires: kernel%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}%{?1:-%{1}}-modules-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
+Requires: %{name}%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?1:+%{1}}}\
 AutoReq: no\
 AutoProv: yes\
 %description %{?1:%{1}-}modules-partner\
@@ -1865,7 +1883,7 @@ cd linux-%{KVERREL}
 %{log_msg "Start of patch applications"}
 %if !%{nopatches}
 
-ApplyOptionalPatch patch-%{patchversion}-redhat.patch
+ApplyOptionalPatch patch-%{kernel_major_minor}-redhat.patch
 %endif
 
 ApplyOptionalPatch linux-kernel-test.patch
@@ -1876,7 +1894,7 @@ ApplyOptionalPatch linux-kernel-test.patch
 # Any further pre-build tree manipulations happen here.
 %{log_msg "Pre-build tree manipulations"}
 chmod +x scripts/checkpatch.pl
-mv COPYING COPYING-%{specrpmversion}-%{release}
+mv COPYING COPYING-%{specversion}-%{release}
 
 # on linux-next prevent scripts/setlocalversion from mucking with our version numbers
 rm -f localversion-next localversion-rt
@@ -2047,7 +2065,7 @@ for opt in %{clang_make_opts}; do
 done
 %endif
 %{log_msg "Generate CIQ configs"}
-RHJOBS=$RPM_BUILD_NCPUS SPECPACKAGE_NAME=%{name} ./process_configs.sh $OPTS %{specrpmversion}
+RHJOBS=$RPM_BUILD_NCPUS SPECPACKAGE_NAME=%{name} ./process_configs.sh $OPTS %{specversion}
 
 # We may want to override files from the primary target in case of building
 # against a flavour of it (eg. centos not rhel), thus override it here if
@@ -2111,6 +2129,18 @@ cp_vmlinux()
 %define build_hostcflags  %{?build_cflags}
 %define build_hostldflags %{?build_ldflags}
 %endif
+
+# Build bundled bindgen and add to PATH
+%{log_msg "Build bindgen"}
+BINDGEN_DIR=$RPM_BUILD_ROOT/bindgen
+BINDGEN_BUNDLE_NAME=$(basename %{SOURCE5000} .tar.gz)
+mkdir -p $BINDGEN_DIR
+tar -xf %{SOURCE5000} -C $BINDGEN_DIR
+pushd $BINDGEN_DIR/$BINDGEN_BUNDLE_NAME
+cargo build --offline --frozen --release
+export PATH="$PWD/target/release:$PATH"
+popd
+bindgen --version
 
 %define make %{__make} %{?cross_opts} %{?make_opts} HOSTCFLAGS="%{?build_hostcflags}" HOSTLDFLAGS="%{?build_hostldflags}"
 
@@ -3477,12 +3507,68 @@ popd
 ###
 
 %if %{with_tools}
-%post -n %{package_name}-tools-libs
+%post tools-libs
 /sbin/ldconfig
 
-%postun -n %{package_name}-tools-libs
+%postun tools-libs
 /sbin/ldconfig
 %endif
+
+%postun default
+# Restore original /etc/sysconfig/kernel on uninstall, but only if the file
+# still references our kernel.  If another kernel-provider(default) package
+# has already taken over the file, the grep won't match and we leave it alone.
+if [ "$1" -eq 0 ] && \
+   grep -q "^DEFAULTKERNEL=kernel-%{pkg_suffix}-core$" /etc/sysconfig/kernel 2>/dev/null; then
+    if [ -f /etc/sysconfig/kernel.rpmsave ]; then
+        mv -f /etc/sysconfig/kernel.rpmsave /etc/sysconfig/kernel
+    else
+        # Backup is gone; write a sane default
+        cat > /etc/sysconfig/kernel <<EOF
+# UPDATEDEFAULT specifies if kernel-install should make
+# new kernels the default
+UPDATEDEFAULT=yes
+
+# DEFAULTKERNEL specifies the default kernel package type
+DEFAULTKERNEL=kernel-core
+EOF
+    fi
+fi
+
+%pre default
+# Already configured -- nothing to do. This also handles upgrades safely:
+# %postun of the old version sees $1 > 0 and skips the restore, so our
+# managed file from the prior install remains intact.
+if grep -q "^DEFAULTKERNEL=kernel-%{pkg_suffix}-core$" /etc/sysconfig/kernel 2>/dev/null; then
+    exit 0
+fi
+
+# Back up the original file only on first install; never clobber an existing
+# backup so the original config is always recoverable on uninstall.
+if [ ! -f /etc/sysconfig/kernel.rpmsave ] && [ -f /etc/sysconfig/kernel ]; then
+    cp -f /etc/sysconfig/kernel /etc/sysconfig/kernel.rpmsave || exit 1
+fi
+
+# Write our managed configuration
+cat > /etc/sysconfig/kernel <<EOF
+# This file is managed by %{package_name}-default
+# To revert to the original, uninstall %{package_name}-default
+# and restore /etc/sysconfig/kernel.rpmsave
+#
+# UPDATEDEFAULT specifies if kernel-install should make
+# new kernels the default
+UPDATEDEFAULT=yes
+
+# DEFAULTKERNEL specifies the default kernel package type
+DEFAULTKERNEL=kernel-%{pkg_suffix}-core
+EOF
+
+%posttrans default
+# Set this kernel version as the boot default after all transactions complete
+if [ -f /boot/vmlinuz-%{KVERREL} ]; then
+    grubby --set-default=/boot/vmlinuz-%{KVERREL} ||
+        echo "warning: failed to set kernel-%{pkg_suffix} as boot default" >&2
+fi
 
 #
 # This macro defines a %%post script for a kernel*-devel package.
@@ -3618,6 +3704,12 @@ fi\
 %endif\
 %endif\
 rm -f %{_localstatedir}/lib/rpm-state/%{name}/installing_core_%{KVERREL}%{?-v:+%{-v*}}\
+# Tell 20-grub.install that this is a non-standard kernel so it only becomes\
+# the boot default when DEFAULTKERNEL in /etc/sysconfig/kernel is set to\
+# %{name}-core.  When DEFAULTKERNEL is kernel-core, grub2-get-kernel-settings\
+# does not output GRUB_NON_STANDARD_KERNEL, so this export survives into\
+# 20-grub.install and prevents the CLK kernel from taking over the default.\
+export GRUB_NON_STANDARD_KERNEL=true\
 /bin/kernel-install add %{KVERREL}%{?-v:+%{-v*}} /lib/modules/%{KVERREL}%{?-v:+%{-v*}}/vmlinuz%{?-u:-%{-u*}.efi} || exit $?\
 if [[ ! -e "/boot/symvers-%{KVERREL}%{?-v:+%{-v*}}.gz" ]]; then\
     cp "/lib/modules/%{KVERREL}%{?-v:+%{-v*}}/symvers.gz" "/boot/symvers-%{KVERREL}%{?-v:+%{-v*}}.gz"\
@@ -3838,9 +3930,9 @@ fi\
 
 %if %{with_tools}
 %ifnarch %{cpupowerarchs}
-%files -n %{package_name}-tools
+%files tools
 %else
-%files -n %{package_name}-tools -f cpupower.lang
+%files tools -f cpupower.lang
 %{_bindir}/cpupower
 %{_datadir}/bash-completion/completions/cpupower
 %ifarch x86_64
@@ -3875,15 +3967,15 @@ fi\
 %{_bindir}/slabinfo
 
 %if %{with_debuginfo}
-%files -f %{package_name}-tools-debuginfo.list -n %{package_name}-tools-debuginfo
+%files -f %{package_name}-tools-debuginfo.list tools-debuginfo
 %endif
 
 %ifarch %{cpupowerarchs}
-%files -n %{package_name}-tools-libs
+%files tools-libs
 %{_libdir}/libcpupower.so.1
 %{_libdir}/libcpupower.so.0.0.1
 
-%files -n %{package_name}-tools-libs-devel
+%files tools-libs-devel
 %{_libdir}/libcpupower.so
 %{_includedir}/cpufreq.h
 %{_includedir}/cpuidle.h
@@ -3914,6 +4006,9 @@ fi\
 
 # with_tools
 %endif
+
+%files default
+# This is a meta-package with no files
 
 %if %{with_selftests}
 %files selftests-internal


### PR DESCRIPTION
This PR brings CLK 6.12 in sync with CLK 6.18 with respect to namespacing

  * Introduces the kernel-clk6.12 package name with %{pkg_suffix} macro. Renames all tool packages (perf, libperf, rtla, rv, etc.) with the clk6.12 suffix. Adds Provides/Conflicts tags for non-parallel installable packages (headers, tools, doc) to prevent conflicts with stock Rocky packages while satisfying their dependencies.
 * Switches Module.symvers compression from xz to gzip to align with upstream kernel spec. Fixes ghost file permissions from 0644 to 0600.
 * Injects +clk6.12 into KVERREL and EXTRAVERSION so running kernels display their CLK identity in uname output (e.g., 6.12.78-1.1.el9.x86_64+clk6.12).
 * Sync spec changes from 6.18 branch - Consolidates version defines, reworks the -default package with proper scriptlets, converts tools to short-form naming, bundles bindgen-cli
for Rocky 9.6, and exports GRUB_NON_STANDARD_KERNEL to prevent boot menu hijacking. Also fixes Provides/Requires to use %{name} instead of hardcoded "kernel".
* Add Obsoletes tags for upgrade path from old kernel packages - Adds explicit Obsoletes entries for specific kernel-6.12 versions (6.12.15, 6.12.30, 6.12.43, 6.12.63, 6.12.74, 6.12.77) to all kernel and tool packages. These explicit Obsoletes ensure systems with the previous un-namespaced CLK 6.12 kernels see the new kernel-clk6.12 packages as upgrades.