### PR TITLE
github actions: Trigger kernelCI on ciq-6.18.y-next branches

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '*_ciq-6.18.y'
+      - '*_ciq-6.18.y-next'
 
 jobs:
   kernelCI:


### PR DESCRIPTION
To allow the CLK Rebase workflow to utilize Kernel CI for build, test and PR creation:
https://github.com/ctrliq/kernel-src-tree/pull/1106