### PR TITLE
[LTS 9.6] CVE-2025-39966, CVE-2025-38129, CVE-2025-39881, CVE-2025-38106

### DIFF
--- a/drivers/iommu/iommufd/fault.c
+++ b/drivers/iommu/iommufd/fault.c
@@ -402,6 +402,7 @@ int iommufd_fault_alloc(struct iommufd_ucmd *ucmd)
 	spin_lock_init(&fault->lock);
 	init_waitqueue_head(&fault->wait_queue);
 
+	/* The filep is fput() by the core code during failure */
 	filep = anon_inode_getfile("[iommufd-pgfault]", &iommufd_fault_fops,
 				   fault, O_RDWR);
 	if (IS_ERR(filep)) {
@@ -416,7 +417,7 @@ int iommufd_fault_alloc(struct iommufd_ucmd *ucmd)
 	fdno = get_unused_fd_flags(O_CLOEXEC);
 	if (fdno < 0) {
 		rc = fdno;
-		goto out_fput;
+		goto out_abort;
 	}
 
 	cmd->out_fault_id = fault->obj.id;
@@ -432,8 +433,6 @@ int iommufd_fault_alloc(struct iommufd_ucmd *ucmd)
 	return 0;
 out_put_fdno:
 	put_unused_fd(fdno);
-out_fput:
-	fput(filep);
 out_abort:
 	iommufd_object_abort_and_destroy(ucmd->ictx, &fault->obj);
 

--- a/drivers/iommu/iommufd/main.c
+++ b/drivers/iommu/iommufd/main.c
@@ -23,6 +23,7 @@
 #include "iommufd_test.h"
 
 struct iommufd_object_ops {
+	size_t file_offset;
 	void (*destroy)(struct iommufd_object *obj);
 	void (*abort)(struct iommufd_object *obj);
 };
@@ -97,10 +98,30 @@ void iommufd_object_abort(struct iommufd_ctx *ictx, struct iommufd_object *obj)
 void iommufd_object_abort_and_destroy(struct iommufd_ctx *ictx,
 				      struct iommufd_object *obj)
 {
-	if (iommufd_object_ops[obj->type].abort)
-		iommufd_object_ops[obj->type].abort(obj);
+	const struct iommufd_object_ops *ops = &iommufd_object_ops[obj->type];
+
+	if (ops->file_offset) {
+		struct file **filep = ((void *)obj) + ops->file_offset;
+
+		/*
+		 * A file should hold a users refcount while the file is open
+		 * and put it back in its release. The file should hold a
+		 * pointer to obj in their private data. Normal fput() is
+		 * deferred to a workqueue and can get out of order with the
+		 * following kfree(obj). Using the sync version ensures the
+		 * release happens immediately. During abort we require the file
+		 * refcount is one at this point - meaning the object alloc
+		 * function cannot do anything to allow another thread to take a
+		 * refcount prior to a guaranteed success.
+		 */
+		if (*filep)
+			__fput_sync(*filep);
+	}
+
+	if (ops->abort)
+		ops->abort(obj);
 	else
-		iommufd_object_ops[obj->type].destroy(obj);
+		ops->destroy(obj);
 	iommufd_object_abort(ictx, obj);
 }
 
@@ -498,6 +519,12 @@ void iommufd_ctx_put(struct iommufd_ctx *ictx)
 }
 EXPORT_SYMBOL_NS_GPL(iommufd_ctx_put, IOMMUFD);
 
+#define IOMMUFD_FILE_OFFSET(_struct, _filep, _obj)                           \
+	.file_offset = (offsetof(_struct, _filep) +                          \
+			BUILD_BUG_ON_ZERO(!__same_type(                      \
+				struct file *, ((_struct *)NULL)->_filep)) + \
+			BUILD_BUG_ON_ZERO(offsetof(_struct, _obj)))
+
 static const struct iommufd_object_ops iommufd_object_ops[] = {
 	[IOMMUFD_OBJ_ACCESS] = {
 		.destroy = iommufd_access_destroy_object,
@@ -518,6 +545,7 @@ static const struct iommufd_object_ops iommufd_object_ops[] = {
 	},
 	[IOMMUFD_OBJ_FAULT] = {
 		.destroy = iommufd_fault_destroy,
+		IOMMUFD_FILE_OFFSET(struct iommufd_fault, filep, obj),
 	},
 #ifdef CONFIG_IOMMUFD_TEST
 	[IOMMUFD_OBJ_SELFTEST] = {

--- a/io_uring/fdinfo.c
+++ b/io_uring/fdinfo.c
@@ -148,18 +148,26 @@ __cold void io_uring_show_fdinfo(struct seq_file *m, struct file *file)
 
 	if (has_lock && (ctx->flags & IORING_SETUP_SQPOLL)) {
 		struct io_sq_data *sq = ctx->sq_data;
+		struct task_struct *tsk;
 
+		rcu_read_lock();
+		tsk = rcu_dereference(sq->thread);
 		/*
 		 * sq->thread might be NULL if we raced with the sqpoll
 		 * thread termination.
 		 */
-		if (sq->thread) {
+		if (tsk) {
+			get_task_struct(tsk);
+			rcu_read_unlock();
+			getrusage(tsk, RUSAGE_SELF, &sq_usage);
+			put_task_struct(tsk);
 			sq_pid = sq->task_pid;
 			sq_cpu = sq->sq_cpu;
-			getrusage(sq->thread, RUSAGE_SELF, &sq_usage);
 			sq_total_time = (sq_usage.ru_stime.tv_sec * 1000000
 					 + sq_usage.ru_stime.tv_usec);
 			sq_work_time = sq->work_time;
+		} else {
+			rcu_read_unlock();
 		}
 	}
 

--- a/io_uring/io_uring.c
+++ b/io_uring/io_uring.c
@@ -2828,7 +2828,7 @@ static __cold void io_ring_exit_work(struct work_struct *work)
 			struct task_struct *tsk;
 
 			io_sq_thread_park(sqd);
-			tsk = sqd->thread;
+			tsk = sqpoll_task_locked(sqd);
 			if (tsk && tsk->io_uring && tsk->io_uring->io_wq)
 				io_wq_cancel_cb(tsk->io_uring->io_wq,
 						io_cancel_ctx_cb, ctx, true);
@@ -3066,7 +3066,7 @@ __cold void io_uring_cancel_generic(bool cancel_all, struct io_sq_data *sqd)
 	s64 inflight;
 	DEFINE_WAIT(wait);
 
-	WARN_ON_ONCE(sqd && sqd->thread != current);
+	WARN_ON_ONCE(sqd && sqpoll_task_locked(sqd) != current);
 
 	if (!current->io_uring)
 		return;

--- a/io_uring/io_uring.c
+++ b/io_uring/io_uring.c
@@ -144,7 +144,8 @@ struct io_defer_entry {
 
 static bool io_uring_try_cancel_requests(struct io_ring_ctx *ctx,
 					 struct task_struct *task,
-					 bool cancel_all);
+					 bool cancel_all,
+					 bool is_sqpoll_thread);
 
 static void io_queue_sqe(struct io_kiocb *req);
 
@@ -2818,7 +2819,8 @@ static __cold void io_ring_exit_work(struct work_struct *work)
 		if (ctx->flags & IORING_SETUP_DEFER_TASKRUN)
 			io_move_task_work_from_local(ctx);
 
-		while (io_uring_try_cancel_requests(ctx, NULL, true))
+		/* The SQPOLL thread never reaches this path */
+		while (io_uring_try_cancel_requests(ctx, NULL, true, false))
 			cond_resched();
 
 		if (ctx->sq_data) {
@@ -2986,7 +2988,8 @@ static __cold bool io_uring_try_cancel_iowq(struct io_ring_ctx *ctx)
 
 static __cold bool io_uring_try_cancel_requests(struct io_ring_ctx *ctx,
 						struct task_struct *task,
-						bool cancel_all)
+						bool cancel_all,
+						bool is_sqpoll_thread)
 {
 	struct io_task_cancel cancel = { .task = task, .all = cancel_all, };
 	struct io_uring_task *tctx = task ? task->io_uring : NULL;
@@ -3017,7 +3020,7 @@ static __cold bool io_uring_try_cancel_requests(struct io_ring_ctx *ctx,
 
 	/* SQPOLL thread does its own polling */
 	if ((!(ctx->flags & IORING_SETUP_SQPOLL) && cancel_all) ||
-	    (ctx->sq_data && ctx->sq_data->thread == current)) {
+	    is_sqpoll_thread) {
 		while (!wq_list_empty(&ctx->iopoll_list)) {
 			io_iopoll_try_reap_events(ctx);
 			ret = true;
@@ -3089,13 +3092,16 @@ __cold void io_uring_cancel_generic(bool cancel_all, struct io_sq_data *sqd)
 				if (node->ctx->sq_data)
 					continue;
 				loop |= io_uring_try_cancel_requests(node->ctx,
-							current, cancel_all);
+								     current,
+								     cancel_all,
+								     false);
 			}
 		} else {
 			list_for_each_entry(ctx, &sqd->ctx_list, sqd_list)
 				loop |= io_uring_try_cancel_requests(ctx,
 								     current,
-								     cancel_all);
+								     cancel_all,
+								     true);
 		}
 
 		if (loop) {

--- a/io_uring/io_uring.c
+++ b/io_uring/io_uring.c
@@ -1262,10 +1262,7 @@ static void io_req_normal_work_add(struct io_kiocb *req)
 
 	/* SQPOLL doesn't need the task_work added, it'll run it itself */
 	if (ctx->flags & IORING_SETUP_SQPOLL) {
-		struct io_sq_data *sqd = ctx->sq_data;
-
-		if (sqd->thread)
-			__set_notify_signal(sqd->thread);
+		__set_notify_signal(req->task);
 		return;
 	}
 

--- a/io_uring/register.c
+++ b/io_uring/register.c
@@ -323,6 +323,8 @@ static __cold int io_register_iowq_max_workers(struct io_ring_ctx *ctx,
 	if (ctx->flags & IORING_SETUP_SQPOLL) {
 		sqd = ctx->sq_data;
 		if (sqd) {
+			struct task_struct *tsk;
+
 			/*
 			 * Observe the correct sqd->lock -> ctx->uring_lock
 			 * ordering. Fine to drop uring_lock here, we hold
@@ -332,8 +334,9 @@ static __cold int io_register_iowq_max_workers(struct io_ring_ctx *ctx,
 			mutex_unlock(&ctx->uring_lock);
 			mutex_lock(&sqd->lock);
 			mutex_lock(&ctx->uring_lock);
-			if (sqd->thread)
-				tctx = sqd->thread->io_uring;
+			tsk = sqpoll_task_locked(sqd);
+			if (tsk)
+				tctx = tsk->io_uring;
 		}
 	} else {
 		tctx = current->io_uring;

--- a/io_uring/sqpoll.c
+++ b/io_uring/sqpoll.c
@@ -280,7 +280,8 @@ static int io_sq_thread(void *data)
 	/* offload context creation failed, just exit */
 	if (!current->io_uring) {
 		mutex_lock(&sqd->lock);
-		sqd->thread = NULL;
+		rcu_assign_pointer(sqd->thread, NULL);
+		put_task_struct(current);
 		mutex_unlock(&sqd->lock);
 		goto err_out;
 	}
@@ -385,7 +386,8 @@ static int io_sq_thread(void *data)
 		io_sq_tw(&retry_list, UINT_MAX);
 
 	io_uring_cancel_generic(true, sqd);
-	sqd->thread = NULL;
+	rcu_assign_pointer(sqd->thread, NULL);
+	put_task_struct(current);
 	list_for_each_entry(ctx, &sqd->ctx_list, sqd_list)
 		atomic_or(IORING_SQ_NEED_WAKEUP, &ctx->rings->sq_flags);
 	io_run_task_work();
@@ -506,9 +508,6 @@ __cold int io_sq_offload_create(struct io_ring_ctx *ctx,
 		ret = -EINVAL;
 		goto err;
 	}
-
-	if (task_to_put)
-		put_task_struct(task_to_put);
 	return 0;
 err_sqpoll:
 	complete(&ctx->sq_data->exited);

--- a/io_uring/sqpoll.c
+++ b/io_uring/sqpoll.c
@@ -425,7 +425,6 @@ void io_sqpoll_wait_sq(struct io_ring_ctx *ctx)
 __cold int io_sq_offload_create(struct io_ring_ctx *ctx,
 				struct io_uring_params *p)
 {
-	struct task_struct *task_to_put = NULL;
 	int ret;
 
 	/* Retain compatibility with failing for an invalid attach attempt */
@@ -509,7 +508,7 @@ __cold int io_sq_offload_create(struct io_ring_ctx *ctx,
 		rcu_assign_pointer(sqd->thread, tsk);
 		mutex_unlock(&sqd->lock);
 
-		task_to_put = get_task_struct(tsk);
+		get_task_struct(tsk);
 		ret = io_uring_alloc_task_context(tsk, ctx);
 		wake_up_new_task(tsk);
 		if (ret)
@@ -524,8 +523,6 @@ err_sqpoll:
 	complete(&ctx->sq_data->exited);
 err:
 	io_sq_thread_finish(ctx);
-	if (task_to_put)
-		put_task_struct(task_to_put);
 	return ret;
 }
 

--- a/io_uring/sqpoll.c
+++ b/io_uring/sqpoll.c
@@ -415,6 +415,7 @@ void io_sqpoll_wait_sq(struct io_ring_ctx *ctx)
 __cold int io_sq_offload_create(struct io_ring_ctx *ctx,
 				struct io_uring_params *p)
 {
+	struct task_struct *task_to_put = NULL;
 	int ret;
 
 	/* Retain compatibility with failing for an invalid attach attempt */
@@ -495,6 +496,7 @@ __cold int io_sq_offload_create(struct io_ring_ctx *ctx,
 		}
 
 		sqd->thread = tsk;
+		task_to_put = get_task_struct(tsk);
 		ret = io_uring_alloc_task_context(tsk, ctx);
 		wake_up_new_task(tsk);
 		if (ret)
@@ -505,11 +507,15 @@ __cold int io_sq_offload_create(struct io_ring_ctx *ctx,
 		goto err;
 	}
 
+	if (task_to_put)
+		put_task_struct(task_to_put);
 	return 0;
 err_sqpoll:
 	complete(&ctx->sq_data->exited);
 err:
 	io_sq_thread_finish(ctx);
+	if (task_to_put)
+		put_task_struct(task_to_put);
 	return ret;
 }
 

--- a/io_uring/sqpoll.c
+++ b/io_uring/sqpoll.c
@@ -30,7 +30,7 @@ enum {
 void io_sq_thread_unpark(struct io_sq_data *sqd)
 	__releases(&sqd->lock)
 {
-	WARN_ON_ONCE(sqd->thread == current);
+	WARN_ON_ONCE(sqpoll_task_locked(sqd) == current);
 
 	/*
 	 * Do the dance but not conditional clear_bit() because it'd race with
@@ -45,24 +45,32 @@ void io_sq_thread_unpark(struct io_sq_data *sqd)
 void io_sq_thread_park(struct io_sq_data *sqd)
 	__acquires(&sqd->lock)
 {
-	WARN_ON_ONCE(data_race(sqd->thread) == current);
+	struct task_struct *tsk;
 
 	atomic_inc(&sqd->park_pending);
 	set_bit(IO_SQ_THREAD_SHOULD_PARK, &sqd->state);
 	mutex_lock(&sqd->lock);
-	if (sqd->thread)
-		wake_up_process(sqd->thread);
+
+	tsk = sqpoll_task_locked(sqd);
+	if (tsk) {
+		WARN_ON_ONCE(tsk == current);
+		wake_up_process(tsk);
+	}
 }
 
 void io_sq_thread_stop(struct io_sq_data *sqd)
 {
-	WARN_ON_ONCE(sqd->thread == current);
+	struct task_struct *tsk;
+
 	WARN_ON_ONCE(test_bit(IO_SQ_THREAD_SHOULD_STOP, &sqd->state));
 
 	set_bit(IO_SQ_THREAD_SHOULD_STOP, &sqd->state);
 	mutex_lock(&sqd->lock);
-	if (sqd->thread)
-		wake_up_process(sqd->thread);
+	tsk = sqpoll_task_locked(sqd);
+	if (tsk) {
+		WARN_ON_ONCE(tsk == current);
+		wake_up_process(tsk);
+	}
 	mutex_unlock(&sqd->lock);
 	wait_for_completion(&sqd->exited);
 }
@@ -497,7 +505,10 @@ __cold int io_sq_offload_create(struct io_ring_ctx *ctx,
 			goto err_sqpoll;
 		}
 
-		sqd->thread = tsk;
+		mutex_lock(&sqd->lock);
+		rcu_assign_pointer(sqd->thread, tsk);
+		mutex_unlock(&sqd->lock);
+
 		task_to_put = get_task_struct(tsk);
 		ret = io_uring_alloc_task_context(tsk, ctx);
 		wake_up_new_task(tsk);
@@ -525,10 +536,13 @@ __cold int io_sqpoll_wq_cpu_affinity(struct io_ring_ctx *ctx,
 	int ret = -EINVAL;
 
 	if (sqd) {
+		struct task_struct *tsk;
+
 		io_sq_thread_park(sqd);
 		/* Don't set affinity for a dying thread */
-		if (sqd->thread)
-			ret = io_wq_cpu_affinity(sqd->thread->io_uring, mask);
+		tsk = sqpoll_task_locked(sqd);
+		if (tsk)
+			ret = io_wq_cpu_affinity(tsk->io_uring, mask);
 		io_sq_thread_unpark(sqd);
 	}
 

--- a/io_uring/sqpoll.c
+++ b/io_uring/sqpoll.c
@@ -45,7 +45,7 @@ void io_sq_thread_unpark(struct io_sq_data *sqd)
 void io_sq_thread_park(struct io_sq_data *sqd)
 	__acquires(&sqd->lock)
 {
-	WARN_ON_ONCE(sqd->thread == current);
+	WARN_ON_ONCE(data_race(sqd->thread) == current);
 
 	atomic_inc(&sqd->park_pending);
 	set_bit(IO_SQ_THREAD_SHOULD_PARK, &sqd->state);

--- a/net/core/page_pool.c
+++ b/net/core/page_pool.c
@@ -144,9 +144,9 @@ u64 *page_pool_ethtool_stats_get(u64 *data, const void *stats)
 EXPORT_SYMBOL(page_pool_ethtool_stats_get);
 
 #else
-#define alloc_stat_inc(pool, __stat)
-#define recycle_stat_inc(pool, __stat)
-#define recycle_stat_add(pool, __stat, val)
+#define alloc_stat_inc(...)	do { } while (0)
+#define recycle_stat_inc(...)	do { } while (0)
+#define recycle_stat_add(...)	do { } while (0)
 #endif
 
 static bool page_pool_producer_lock(struct page_pool *pool)
@@ -678,19 +678,16 @@ void page_pool_return_page(struct page_pool *pool, struct page *page)
 
 static bool page_pool_recycle_in_ring(struct page_pool *pool, struct page *page)
 {
-	int ret;
+	bool in_softirq, ret;
+
 	/* BH protection not needed if current is softirq */
-	if (in_softirq())
-		ret = ptr_ring_produce(&pool->ring, page);
-	else
-		ret = ptr_ring_produce_bh(&pool->ring, page);
-
-	if (!ret) {
+	in_softirq = page_pool_producer_lock(pool);
+	ret = !__ptr_ring_produce(&pool->ring, page);
+	if (ret)
 		recycle_stat_inc(pool, ring);
-		return true;
-	}
+	page_pool_producer_unlock(pool, in_softirq);
 
-	return false;
+	return ret;
 }
 
 /* Only allow direct recycling in special circumstances, into the
@@ -1022,10 +1019,14 @@ static void page_pool_scrub(struct page_pool *pool)
 
 static int page_pool_release(struct page_pool *pool)
 {
+	bool in_softirq;
 	int inflight;
 
 	page_pool_scrub(pool);
 	inflight = page_pool_inflight(pool, true);
+	/* Acquire producer lock to make sure producers have exited. */
+	in_softirq = page_pool_producer_lock(pool);
+	page_pool_producer_unlock(pool, in_softirq);
 	if (!inflight)
 		__page_pool_destroy(pool);
 


### PR DESCRIPTION
[LTS 9.6]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2025-39966</td>
<td class="org-left">VULN-161965</td>
</tr>


<tr>
<td class="org-left">CVE-2025-38129</td>
<td class="org-left">VULN-162992</td>
</tr>


<tr>
<td class="org-left">CVE-2025-39881</td>
<td class="org-left">VULN-161581</td>
</tr>


<tr>
<td class="org-left">CVE-2025-38106</td>
<td class="org-left">VULN-162982</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2025-39966

    iommufd: Fix race during abort for file descriptors
    
    jira VULN-161965
    cve CVE-2025-39966
    commit-author Jason Gunthorpe <jgg@ziepe.ca>
    commit 4e034bf045b12852a24d5d33f2451850818ba0c1
    upstream-diff |
      drivers/iommu/iommufd/main.c
            - The modified `IOMMUFD_OBJ_FAULT' entry can be found at different
              place than in the upstream because of the missing
              442003f3a842dc374b1c706187778c3d57b84c23 ("iommufd: Keep
              OBJ/IOCTL lists in an alphabetical order")
            - Ignored the `IOMMUFD_OBJ_VEVENTQ' entry in the
              `iommufd_object_ops' array, which was introduced in the
              non-backported commit e36ba5ab808ef6237c3148d469c8238674230e2b
              ("iommufd: Add IOMMUFD_OBJ_VEVENTQ and
              IOMMUFD_CMD_VEVENTQ_ALLOC")
            - Passed `filep' and `obj' to the `IOMMUFD_FILE_OFFSET' macro
              instead of `common.filep' and `common.obj' as in the upstream
              because these fields of `iommufd_fault' have not yet been
              extracted to the `common' sub-struct as in the upstream
              (5426a78bebefbb32643ee85320e977f3971c5521 ("iommufd: Abstract an
              iommufd_eventq from iommufd_fault"))
      drivers/iommu/iommufd/fault.c
            - Modified drivers/iommu/iommufd/fault.c instead of upstream's
              drivers/iommu/iommufd/eventq.c - it's the same file just renamed
              in the non-backported 0507f337fc0c3a10f802b42834e6532edcf605be
              ("iommufd: Rename fault.c to eventq.c")
            - Accounted for the missing
              927dabc9aa4dbebf92b34da9b7acd7d8d5c6331b ("iommufd/fault: Add an
              iommufd_fault_init() helper"): implemented the omission of
              `fput()' call on failure in the `iommufd_fault_alloc()' function
              instead of `iommufd_eventq_init()' (named `iommufd_fault_init()'
              at the moment of 927dabc9aa4).
            - Ignored change to the non-existing function
              `iommufd_veventq_alloc()' only introduced in e36ba5ab808.

(No idea why `BUILD_BUG_ON_ZERO` macro was called like that if it triggers compilation error when the argument is *non*-zero - confirmed experimentally)


## CVE-2025-38129

    page_pool: Fix use-after-free in page_pool_recycle_in_ring
    
    jira VULN-162992
    cve CVE-2025-38129
    commit-author Dong Chenchen <dongchenchen2@huawei.com>
    commit 271683bb2cf32e5126c592b5d5e6a756fa374fd9
    upstream-diff Accounted in `page_pool_recycle_in_ring()' for the missing
      4dec64c52e24c2c9a15f81c115f1be5ea35121cb ("page_pool: convert to use
      netmem")


## CVE-2025-39881

    kernfs: Fix UAF in polling when open file is released
    
    jira VULN-161581
    cve CVE-2025-39881
    commit-author Chen Ridong <chenridong@huawei.com>
    commit 3c9ba2777d6c86025e1ba4186dc5cd930e40ec5f
    upstream-diff Omitted in the `kernfs_fop_llseek()' function the
      `kernfs_get_active()' -> `kernfs_get_active_of()' replacement - it was
      introduced in the non-backported commit
      0fedefd4c4e33dd24f726b13b5d7c143e2b483be ("kernfs: sysfs: support
      custom llseek method for sysfs entries")


## CVE-2025-38106

    io_uring/sqpoll: annotate debug task == current with data_race()
    
    jira VULN-162982
    cve-pre CVE-2025-38106
    commit-author Jens Axboe <axboe@kernel.dk>
    commit e4956dc7a84da074fd8dc10f7abd147f15b3ae58

>

    io_uring/sqpoll: fix sqpoll error handling races
    
    jira VULN-162982
    cve-pre CVE-2025-38106
    commit-author Pavel Begunkov <asml.silence@gmail.com>
    commit e33ac68e5e21ec1292490dfe061e75c0dbdd3bd4

Not a strict prerequisite - omitting it would merely lead to a trivial context conflict resolution. However, it's small, does fix another UAF bug and allows for a clean pick of ac0b8b327a5677dc6fecdf353d808161525b1ff0 so may as well be included.

>

    io_uring: fix use-after-free of sq->thread in __io_uring_show_fdinfo()
    
    jira VULN-162982
    cve CVE-2025-38106
    commit-author Penglei Jiang <superman.xpt@gmail.com>
    commit ac0b8b327a5677dc6fecdf353d808161525b1ff0

>

    io_uring: consistently use rcu semantics with sqpoll thread
    
    jira VULN-162982
    cve-bf CVE-2025-38106
    commit-author Keith Busch <kbusch@kernel.org>
    commit c538f400fae22725580842deb2bef546701b64bd

>

    io_uring/sqpoll: don't put task_struct on tctx setup failure
    
    jira VULN-162982
    cve-bf CVE-2025-38106
    commit-author Jens Axboe <axboe@kernel.dk>
    commit f2320f1dd6f6f82cb2c7aff23a12bab537bdea89


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts9_6-CVE-batch-27]	_kabi_check_kernel__x86_64--test--ciqlts9_6-CVE-batch-27
    + dist_git_version=el-9.6
    + local_version=ciqlts9_6-CVE-batch-27
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts9_6
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-9.6
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts9_6-CVE-batch-27
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-9.6/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts9_6 ''\''/mnt/code/kernel-dist-git-el-9.6/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-9.6/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts9_6-CVE-batch-27/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts9_6-CVE-batch-27/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/26686980/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_6&#x2013;run1.log](<https://github.com/user-attachments/files/26686981/kselftests--ciqlts9_6--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_6-CVE-batch-27&#x2013;run1.log](<https://github.com/user-attachments/files/26686982/kselftests--ciqlts9_6-CVE-batch-27--run1.log>)
[kselftests&#x2013;ciqlts9\_6-CVE-batch-27&#x2013;run2.log](<https://github.com/user-attachments/files/26686983/kselftests--ciqlts9_6-CVE-batch-27--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff  kselftests*.log

    Column    File
    --------  --------------------------------------------
    Status0   kselftests--ciqlts9_6--run1.log
    Status1   kselftests--ciqlts9_6-CVE-batch-27--run1.log
    Status2   kselftests--ciqlts9_6-CVE-batch-27--run2.log
    
    TestCase                                               Status0  Status1  Status2  Summary
    bpf:test_cgroup_storage                                pass     pass     pass     same
    bpf:test_lru_map                                       pass     pass     pass     same
    bpf:test_sock                                          pass     pass     pass     same
    bpf:test_sysctl                                        pass     pass     pass     same
    bpf:test_tag                                           pass     pass     pass     same
    bpf:test_tcpnotify_user                                fail     fail     fail     same
    bpf:test_verifier                                      fail     fail     fail     same
    breakpoints:breakpoint_test                            pass     pass     pass     same
    capabilities:test_execve                               pass     pass     pass     same
    clone3:clone3                                          pass     pass     pass     same
    clone3:clone3_cap_checkpoint_restore                   pass     pass     pass     same
    clone3:clone3_clear_sighand                            pass     pass     pass     same
    clone3:clone3_set_tid                                  pass     pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh                         pass     pass     pass     same
    cpufreq:main.sh                                        fail     fail     fail     same
    drivers/dma-buf:udmabuf                                pass     pass     pass     same
    drivers/net/bonding:bond-arp-interval-causes-panic.sh  pass     pass     pass     same
    drivers/net/bonding:bond-break-lacpdu-tx.sh            fail     fail     fail     same
    drivers/net/bonding:bond-eth-type-change.sh            pass     pass     pass     same
    drivers/net/bonding:bond-lladdr-target.sh              pass     pass     pass     same
    drivers/net/bonding:bond_options.sh                    fail     fail     fail     same
    drivers/net/bonding:dev_addr_lists.sh                  pass     pass     pass     same
    drivers/net/bonding:mode-1-recovery-updelay.sh         pass     pass     pass     same
    drivers/net/bonding:mode-2-recovery-updelay.sh         pass     pass     pass     same
    drivers/net/team:dev_addr_lists.sh                     pass     pass     pass     same
    exec:binfmt_script                                     pass     pass     pass     same
    exec:execveat                                          pass     pass     pass     same
    exec:load_address_16777216                             fail     fail     fail     same
    exec:load_address_2097152                              pass     pass     pass     same
    exec:load_address_4096                                 pass     pass     pass     same
    exec:non-regular                                       fail     fail     fail     same
    exec:recursion-depth                                   pass     pass     pass     same
    filesystems/binderfs:binderfs_test                     fail     fail     fail     same
    filesystems/epoll:epoll_wakeup_test                    pass     pass     pass     same
    firmware:fw_run_tests.sh                               skip     skip     skip     same
    fpu:run_test_fpu.sh                                    skip     skip     skip     same
    fpu:test_fpu                                           pass     pass     pass     same
    ftrace:ftracetest                                      pass     pass     pass     same
    futex:run.sh                                           pass     pass     pass     same
    gpio:gpio-mockup.sh                                    fail     fail     fail     same
    intel_pstate:run.sh                                    pass     pass     pass     same
    iommu:iommufd                                          fail     fail     fail     same
    iommu:iommufd_fail_nth                                 pass     pass     pass     same
    ipc:msgque                                             pass     pass     pass     same
    ir:ir_loopback.sh                                      skip     skip     skip     same
    kcmp:kcmp_test                                         pass     pass     pass     same
    kexec:test_kexec_file_load.sh                          skip     skip     skip     same
    kexec:test_kexec_load.sh                               skip     skip     skip     same
    kvm:access_tracking_perf_test                          pass     pass     pass     same
    kvm:amx_test                                           fail     fail     fail     same
    kvm:cpuid_test                                         fail     fail     fail     same
    kvm:cr4_cpuid_sync_test                                fail     fail     fail     same
    kvm:debug_regs                                         fail     fail     fail     same
    kvm:demand_paging_test                                 pass     pass     pass     same
    kvm:dirty_log_page_splitting_test                      fail     fail     fail     same
    kvm:dirty_log_perf_test                                pass     pass     pass     same
    kvm:dirty_log_test                                     fail     fail     fail     same
    kvm:exit_on_emulation_failure_test                     fail     fail     fail     same
    kvm:fix_hypercall_test                                 fail     fail     fail     same
    kvm:get_msr_index_features                             fail     fail     fail     same
    kvm:guest_memfd_test                                   pass     pass     pass     same
    kvm:guest_print_test                                   pass     pass     pass     same
    kvm:hardware_disable_test                              pass     pass     pass     same
    kvm:hyperv_clock                                       fail     fail     fail     same
    kvm:hyperv_cpuid                                       fail     fail     fail     same
    kvm:hyperv_evmcs                                       fail     fail     fail     same
    kvm:hyperv_extended_hypercalls                         fail     fail     fail     same
    kvm:hyperv_features                                    fail     fail     fail     same
    kvm:hyperv_ipi                                         fail     fail     fail     same
    kvm:hyperv_svm_test                                    fail     fail     fail     same
    kvm:hyperv_tlb_flush                                   fail     fail     fail     same
    kvm:kvm_binary_stats_test                              pass     pass     pass     same
    kvm:kvm_clock_test                                     fail     fail     fail     same
    kvm:kvm_create_max_vcpus                               pass     pass     pass     same
    kvm:kvm_page_table_test                                pass     pass     pass     same
    kvm:kvm_pv_test                                        fail     fail     fail     same
    kvm:max_guest_memory_test                              pass     pass     pass     same
    kvm:max_vcpuid_cap_test                                fail     fail     fail     same
    kvm:memslot_modification_stress_test                   pass     pass     pass     same
    kvm:memslot_perf_test                                  pass     pass     pass     same
    kvm:mmio_warning_test                                  fail     fail     fail     same
    kvm:monitor_mwait_test                                 fail     fail     fail     same
    kvm:nested_exceptions_test                             fail     fail     fail     same
    kvm:nx_huge_pages_test.sh                              fail     fail     fail     same
    kvm:platform_info_test                                 fail     fail     fail     same
    kvm:pmu_event_filter_test                              fail     fail     fail     same
    kvm:private_mem_conversions_test                       fail     fail     fail     same
    kvm:private_mem_kvm_exits_test                         fail     fail     fail     same
    kvm:recalc_apic_map_test                               fail     fail     fail     same
    kvm:rseq_test                                          fail     fail     fail     same
    kvm:set_boot_cpu_id                                    fail     fail     fail     same
    kvm:set_memory_region_test                             pass     pass     pass     same
    kvm:set_sregs_test                                     fail     fail     fail     same
    kvm:sev_migrate_tests                                  fail     fail     fail     same
    kvm:smaller_maxphyaddr_emulation_test                  fail     fail     fail     same
    kvm:smm_test                                           fail     fail     fail     same
    kvm:state_test                                         fail     fail     fail     same
    kvm:steal_time                                         pass     pass     pass     same
    kvm:svm_int_ctl_test                                   fail     fail     fail     same
    kvm:svm_nested_shutdown_test                           fail     fail     fail     same
    kvm:svm_nested_soft_inject_test                        fail     fail     fail     same
    kvm:svm_vmcall_test                                    fail     fail     fail     same
    kvm:sync_regs_test                                     fail     fail     fail     same
    kvm:system_counter_offset_test                         pass     pass     pass     same
    kvm:triple_fault_event_test                            fail     fail     fail     same
    kvm:tsc_msrs_test                                      fail     fail     fail     same
    kvm:tsc_scaling_sync                                   fail     fail     fail     same
    kvm:ucna_injection_test                                fail     fail     fail     same
    kvm:userspace_io_test                                  fail     fail     fail     same
    kvm:userspace_msr_exit_test                            fail     fail     fail     same
    kvm:vmx_apic_access_test                               fail     fail     fail     same
    kvm:vmx_close_while_nested_test                        fail     fail     fail     same
    kvm:vmx_dirty_log_test                                 fail     fail     fail     same
    kvm:vmx_exception_with_invalid_guest_state             fail     fail     fail     same
    kvm:vmx_invalid_nested_guest_state                     fail     fail     fail     same
    kvm:vmx_msrs_test                                      fail     fail     fail     same
    kvm:vmx_nested_tsc_scaling_test                        fail     fail     fail     same
    kvm:vmx_pmu_caps_test                                  fail     fail     fail     same
    kvm:vmx_preemption_timer_test                          fail     fail     fail     same
    kvm:vmx_set_nested_state_test                          fail     fail     fail     same
    kvm:vmx_tsc_adjust_test                                fail     fail     fail     same
    kvm:xapic_ipi_test                                     fail     fail     fail     same
    kvm:xapic_state_test                                   fail     fail     fail     same
    kvm:xcr0_cpuid_test                                    fail     fail     fail     same
    kvm:xen_shinfo_test                                    fail     fail     fail     same
    kvm:xen_vmcall_test                                    fail     fail     fail     same
    kvm:xss_msr_test                                       fail     fail     fail     same
    landlock:base_test                                     fail     fail     fail     same
    landlock:fs_test                                       fail     fail     fail     same
    landlock:ptrace_test                                   pass     pass     pass     same
    lib:bitmap.sh                                          skip     skip     skip     same
    lib:prime_numbers.sh                                   pass     pass     pass     same
    lib:printf.sh                                          skip     skip     skip     same
    lib:scanf.sh                                           skip     skip     skip     same
    lib:strscpy.sh                                         skip     skip     skip     same
    livepatch:test-callbacks.sh                            pass     pass     pass     same
    livepatch:test-ftrace.sh                               pass     pass     pass     same
    livepatch:test-livepatch.sh                            pass     pass     pass     same
    livepatch:test-shadow-vars.sh                          pass     pass     pass     same
    livepatch:test-state.sh                                pass     pass     pass     same
    livepatch:test-sysfs.sh                                pass     pass     pass     same
    membarrier:membarrier_test_multi_thread                pass     pass     pass     same
    membarrier:membarrier_test_single_thread               pass     pass     pass     same
    memfd:memfd_test                                       pass     pass     pass     same
    memfd:run_fuse_test.sh                                 pass     pass     pass     same
    memfd:run_hugetlbfs_test.sh                            pass     pass     pass     same
    memory-hotplug:mem-on-off-test.sh                      pass     pass     pass     same
    mincore:mincore_selftest                               fail     fail     fail     same
    mount:run_nosymfollow.sh                               pass     pass     pass     same
    mount:run_unprivileged_remount.sh                      pass     pass     pass     same
    mqueue:mq_open_tests                                   pass     pass     pass     same
    mqueue:mq_perf_tests                                   pass     pass     pass     same
    nci:nci_dev                                            fail     fail     fail     same
    net/forwarding:bridge_locked_port.sh                   fail     fail     fail     same
    net/forwarding:bridge_mdb.sh                           fail     fail     fail     same
    net/forwarding:bridge_mdb_host.sh                      pass     pass     pass     same
    net/forwarding:bridge_mdb_max.sh                       pass     pass     pass     same
    net/forwarding:bridge_mdb_port_down.sh                 pass     pass     pass     same
    net/forwarding:bridge_mld.sh                           pass     pass     pass     same
    net/forwarding:bridge_port_isolation.sh                fail     fail     fail     same
    net/forwarding:bridge_sticky_fdb.sh                    pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh                    fail     fail     fail     same
    net/forwarding:bridge_vlan_mcast.sh                    pass     pass     pass     same
    net/forwarding:bridge_vlan_unaware.sh                  fail     fail     fail     same
    net/forwarding:custom_multipath_hash.sh                fail     fail     fail     same
    net/forwarding:ethtool.sh                              skip     skip     skip     same
    net/forwarding:ethtool_extended_state.sh               skip     skip     skip     same
    net/forwarding:gre_custom_multipath_hash.sh            fail     fail     fail     same
    net/forwarding:gre_inner_v4_multipath.sh               fail     fail     fail     same
    net/forwarding:gre_multipath.sh                        fail     fail     fail     same
    net/forwarding:gre_multipath_nh.sh                     fail     fail     fail     same
    net/forwarding:gre_multipath_nh_res.sh                 fail     fail     fail     same
    net/forwarding:hw_stats_l3.sh                          skip     skip     skip     same
    net/forwarding:hw_stats_l3_gre.sh                      skip     skip     skip     same
    net/forwarding:ip6_forward_instats_vrf.sh              skip     skip     skip     same
    net/forwarding:ip6gre_custom_multipath_hash.sh         fail     fail     fail     same
    net/forwarding:ip6gre_flat.sh                          fail     fail     fail     same
    net/forwarding:ip6gre_flat_key.sh                      fail     fail     fail     same
    net/forwarding:ip6gre_flat_keys.sh                     fail     fail     fail     same
    net/forwarding:ip6gre_hier.sh                          fail     fail     fail     same
    net/forwarding:ip6gre_hier_key.sh                      fail     fail     fail     same
    net/forwarding:ip6gre_hier_keys.sh                     fail     fail     fail     same
    net/forwarding:ip6gre_inner_v4_multipath.sh            fail     fail     fail     same
    net/forwarding:ipip_flat_gre.sh                        fail     fail     fail     same
    net/forwarding:ipip_flat_gre_key.sh                    fail     fail     fail     same
    net/forwarding:ipip_flat_gre_keys.sh                   fail     fail     fail     same
    net/forwarding:ipip_hier_gre.sh                        fail     fail     fail     same
    net/forwarding:ipip_hier_gre_key.sh                    fail     fail     fail     same
    net/forwarding:local_termination.sh                    skip     skip     skip     same
    net/forwarding:loopback.sh                             skip     skip     skip     same
    net/forwarding:mirror_gre.sh                           pass     pass     pass     same
    net/forwarding:mirror_gre_bound.sh                     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh                 pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh                 pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh             pass     pass     pass     same
    net/forwarding:mirror_gre_changes.sh                   pass     pass     pass     same
    net/forwarding:mirror_gre_flower.sh                    pass     pass     pass     same
    net/forwarding:mirror_gre_lag_lacp.sh                  pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh                     pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh                        pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh                      pass     pass     pass     same
    net/forwarding:mirror_vlan.sh                          pass     pass     pass     same
    net/forwarding:no_forwarding.sh                        pass     pass     pass     same
    net/forwarding:pedit_dsfield.sh                        fail     fail     fail     same
    net/forwarding:pedit_ip.sh                             fail     fail     fail     same
    net/forwarding:pedit_l4port.sh                         fail     fail     fail     same
    net/forwarding:q_in_vni_ipv6.sh                        fail     fail     fail     same
    net/forwarding:router.sh                               skip     skip     skip     same
    net/forwarding:router_bridge.sh                        fail     fail     fail     same
    net/forwarding:router_bridge_1d.sh                     fail     fail     fail     same
    net/forwarding:router_bridge_pvid_vlan_upper.sh        fail     fail     fail     same
    net/forwarding:router_bridge_vlan.sh                   fail     fail     fail     same
    net/forwarding:router_bridge_vlan_upper.sh             fail     fail     fail     same
    net/forwarding:router_bridge_vlan_upper_pvid.sh        fail     fail     fail     same
    net/forwarding:router_broadcast.sh                     fail     fail     fail     same
    net/forwarding:router_mpath_nh.sh                      fail     fail     fail     same
    net/forwarding:router_mpath_nh_res.sh                  fail     fail     fail     same
    net/forwarding:router_multicast.sh                     skip     skip     skip     same
    net/forwarding:router_multipath.sh                     fail     fail     fail     same
    net/forwarding:router_nh.sh                            fail     fail     fail     same
    net/forwarding:router_vid_1.sh                         fail     fail     fail     same
    net/forwarding:skbedit_priority.sh                     fail     fail     fail     same
    net/forwarding:tc_chains.sh                            pass     pass     pass     same
    net/forwarding:tc_flower.sh                            pass     pass     pass     same
    net/forwarding:tc_flower_cfm.sh                        pass     pass     pass     same
    net/forwarding:tc_flower_l2_miss.sh                    fail     fail     fail     same
    net/forwarding:tc_flower_router.sh                     pass     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh                        fail     fail     fail     same
    net/forwarding:tc_shblocks.sh                          pass     pass     pass     same
    net/forwarding:tc_tunnel_key.sh                        pass     pass     pass     same
    net/forwarding:tc_vlan_modify.sh                       fail     fail     fail     same
    net/forwarding:vxlan_asymmetric.sh                     fail     fail     fail     same
    net/forwarding:vxlan_asymmetric_ipv6.sh                fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d.sh                      fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d_port_8472_ipv6.sh       fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q.sh                      fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_ipv6.sh                 fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_port_8472_ipv6.sh       fail     fail     fail     same
    net/forwarding:vxlan_symmetric.sh                      fail     fail     fail     same
    net/forwarding:vxlan_symmetric_ipv6.sh                 fail     fail     fail     same
    net/hsr:hsr_ping.sh                                    fail     fail     fail     same
    net/mptcp:diag.sh                                      pass     pass     pass     same
    net/mptcp:mptcp_connect.sh                             pass     pass     pass     same
    net/mptcp:mptcp_sockopt.sh                             skip     skip     skip     same
    net/mptcp:pm_netlink.sh                                pass     pass     pass     same
    net:altnames.sh                                        pass     pass     pass     same
    net:bareudp.sh                                         pass     pass     pass     same
    net:big_tcp.sh                                         skip     skip     skip     same
    net:cmsg_so_mark.sh                                    pass     pass     pass     same
    net:devlink_port_split.py                              skip     skip     skip     same
    net:drop_monitor_tests.sh                              skip     skip     skip     same
    net:fcnal-test.sh                                      skip     skip     skip     same
    net:fib-onlink-tests.sh                                pass     pass     pass     same
    net:fib_nexthop_multiprefix.sh                         pass     pass     pass     same
    net:fib_nexthop_nongw.sh                               pass     pass     pass     same
    net:fib_rule_tests.sh                                  pass     pass     pass     same
    net:fib_tests.sh                                       fail     fail     fail     same
    net:fin_ack_lat.sh                                     pass     pass     pass     same
    net:gre_gso.sh                                         pass     pass     pass     same
    net:icmp.sh                                            fail     fail     fail     same
    net:icmp_redirect.sh                                   pass     pass     pass     same
    net:io_uring_zerocopy_tx.sh                            fail     fail     fail     same
    net:ip6_gre_headroom.sh                                pass     pass     pass     same
    net:ipv6_flowlabel.sh                                  pass     pass     pass     same
    net:l2_tos_ttl_inherit.sh                              skip     skip     skip     same
    net:l2tp.sh                                            pass     pass     pass     same
    net:msg_zerocopy.sh                                    pass     pass     pass     same
    net:netdevice.sh                                       pass     pass     pass     same
    net:pmtu.sh                                            fail     fail     fail     same
    net:psock_snd.sh                                       pass     pass     pass     same
    net:reuseaddr_conflict                                 pass     pass     pass     same
    net:reuseaddr_ports_exhausted.sh                       pass     pass     pass     same
    net:reuseport_bpf                                      pass     pass     pass     same
    net:reuseport_bpf_cpu                                  pass     pass     pass     same
    net:reuseport_bpf_numa                                 pass     pass     pass     same
    net:reuseport_dualstack                                pass     pass     pass     same
    net:route_localnet.sh                                  pass     pass     pass     same
    net:rps_default_mask.sh                                pass     pass     pass     same
    net:rtnetlink.sh                                       skip     skip     skip     same
    net:run_afpackettests                                  pass     pass     pass     same
    net:run_netsocktests                                   pass     pass     pass     same
    net:rxtimestamp.sh                                     pass     pass     pass     same
    net:so_txtime.sh                                       pass     pass     pass     same
    net:srv6_end_next_csid_l3vpn_test.sh                   pass     pass     pass     same
    net:srv6_hencap_red_l3vpn_test.sh                      pass     pass     pass     same
    net:srv6_hl2encap_red_l2vpn_test.sh                    pass     pass     pass     same
    net:stress_reuseport_listen.sh                         pass     pass     pass     same
    net:tcp_fastopen_backup_key.sh                         pass     pass     pass     same
    net:test_blackhole_dev.sh                              fail     fail     fail     same
    net:test_bpf.sh                                        pass     pass     pass     same
    net:test_bridge_neigh_suppress.sh                      skip     skip     skip     same
    net:test_vxlan_fdb_changelink.sh                       pass     pass     pass     same
    net:test_vxlan_under_vrf.sh                            pass     pass     pass     same
    net:tls                                                pass     pass     pass     same
    net:traceroute.sh                                      pass     pass     pass     same
    net:udpgro.sh                                          fail     fail     fail     same
    net:udpgro_bench.sh                                    fail     fail     fail     same
    net:udpgso.sh                                          fail     fail     fail     same
    net:unicast_extensions.sh                              pass     pass     pass     same
    net:veth.sh                                            fail     fail     fail     same
    net:vrf-xfrm-tests.sh                                  pass     pass     pass     same
    net:vrf_route_leaking.sh                               pass     pass     pass     same
    net:vrf_strict_mode_test.sh                            pass     pass     pass     same
    netfilter:bridge_brouter.sh                            skip     skip     skip     same
    netfilter:conntrack_icmp_related.sh                    skip     skip     skip     same
    netfilter:conntrack_tcp_unreplied.sh                   skip     skip     skip     same
    netfilter:conntrack_vrf.sh                             skip     skip     skip     same
    netfilter:ipvs.sh                                      pass     pass     pass     same
    netfilter:nf_nat_edemux.sh                             skip     skip     skip     same
    netfilter:nft_audit.sh                                 skip     skip     skip     same
    netfilter:nft_concat_range.sh                          fail     fail     fail     same
    netfilter:nft_conntrack_helper.sh                      skip     skip     skip     same
    netfilter:nft_fib.sh                                   skip     skip     skip     same
    netfilter:nft_flowtable.sh                             skip     skip     skip     same
    netfilter:nft_meta.sh                                  skip     skip     skip     same
    netfilter:nft_nat.sh                                   skip     skip     skip     same
    netfilter:nft_queue.sh                                 skip     skip     skip     same
    netfilter:rpath.sh                                     skip     skip     skip     same
    nsfs:owner                                             pass     pass     pass     same
    nsfs:pidns                                             pass     pass     pass     same
    pid_namespace:regression_enomem                        pass     pass     pass     same
    pidfd:pidfd_fdinfo_test                                pass     pass     pass     same
    pidfd:pidfd_getfd_test                                 pass     pass     pass     same
    pidfd:pidfd_open_test                                  pass     pass     pass     same
    pidfd:pidfd_poll_test                                  pass     pass     pass     same
    pidfd:pidfd_setns_test                                 pass     pass     pass     same
    pidfd:pidfd_test                                       pass     pass     pass     same
    pidfd:pidfd_wait                                       pass     pass     pass     same
    proc:fd-001-lookup                                     pass     pass     pass     same
    proc:fd-002-posix-eq                                   pass     pass     pass     same
    proc:fd-003-kthread                                    pass     pass     pass     same
    proc:proc-fsconfig-hidepid                             pass     pass     pass     same
    proc:proc-loadavg-001                                  pass     pass     pass     same
    proc:proc-multiple-procfs                              pass     pass     pass     same
    proc:proc-self-map-files-001                           pass     pass     pass     same
    proc:proc-self-map-files-002                           pass     pass     pass     same
    proc:proc-self-syscall                                 pass     pass     pass     same
    proc:proc-self-wchan                                   pass     pass     pass     same
    proc:proc-subset-pid                                   pass     pass     pass     same
    proc:proc-uptime-002                                   pass     pass     pass     same
    proc:read                                              pass     pass     pass     same
    proc:self                                              pass     pass     pass     same
    proc:setns-dcache                                      pass     pass     pass     same
    proc:setns-sysvipc                                     pass     pass     pass     same
    proc:thread-self                                       pass     pass     pass     same
    pstore:pstore_post_reboot_tests                        skip     skip     skip     same
    pstore:pstore_tests                                    fail     fail     fail     same
    ptrace:get_syscall_info                                pass     pass     pass     same
    ptrace:peeksiginfo                                     pass     pass     pass     same
    ptrace:vmaccess                                        fail     fail     fail     same
    rlimits:rlimits-per-userns                             pass     pass     pass     same
    rseq:basic_percpu_ops_test                             pass     pass     pass     same
    rseq:basic_test                                        pass     pass     pass     same
    rseq:param_test                                        pass     pass     pass     same
    rseq:param_test_benchmark                              pass     pass     pass     same
    rseq:param_test_compare_twice                          pass     pass     pass     same
    rseq:run_param_test.sh                                 pass     pass     pass     same
    seccomp:seccomp_benchmark                              pass     pass     pass     same
    seccomp:seccomp_bpf                                    pass     pass     pass     same
    sgx:test_sgx                                           fail     fail     fail     same
    sigaltstack:sas                                        pass     pass     pass     same
    size:get_size                                          pass     pass     pass     same
    splice:default_file_splice_read.sh                     pass     pass     pass     same
    splice:short_splice_read.sh                            fail     fail     fail     same
    static_keys:test_static_keys.sh                        skip     skip     skip     same
    syscall_user_dispatch:sud_benchmark                    pass     pass     pass     same
    syscall_user_dispatch:sud_test                         pass     pass     pass     same
    tc-testing:tdc.sh                                      fail     fail     fail     same
    tdx:tdx_guest_test                                     fail     fail     fail     same
    timens:clock_nanosleep                                 pass     pass     pass     same
    timens:exec                                            pass     pass     pass     same
    timens:futex                                           pass     pass     pass     same
    timens:procfs                                          pass     pass     pass     same
    timens:timens                                          pass     pass     pass     same
    timens:timer                                           pass     pass     pass     same
    timens:timerfd                                         pass     pass     pass     same
    timens:vfork_exec                                      pass     pass     pass     same
    timers:inconsistency-check                             pass     pass     pass     same
    timers:mqueue-lat                                      pass     pass     pass     same
    timers:nanosleep                                       pass     pass     pass     same
    timers:nsleep-lat                                      pass     pass     pass     same
    timers:posix_timers                                    pass     pass     pass     same
    timers:rtcpie                                          pass     pass     pass     same
    timers:set-timer-lat                                   pass     pass     pass     same
    timers:threadtest                                      pass     pass     pass     same
    tmpfs:bug-link-o-tmpfile                               pass     pass     pass     same
    tpm2:test_smoke.sh                                     skip     skip     skip     same
    tpm2:test_space.sh                                     skip     skip     skip     same
    tty:tty_tstamp_update                                  skip     skip     skip     same
    vDSO:vdso_standalone_test_x86                          pass     pass     pass     same
    vDSO:vdso_test_abi                                     pass     pass     pass     same
    vDSO:vdso_test_clock_getres                            pass     pass     pass     same
    vDSO:vdso_test_correctness                             pass     pass     pass     same
    vDSO:vdso_test_getcpu                                  pass     pass     pass     same
    vDSO:vdso_test_gettimeofday                            pass     pass     pass     same
    x86:amx_64                                             fail     fail     fail     same
    x86:check_initial_reg_state_64                         fail     fail     fail     same
    x86:corrupt_xstate_header_64                           fail     fail     fail     same
    x86:fsgsbase_64                                        fail     fail     fail     same
    x86:fsgsbase_restore_64                                fail     fail     fail     same
    x86:ioperm_64                                          fail     fail     fail     same
    x86:iopl_64                                            fail     fail     fail     same
    x86:lam_64                                             fail     fail     fail     same
    x86:mov_ss_trap_64                                     fail     fail     fail     same
    x86:sigaltstack_64                                     fail     fail     fail     same
    x86:sigreturn_64                                       fail     fail     fail     same
    x86:single_step_syscall_64                             fail     fail     fail     same
    x86:syscall_arg_fault_64                               fail     fail     fail     same
    x86:syscall_nt_64                                      fail     fail     fail     same
    x86:syscall_numbering_64                               fail     fail     fail     same
    x86:sysret_rip_64                                      fail     fail     fail     same
    x86:sysret_ss_attrs_64                                 fail     fail     fail     same
    x86:test_mremap_vdso_64                                fail     fail     fail     same
    x86:test_vsyscall_64                                   fail     fail     fail     same
    zram:zram.sh                                           pass     pass     pass     same

