### PR TITLE
github-actions: Skip LTP testing on CBR 7.9

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
@@ -24,4 +24,5 @@ jobs:
     with:
       architectures: 'x86_64'
       skip_kselftests: true
+      skip_ltp: true
     secrets: inherit


### PR DESCRIPTION
Skip LTP testing on CBR 7.9