### PR TITLE
CLK 6.18 Update branding in package descrptions and log messages

### DIFF
--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -1,0 +1,58 @@
+name: RPM Build
+on:
+  pull_request:
+    branches:
+      - '**'
+      - '!mainline'
+
+jobs:
+  rpm-build-job:
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            runner: kernel-build
+            mock_config: rocky-9-x86_64
+          - arch: aarch64
+            runner: kernel-build-arm64
+            mock_config: rocky-9-aarch64
+    runs-on:
+      labels: ${{ matrix.runner }}
+    container:
+      image: rockylinux/rockylinux:9
+      options: --privileged --cpus 8
+    steps:
+      - name: Install tools and libraries
+        run: |
+          dnf install -y epel-release
+          dnf install -y mock git rust cargo zstd which
+          useradd -m -G mock mockbuild
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.head.sha }}"
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Generate tarball
+        run: |
+          git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
+          ./ciq/SOURCES/generate_tarball.sh
+
+      - name: Bundle bindgen
+        run: ./ciq/SOURCES/bundle_bindgen.sh ./ciq/SOURCES
+
+      - name: Build SRPM
+        run: |
+          mkdir -p ../build_files
+          chown mockbuild:mock ../build_files
+          su mockbuild -c "mock -v -r ${{ matrix.mock_config }} --resultdir=$(pwd)/../build_files \
+            --buildsrpm \
+            --sources=$(pwd)/ciq/SOURCES \
+            --spec=$(pwd)/ciq/SPECS/kernel-clk6.18.spec"
+
+      - name: Build RPM
+        run: |
+          SRPM=$(ls ../build_files/*.src.rpm | head -1)
+          su mockbuild -c "mock -v -r ${{ matrix.mock_config }} --resultdir=$(pwd)/../build_files $SRPM"

--- a/ciq/SPECS/kernel-clk6.18.spec
+++ b/ciq/SPECS/kernel-clk6.18.spec
@@ -1545,7 +1545,7 @@ Requires: %{name}%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?
 AutoReq: no\
 AutoProv: yes\
 %description %{?1:%{1}-}modules-internal\
-This package provides kernel modules for the %{?2:%{2} }kernel package for Red Hat internal usage.\
+This package provides kernel modules for the %{?2:%{2} }kernel package for CIQ internal usage.\
 %{nil}
 
 #
@@ -1709,7 +1709,7 @@ Requires: %{name}%{?1:-%{1}}-modules-core-uname-r = %{KVERREL}%{uname_suffix %{?
 AutoReq: no\
 AutoProv: yes\
 %description %{?1:%{1}-}modules-partner\
-This package provides kernel modules for the %{?2:%{2} }kernel package for Red Hat partners usage.\
+This package provides kernel modules for the %{?2:%{2} }kernel package for CIQ partners usage.\
 %{nil}
 
 # Now, each variant package.
@@ -2177,7 +2177,7 @@ for opt in %{clang_make_opts}; do
   OPTS="$OPTS -m $opt"
 done
 %endif
-%{log_msg "Generate redhat configs"}
+%{log_msg "Generate CIQ configs"}
 RHJOBS=$RPM_BUILD_NCPUS SPECPACKAGE_NAME=%{name} ./process_configs.sh $OPTS %{specversion}
 
 # We may want to override files from the primary target in case of building
@@ -2987,7 +2987,7 @@ BuildKernel() {
     # prune junk from kernel-debuginfo
     find $RPM_BUILD_ROOT/usr/src/kernels -name "*.mod.c" -delete
 
-    # Red Hat UEFI Secure Boot CA cert, which can be used to authenticate the kernel
+    # UEFI Secure Boot CA cert, which can be used to authenticate the kernel
     %{log_msg "Install certs"}
     mkdir -p $RPM_BUILD_ROOT%{_datadir}/doc/kernel-keys/$KernelVer
 %if %{signkernel}
@@ -3000,7 +3000,7 @@ BuildKernel() {
 %endif
 
 %if 0%{?rhel}
-    # Red Hat IMA code-signing cert, which is used to authenticate package files
+    # IMA code-signing cert, which is used to authenticate package files
     install -m 0644 %{ima_signing_cert} $RPM_BUILD_ROOT%{_datadir}/doc/kernel-keys/$KernelVer/%{ima_cert_name}
 %endif
 


### PR DESCRIPTION
Just little cleanup to fix some branding in the spec where a customer might actually see it.  There is certainly more cleanup to be done here in the areas that customers don't see which we can do in the future.  This PR also adds an RPM build workflow so that spec changes are validated to at least build successfully for both x86_64 and aarch64.  This workflow is essentially the same build steps I do before creating a secure boot ticket for CLK kernels, so this helps ensure we are in good shape for releases.