### PR TITLE
spec: Fix posttrans script to handle noarch package expansion

### DIFF
--- a/ciq/SPECS/kernel-clk6.18.spec
+++ b/ciq/SPECS/kernel-clk6.18.spec
@@ -3842,11 +3842,14 @@ DEFAULTKERNEL=kernel-%{pkg_suffix}-core
 EOF
 
 %posttrans default
-# Set this kernel version as the boot default after all transactions complete
-if [ -f /boot/vmlinuz-%{KVERREL} ]; then
-    grubby --set-default=/boot/vmlinuz-%{KVERREL} ||
+# Use a glob -- this is a noarch package so %{_target_cpu} expands to "noarch"
+# at build time, not the actual installed arch.
+for vmlinuz in /boot/vmlinuz-%{specversion}-%{release}.*+%{pkg_suffix}; do
+    [ -f "$vmlinuz" ] || continue
+    grubby --set-default="$vmlinuz" ||
         echo "warning: failed to set kernel-%{pkg_suffix} as boot default" >&2
-fi
+    break
+done
 
 #
 # This macro defines a %%post script for a kernel*-devel package.


### PR DESCRIPTION
https://ciqinc.atlassian.net/browse/KERNEL-852

This issue was discovered by @josephtate during secure boot build testing.  The noarch version of the kernel-clk6.18-default package is looking for a kernel binary path that will never exist.  He proposed this fix in the ticket.  I've built and verified that it addresses the issue.

```
Last metadata expiration check: 1:04:01 ago on Mon 20 Apr 2026 12:15:58 PM UTC.
Dependencies resolved.
=================================================================================================================================================================================================================================================================================
 Package                                                                       Architecture                                             Version                                                             Repository                                                      Size
=================================================================================================================================================================================================================================================================================
Installing:
 kernel-clk6.18                                                                x86_64                                                   6.18.22-1.1.el9                                                     @commandline                                                    11 k
 kernel-clk6.18-core                                                           x86_64                                                   6.18.22-1.1.el9                                                     @commandline                                                    16 M
 kernel-clk6.18-default                                                        noarch                                                   6.18.22-1.1.el9                                                     @commandline                                                    16 k
 kernel-clk6.18-modules                                                        x86_64                                                   6.18.22-1.1.el9                                                     @commandline                                                    40 M
 kernel-clk6.18-modules-core                                                   x86_64                                                   6.18.22-1.1.el9                                                     @commandline                                                    29 M

Transaction Summary
=================================================================================================================================================================================================================================================================================
Install  5 Packages

Total size: 84 M
Installed size: 153 M
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
7Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                                                                         1/1
  Installing       : kernel-clk6.18-modules-core-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                      1/5
  Installing       : kernel-clk6.18-core-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                              2/5
  Running scriptlet: kernel-clk6.18-core-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                              2/5
  Installing       : kernel-clk6.18-modules-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                           3/5
  Running scriptlet: kernel-clk6.18-modules-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                           3/5
  Installing       : kernel-clk6.18-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                                   4/5
  Running scriptlet: kernel-clk6.18-default-6.18.22-1.1.el9.noarch                                                                                                                                                                                                           5/5
  Installing       : kernel-clk6.18-default-6.18.22-1.1.el9.noarch                                                                                                                                                                                                           5/5
  Running scriptlet: kernel-clk6.18-modules-core-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                      5/5
  Running scriptlet: kernel-clk6.18-core-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                              5/5
  Running scriptlet: kernel-clk6.18-modules-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                           5/5
  Running scriptlet: kernel-clk6.18-default-6.18.22-1.1.el9.noarch                                                                                                                                                                                                           5/5
The default is /boot/loader/entries/0364e7fed1384d83aa560888c168e28a-6.18.22-1.1.el9.x86_64+clk6.18.conf with index 0 and kernel /boot/vmlinuz-6.18.22-1.1.el9.x86_64+clk6.18

  Verifying        : kernel-clk6.18-default-6.18.22-1.1.el9.noarch                                                                                                                                                                                                           1/5
  Verifying        : kernel-clk6.18-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                                   2/5
  Verifying        : kernel-clk6.18-core-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                              3/5
  Verifying        : kernel-clk6.18-modules-core-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                      4/5
  Verifying        : kernel-clk6.18-modules-6.18.22-1.1.el9.x86_64                                                                                                                                                                                                           5/5

Installed:
  kernel-clk6.18-6.18.22-1.1.el9.x86_64          kernel-clk6.18-core-6.18.22-1.1.el9.x86_64          kernel-clk6.18-default-6.18.22-1.1.el9.noarch          kernel-clk6.18-modules-6.18.22-1.1.el9.x86_64          kernel-clk6.18-modules-core-6.18.22-1.1.el9.x86_64

Complete!
[brett@clk-test 6.18-jt]$ sudo grubby --default-kernel
/boot/vmlinuz-6.18.22-1.1.el9.x86_64+clk6.18
```