### PR TITLE
github-actions: Use main branch for kernel-container-build

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -280,11 +280,11 @@ jobs:
       run: |
         git checkout -b "$HEAD_REF"
 
-    - name: Checkout kernel-container-build (test branch)
+    - name: Checkout kernel-container-build
       uses: actions/checkout@v4
       with:
         repository: ctrliq/kernel-container-build
-        ref: automated-testing-v1
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -397,11 +397,11 @@ jobs:
         repositories: |
           kernel-container-build
 
-    - name: Checkout kernel-container-build (test branch)
+    - name: Checkout kernel-container-build
       uses: actions/checkout@v4
       with:
         repository: ctrliq/kernel-container-build
-        ref: automated-testing-v1
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -479,11 +479,11 @@ jobs:
         repositories: |
           kernel-container-build
 
-    - name: Checkout kernel-container-build (test branch)
+    - name: Checkout kernel-container-build
       uses: actions/checkout@v4
       with:
         repository: ctrliq/kernel-container-build
-        ref: automated-testing-v1
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -549,11 +549,11 @@ jobs:
         repositories: |
           kernel-container-build
 
-    - name: Checkout kernel-container-build (test branch)
+    - name: Checkout kernel-container-build
       uses: actions/checkout@v4
       with:
         repository: ctrliq/kernel-container-build
-        ref: automated-testing-v1
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -651,7 +651,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ctrliq/kernel-container-build
-        ref: automated-testing-v1
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 


### PR DESCRIPTION
We have been using automated-testing-v1 to keep Dieter's changes different from ours but I think it's time for us to move those changes to main and start using main branch here in KernelCI.