### PR TITLE
[LTS 9.6] bluetooth: CVE-2025-39981, CVE-2025-38117, CVE-2025-40213, CVE-2025-68305, CVE-2026-23151, CVE-2026-31511

### DIFF
--- a/include/net/bluetooth/hci_core.h
+++ b/include/net/bluetooth/hci_core.h
@@ -540,6 +540,7 @@ struct hci_dev {
 	struct hci_conn_hash	conn_hash;
 
 	struct list_head	mesh_pending;
+	struct mutex		mgmt_pending_lock;
 	struct list_head	mgmt_pending;
 	struct list_head	reject_list;
 	struct list_head	accept_list;

--- a/include/net/bluetooth/hci_sync.h
+++ b/include/net/bluetooth/hci_sync.h
@@ -93,7 +93,7 @@ int hci_update_class_sync(struct hci_dev *hdev);
 
 int hci_update_eir_sync(struct hci_dev *hdev);
 int hci_update_class_sync(struct hci_dev *hdev);
-int hci_update_name_sync(struct hci_dev *hdev);
+int hci_update_name_sync(struct hci_dev *hdev, const u8 *name);
 int hci_write_ssp_mode_sync(struct hci_dev *hdev, u8 mode);
 
 int hci_get_random_address(struct hci_dev *hdev, bool require_privacy,

--- a/include/net/bluetooth/mgmt.h
+++ b/include/net/bluetooth/mgmt.h
@@ -847,7 +847,7 @@ struct mgmt_cp_set_mesh {
 	__le16 window;
 	__le16 period;
 	__u8   num_ad_types;
-	__u8   ad_types[];
+	__u8   ad_types[] __counted_by(num_ad_types);
 } __packed;
 #define MGMT_SET_MESH_RECEIVER_SIZE	6
 

--- a/net/bluetooth/hci_core.c
+++ b/net/bluetooth/hci_core.c
@@ -2529,6 +2529,7 @@ struct hci_dev *hci_alloc_dev_priv(int sizeof_priv)
 
 	mutex_init(&hdev->lock);
 	mutex_init(&hdev->req_lock);
+	mutex_init(&hdev->mgmt_pending_lock);
 
 	ida_init(&hdev->unset_handle_ida);
 

--- a/net/bluetooth/hci_sock.c
+++ b/net/bluetooth/hci_sock.c
@@ -1316,7 +1316,9 @@ static int hci_sock_bind(struct socket *sock, struct sockaddr *addr,
 			goto done;
 		}
 
+		hci_dev_lock(hdev);
 		mgmt_index_removed(hdev);
+		hci_dev_unlock(hdev);
 
 		err = hci_dev_open(hdev->id);
 		if (err) {

--- a/net/bluetooth/hci_sync.c
+++ b/net/bluetooth/hci_sync.c
@@ -3441,13 +3441,13 @@ int hci_update_scan_sync(struct hci_dev *hdev)
 	return hci_write_scan_enable_sync(hdev, scan);
 }
 
-int hci_update_name_sync(struct hci_dev *hdev)
+int hci_update_name_sync(struct hci_dev *hdev, const u8 *name)
 {
 	struct hci_cp_write_local_name cp;
 
 	memset(&cp, 0, sizeof(cp));
 
-	memcpy(cp.name, hdev->dev_name, sizeof(cp.name));
+	memcpy(cp.name, name, sizeof(cp.name));
 
 	return __hci_cmd_sync_status(hdev, HCI_OP_WRITE_LOCAL_NAME,
 					    sizeof(cp), &cp,
@@ -3500,7 +3500,7 @@ int hci_powered_update_sync(struct hci_dev *hdev)
 			hci_write_fast_connectable_sync(hdev, false);
 		hci_update_scan_sync(hdev);
 		hci_update_class_sync(hdev);
-		hci_update_name_sync(hdev);
+		hci_update_name_sync(hdev, hdev->dev_name);
 		hci_update_eir_sync(hdev);
 	}
 

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -2169,19 +2169,24 @@ static void set_mesh_complete(struct hci_dev *hdev, void *data, int err)
 	sk = cmd->sk;
 
 	if (status) {
+		mgmt_cmd_status(cmd->sk, hdev->id, MGMT_OP_SET_MESH_RECEIVER,
+				status);
 		mgmt_pending_foreach(MGMT_OP_SET_MESH_RECEIVER, hdev, true,
 				     cmd_status_rsp, &status);
-		return;
+		goto done;
 	}
 
-	mgmt_pending_remove(cmd);
 	mgmt_cmd_complete(sk, hdev->id, MGMT_OP_SET_MESH_RECEIVER, 0, NULL, 0);
+
+done:
+	mgmt_pending_free(cmd);
 }
 
 static int set_mesh_sync(struct hci_dev *hdev, void *data)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct mgmt_cp_set_mesh cp;
+	DEFINE_FLEX(struct mgmt_cp_set_mesh, cp, ad_types, num_ad_types,
+		    sizeof(hdev->mesh_ad_types));
 	size_t len;
 
 	mutex_lock(&hdev->mgmt_pending_lock);
@@ -2191,27 +2196,26 @@ static int set_mesh_sync(struct hci_dev *hdev, void *data)
 		return -ECANCELED;
 	}
 
-	memcpy(&cp, cmd->param, sizeof(cp));
+	len = cmd->param_len;
+	memcpy(cp, cmd->param, min(__struct_size(cp), len));
 
 	mutex_unlock(&hdev->mgmt_pending_lock);
 
-	len = cmd->param_len;
-
 	memset(hdev->mesh_ad_types, 0, sizeof(hdev->mesh_ad_types));
 
-	if (cp.enable)
+	if (cp->enable)
 		hci_dev_set_flag(hdev, HCI_MESH);
 	else
 		hci_dev_clear_flag(hdev, HCI_MESH);
 
-	hdev->le_scan_interval = __le16_to_cpu(cp.period);
-	hdev->le_scan_window = __le16_to_cpu(cp.window);
+	hdev->le_scan_interval = __le16_to_cpu(cp->period);
+	hdev->le_scan_window = __le16_to_cpu(cp->window);
 
-	len -= sizeof(cp);
+	len -= sizeof(struct mgmt_cp_set_mesh);
 
 	/* If filters don't fit, forward all adv pkts */
 	if (len <= sizeof(hdev->mesh_ad_types))
-		memcpy(hdev->mesh_ad_types, cp.ad_types, len);
+		memcpy(hdev->mesh_ad_types, cp->ad_types, len);
 
 	hci_update_passive_scan_sync(hdev);
 	return 0;

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -1942,6 +1942,7 @@ static void set_ssp_complete(struct hci_dev *hdev, void *data, int err)
 		}
 
 		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_err);
+		mgmt_pending_free(cmd);
 		return;
 	}
 
@@ -1960,6 +1961,7 @@ static void set_ssp_complete(struct hci_dev *hdev, void *data, int err)
 		sock_put(match.sk);
 
 	hci_update_eir_sync(hdev);
+	mgmt_pending_free(cmd);
 }
 
 static int set_ssp_sync(struct hci_dev *hdev, void *data)
@@ -6461,6 +6463,7 @@ static void set_advertising_complete(struct hci_dev *hdev, void *data, int err)
 		hci_dev_clear_flag(hdev, HCI_ADVERTISING);
 
 	settings_rsp(cmd, &match);
+	mgmt_pending_free(cmd);
 
 	new_settings(hdev, match.sk);
 

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -3825,8 +3825,11 @@ static void set_name_complete(struct hci_dev *hdev, void *data, int err)
 
 static int set_name_sync(struct hci_dev *hdev, void *data)
 {
+	struct mgmt_pending_cmd *cmd = data;
+	struct mgmt_cp_set_local_name *cp = cmd->param;
+
 	if (lmp_bredr_capable(hdev)) {
-		hci_update_name_sync(hdev);
+		hci_update_name_sync(hdev, cp->name);
 		hci_update_eir_sync(hdev);
 	}
 

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -2146,6 +2146,9 @@ static int set_mesh_sync(struct hci_dev *hdev, void *data)
 	else
 		hci_dev_clear_flag(hdev, HCI_MESH);
 
+	hdev->le_scan_interval = __le16_to_cpu(cp->period);
+	hdev->le_scan_window = __le16_to_cpu(cp->window);
+
 	len -= sizeof(*cp);
 
 	/* If filters don't fit, forward all adv pkts */
@@ -2160,6 +2163,7 @@ static int set_mesh(struct sock *sk, struct hci_dev *hdev, void *data, u16 len)
 {
 	struct mgmt_cp_set_mesh *cp = data;
 	struct mgmt_pending_cmd *cmd;
+	__u16 period, window;
 	int err = 0;
 
 	bt_dev_dbg(hdev, "sock %p", sk);
@@ -2170,6 +2174,23 @@ static int set_mesh(struct sock *sk, struct hci_dev *hdev, void *data, u16 len)
 				       MGMT_STATUS_NOT_SUPPORTED);
 
 	if (cp->enable != 0x00 && cp->enable != 0x01)
+		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_SET_MESH_RECEIVER,
+				       MGMT_STATUS_INVALID_PARAMS);
+
+	/* Keep allowed ranges in sync with set_scan_params() */
+	period = __le16_to_cpu(cp->period);
+
+	if (period < 0x0004 || period > 0x4000)
+		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_SET_MESH_RECEIVER,
+				       MGMT_STATUS_INVALID_PARAMS);
+
+	window = __le16_to_cpu(cp->window);
+
+	if (window < 0x0004 || window > 0x4000)
+		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_SET_MESH_RECEIVER,
+				       MGMT_STATUS_INVALID_PARAMS);
+
+	if (window > period)
 		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_SET_MESH_RECEIVER,
 				       MGMT_STATUS_INVALID_PARAMS);
 
@@ -6541,6 +6562,7 @@ static int set_scan_params(struct sock *sk, struct hci_dev *hdev,
 		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_SET_SCAN_PARAMS,
 				       MGMT_STATUS_NOT_SUPPORTED);
 
+	/* Keep allowed ranges in sync with set_mesh() */
 	interval = __le16_to_cpu(cp->interval);
 
 	if (interval < 0x0004 || interval > 0x4000)

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -1440,22 +1440,17 @@ static void settings_rsp(struct mgmt_pending_cmd *cmd, void *data)
 
 	send_settings_rsp(cmd->sk, cmd->opcode, match->hdev);
 
-	list_del(&cmd->list);
-
 	if (match->sk == NULL) {
 		match->sk = cmd->sk;
 		sock_hold(match->sk);
 	}
-
-	mgmt_pending_free(cmd);
 }
 
 static void cmd_status_rsp(struct mgmt_pending_cmd *cmd, void *data)
 {
 	u8 *status = data;
 
-	mgmt_cmd_status(cmd->sk, cmd->index, cmd->opcode, *status);
-	mgmt_pending_remove(cmd);
+	mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode, *status);
 }
 
 static void cmd_complete_rsp(struct mgmt_pending_cmd *cmd, void *data)
@@ -1469,8 +1464,6 @@ static void cmd_complete_rsp(struct mgmt_pending_cmd *cmd, void *data)
 
 	if (cmd->cmd_complete) {
 		cmd->cmd_complete(cmd, match->mgmt_status);
-		mgmt_pending_remove(cmd);
-
 		return;
 	}
 
@@ -1479,13 +1472,13 @@ static void cmd_complete_rsp(struct mgmt_pending_cmd *cmd, void *data)
 
 static int generic_cmd_complete(struct mgmt_pending_cmd *cmd, u8 status)
 {
-	return mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode, status,
+	return mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode, status,
 				 cmd->param, cmd->param_len);
 }
 
 static int addr_cmd_complete(struct mgmt_pending_cmd *cmd, u8 status)
 {
-	return mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode, status,
+	return mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode, status,
 				 cmd->param, sizeof(struct mgmt_addr_info));
 }
 
@@ -1525,7 +1518,7 @@ static void mgmt_set_discoverable_complete(struct hci_dev *hdev, void *data,
 
 	if (err) {
 		u8 mgmt_err = mgmt_status(err);
-		mgmt_cmd_status(cmd->sk, cmd->index, cmd->opcode, mgmt_err);
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_err);
 		hci_dev_clear_flag(hdev, HCI_LIMITED_DISCOVERABLE);
 		goto done;
 	}
@@ -1700,7 +1693,7 @@ static void mgmt_set_connectable_complete(struct hci_dev *hdev, void *data,
 
 	if (err) {
 		u8 mgmt_err = mgmt_status(err);
-		mgmt_cmd_status(cmd->sk, cmd->index, cmd->opcode, mgmt_err);
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_err);
 		goto done;
 	}
 
@@ -1936,8 +1929,8 @@ static void set_ssp_complete(struct hci_dev *hdev, void *data, int err)
 			new_settings(hdev, NULL);
 		}
 
-		mgmt_pending_foreach(MGMT_OP_SET_SSP, hdev, cmd_status_rsp,
-				     &mgmt_err);
+		mgmt_pending_foreach(MGMT_OP_SET_SSP, hdev, true,
+				     cmd_status_rsp, &mgmt_err);
 		return;
 	}
 
@@ -1947,7 +1940,7 @@ static void set_ssp_complete(struct hci_dev *hdev, void *data, int err)
 		changed = hci_dev_test_and_clear_flag(hdev, HCI_SSP_ENABLED);
 	}
 
-	mgmt_pending_foreach(MGMT_OP_SET_SSP, hdev, settings_rsp, &match);
+	mgmt_pending_foreach(MGMT_OP_SET_SSP, hdev, true, settings_rsp, &match);
 
 	if (changed)
 		new_settings(hdev, match.sk);
@@ -2067,12 +2060,12 @@ static void set_le_complete(struct hci_dev *hdev, void *data, int err)
 	bt_dev_dbg(hdev, "err %d", err);
 
 	if (status) {
-		mgmt_pending_foreach(MGMT_OP_SET_LE, hdev, cmd_status_rsp,
-							&status);
+		mgmt_pending_foreach(MGMT_OP_SET_LE, hdev, true, cmd_status_rsp,
+				     &status);
 		return;
 	}
 
-	mgmt_pending_foreach(MGMT_OP_SET_LE, hdev, settings_rsp, &match);
+	mgmt_pending_foreach(MGMT_OP_SET_LE, hdev, true, settings_rsp, &match);
 
 	new_settings(hdev, match.sk);
 
@@ -2131,7 +2124,7 @@ static void set_mesh_complete(struct hci_dev *hdev, void *data, int err)
 	struct sock *sk = cmd->sk;
 
 	if (status) {
-		mgmt_pending_foreach(MGMT_OP_SET_MESH_RECEIVER, hdev,
+		mgmt_pending_foreach(MGMT_OP_SET_MESH_RECEIVER, hdev, true,
 				     cmd_status_rsp, &status);
 		return;
 	}
@@ -2572,7 +2565,7 @@ static void mgmt_class_complete(struct hci_dev *hdev, void *data, int err)
 
 	bt_dev_dbg(hdev, "err %d", err);
 
-	mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode,
+	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode,
 			  mgmt_status(err), hdev->dev_class, 3);
 
 	mgmt_pending_free(cmd);
@@ -3360,7 +3353,7 @@ static int pairing_complete(struct mgmt_pending_cmd *cmd, u8 status)
 	bacpy(&rp.addr.bdaddr, &conn->dst);
 	rp.addr.type = link_to_bdaddr(conn->type, conn->dst_type);
 
-	err = mgmt_cmd_complete(cmd->sk, cmd->index, MGMT_OP_PAIR_DEVICE,
+	err = mgmt_cmd_complete(cmd->sk, cmd->hdev->id, MGMT_OP_PAIR_DEVICE,
 				status, &rp, sizeof(rp));
 
 	/* So we don't get further callbacks for this connection */
@@ -5260,7 +5253,7 @@ static void mgmt_add_adv_patterns_monitor_complete(struct hci_dev *hdev,
 		hci_update_passive_scan(hdev);
 	}
 
-	mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode,
+	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode,
 			  mgmt_status(status), &rp, sizeof(rp));
 	mgmt_pending_remove(cmd);
 
@@ -5469,7 +5462,7 @@ static void mgmt_remove_adv_monitor_complete(struct hci_dev *hdev,
 	if (!status)
 		hci_update_passive_scan(hdev);
 
-	mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode,
+	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode,
 			  mgmt_status(status), &rp, sizeof(rp));
 	mgmt_pending_remove(cmd);
 
@@ -5869,7 +5862,7 @@ static void start_discovery_complete(struct hci_dev *hdev, void *data, int err)
 	    cmd != pending_find(MGMT_OP_START_SERVICE_DISCOVERY, hdev))
 		return;
 
-	mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode, mgmt_status(err),
+	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_status(err),
 			  cmd->param, 1);
 	mgmt_pending_remove(cmd);
 
@@ -6107,7 +6100,7 @@ static void stop_discovery_complete(struct hci_dev *hdev, void *data, int err)
 
 	bt_dev_dbg(hdev, "err %d", err);
 
-	mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode, mgmt_status(err),
+	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_status(err),
 			  cmd->param, 1);
 	mgmt_pending_remove(cmd);
 
@@ -6332,7 +6325,7 @@ static void set_advertising_complete(struct hci_dev *hdev, void *data, int err)
 	u8 status = mgmt_status(err);
 
 	if (status) {
-		mgmt_pending_foreach(MGMT_OP_SET_ADVERTISING, hdev,
+		mgmt_pending_foreach(MGMT_OP_SET_ADVERTISING, hdev, true,
 				     cmd_status_rsp, &status);
 		return;
 	}
@@ -6342,7 +6335,7 @@ static void set_advertising_complete(struct hci_dev *hdev, void *data, int err)
 	else
 		hci_dev_clear_flag(hdev, HCI_ADVERTISING);
 
-	mgmt_pending_foreach(MGMT_OP_SET_ADVERTISING, hdev, settings_rsp,
+	mgmt_pending_foreach(MGMT_OP_SET_ADVERTISING, hdev, true, settings_rsp,
 			     &match);
 
 	new_settings(hdev, match.sk);
@@ -6686,7 +6679,7 @@ static void set_bredr_complete(struct hci_dev *hdev, void *data, int err)
 		 */
 		hci_dev_clear_flag(hdev, HCI_BREDR_ENABLED);
 
-		mgmt_cmd_status(cmd->sk, cmd->index, cmd->opcode, mgmt_err);
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_err);
 	} else {
 		send_settings_rsp(cmd->sk, MGMT_OP_SET_BREDR, hdev);
 		new_settings(hdev, cmd->sk);
@@ -6823,7 +6816,7 @@ static void set_secure_conn_complete(struct hci_dev *hdev, void *data, int err)
 	if (err) {
 		u8 mgmt_err = mgmt_status(err);
 
-		mgmt_cmd_status(cmd->sk, cmd->index, cmd->opcode, mgmt_err);
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_err);
 		goto done;
 	}
 
@@ -7270,7 +7263,7 @@ static void get_conn_info_complete(struct hci_dev *hdev, void *data, int err)
 		rp.max_tx_power = HCI_TX_POWER_INVALID;
 	}
 
-	mgmt_cmd_complete(cmd->sk, cmd->index, MGMT_OP_GET_CONN_INFO, status,
+	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, MGMT_OP_GET_CONN_INFO, status,
 			  &rp, sizeof(rp));
 
 	mgmt_pending_free(cmd);
@@ -7431,7 +7424,7 @@ static void get_clock_info_complete(struct hci_dev *hdev, void *data, int err)
 	}
 
 complete:
-	mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode, status, &rp,
+	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode, status, &rp,
 			  sizeof(rp));
 
 	mgmt_pending_free(cmd);
@@ -8644,10 +8637,10 @@ static void add_advertising_complete(struct hci_dev *hdev, void *data, int err)
 	rp.instance = cp->instance;
 
 	if (err)
-		mgmt_cmd_status(cmd->sk, cmd->index, cmd->opcode,
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode,
 				mgmt_status(err));
 	else
-		mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode,
+		mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode,
 				  mgmt_status(err), &rp, sizeof(rp));
 
 	add_adv_complete(hdev, cmd->sk, cp->instance, err);
@@ -8835,10 +8828,10 @@ static void add_ext_adv_params_complete(struct hci_dev *hdev, void *data,
 
 		hci_remove_adv_instance(hdev, cp->instance);
 
-		mgmt_cmd_status(cmd->sk, cmd->index, cmd->opcode,
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode,
 				mgmt_status(err));
 	} else {
-		mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode,
+		mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode,
 				  mgmt_status(err), &rp, sizeof(rp));
 	}
 
@@ -8985,10 +8978,10 @@ static void add_ext_adv_data_complete(struct hci_dev *hdev, void *data, int err)
 	rp.instance = cp->instance;
 
 	if (err)
-		mgmt_cmd_status(cmd->sk, cmd->index, cmd->opcode,
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode,
 				mgmt_status(err));
 	else
-		mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode,
+		mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode,
 				  mgmt_status(err), &rp, sizeof(rp));
 
 	mgmt_pending_free(cmd);
@@ -9147,10 +9140,10 @@ static void remove_advertising_complete(struct hci_dev *hdev, void *data,
 	rp.instance = cp->instance;
 
 	if (err)
-		mgmt_cmd_status(cmd->sk, cmd->index, cmd->opcode,
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode,
 				mgmt_status(err));
 	else
-		mgmt_cmd_complete(cmd->sk, cmd->index, cmd->opcode,
+		mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode,
 				  MGMT_STATUS_SUCCESS, &rp, sizeof(rp));
 
 	mgmt_pending_free(cmd);
@@ -9421,7 +9414,7 @@ void mgmt_index_removed(struct hci_dev *hdev)
 	if (test_bit(HCI_QUIRK_RAW_DEVICE, &hdev->quirks))
 		return;
 
-	mgmt_pending_foreach(0, hdev, cmd_complete_rsp, &match);
+	mgmt_pending_foreach(0, hdev, true, cmd_complete_rsp, &match);
 
 	if (hci_dev_test_flag(hdev, HCI_UNCONFIGURED)) {
 		mgmt_index_event(MGMT_EV_UNCONF_INDEX_REMOVED, hdev, NULL, 0,
@@ -9459,7 +9452,8 @@ void mgmt_power_on(struct hci_dev *hdev, int err)
 		hci_update_passive_scan(hdev);
 	}
 
-	mgmt_pending_foreach(MGMT_OP_SET_POWERED, hdev, settings_rsp, &match);
+	mgmt_pending_foreach(MGMT_OP_SET_POWERED, hdev, true, settings_rsp,
+			     &match);
 
 	new_settings(hdev, match.sk);
 
@@ -9474,7 +9468,8 @@ void __mgmt_power_off(struct hci_dev *hdev)
 	struct cmd_lookup match = { NULL, hdev };
 	u8 zero_cod[] = { 0, 0, 0 };
 
-	mgmt_pending_foreach(MGMT_OP_SET_POWERED, hdev, settings_rsp, &match);
+	mgmt_pending_foreach(MGMT_OP_SET_POWERED, hdev, true, settings_rsp,
+			     &match);
 
 	/* If the power off is because of hdev unregistration let
 	 * use the appropriate INVALID_INDEX status. Otherwise use
@@ -9488,7 +9483,7 @@ void __mgmt_power_off(struct hci_dev *hdev)
 	else
 		match.mgmt_status = MGMT_STATUS_NOT_POWERED;
 
-	mgmt_pending_foreach(0, hdev, cmd_complete_rsp, &match);
+	mgmt_pending_foreach(0, hdev, true, cmd_complete_rsp, &match);
 
 	if (memcmp(hdev->dev_class, zero_cod, sizeof(zero_cod)) != 0) {
 		mgmt_limited_event(MGMT_EV_CLASS_OF_DEV_CHANGED, hdev,
@@ -9726,7 +9721,6 @@ static void unpair_device_rsp(struct mgmt_pending_cmd *cmd, void *data)
 	device_unpaired(hdev, &cp->addr.bdaddr, cp->addr.type, cmd->sk);
 
 	cmd->cmd_complete(cmd, 0);
-	mgmt_pending_remove(cmd);
 }
 
 bool mgmt_powering_down(struct hci_dev *hdev)
@@ -9782,8 +9776,8 @@ void mgmt_disconnect_failed(struct hci_dev *hdev, bdaddr_t *bdaddr,
 	struct mgmt_cp_disconnect *cp;
 	struct mgmt_pending_cmd *cmd;
 
-	mgmt_pending_foreach(MGMT_OP_UNPAIR_DEVICE, hdev, unpair_device_rsp,
-			     hdev);
+	mgmt_pending_foreach(MGMT_OP_UNPAIR_DEVICE, hdev, true,
+			     unpair_device_rsp, hdev);
 
 	cmd = pending_find(MGMT_OP_DISCONNECT, hdev);
 	if (!cmd)
@@ -9976,7 +9970,7 @@ void mgmt_auth_enable_complete(struct hci_dev *hdev, u8 status)
 
 	if (status) {
 		u8 mgmt_err = mgmt_status(status);
-		mgmt_pending_foreach(MGMT_OP_SET_LINK_SECURITY, hdev,
+		mgmt_pending_foreach(MGMT_OP_SET_LINK_SECURITY, hdev, true,
 				     cmd_status_rsp, &mgmt_err);
 		return;
 	}
@@ -9986,8 +9980,8 @@ void mgmt_auth_enable_complete(struct hci_dev *hdev, u8 status)
 	else
 		changed = hci_dev_test_and_clear_flag(hdev, HCI_LINK_SECURITY);
 
-	mgmt_pending_foreach(MGMT_OP_SET_LINK_SECURITY, hdev, settings_rsp,
-			     &match);
+	mgmt_pending_foreach(MGMT_OP_SET_LINK_SECURITY, hdev, true,
+			     settings_rsp, &match);
 
 	if (changed)
 		new_settings(hdev, match.sk);
@@ -10011,9 +10005,12 @@ void mgmt_set_class_of_dev_complete(struct hci_dev *hdev, u8 *dev_class,
 {
 	struct cmd_lookup match = { NULL, hdev, mgmt_status(status) };
 
-	mgmt_pending_foreach(MGMT_OP_SET_DEV_CLASS, hdev, sk_lookup, &match);
-	mgmt_pending_foreach(MGMT_OP_ADD_UUID, hdev, sk_lookup, &match);
-	mgmt_pending_foreach(MGMT_OP_REMOVE_UUID, hdev, sk_lookup, &match);
+	mgmt_pending_foreach(MGMT_OP_SET_DEV_CLASS, hdev, false, sk_lookup,
+			     &match);
+	mgmt_pending_foreach(MGMT_OP_ADD_UUID, hdev, false, sk_lookup,
+			     &match);
+	mgmt_pending_foreach(MGMT_OP_REMOVE_UUID, hdev, false, sk_lookup,
+			     &match);
 
 	if (!status) {
 		mgmt_limited_event(MGMT_EV_CLASS_OF_DEV_CHANGED, hdev, dev_class,

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -2171,10 +2171,7 @@ static void set_mesh_complete(struct hci_dev *hdev, void *data, int err)
 	sk = cmd->sk;
 
 	if (status) {
-		mgmt_cmd_status(cmd->sk, hdev->id, MGMT_OP_SET_MESH_RECEIVER,
-				status);
-		mgmt_pending_foreach(MGMT_OP_SET_MESH_RECEIVER, hdev, true,
-				     cmd_status_rsp, &status);
+		mgmt_cmd_status(cmd->sk, hdev->id, cmd->opcode, status);
 		goto done;
 	}
 
@@ -5365,7 +5362,7 @@ static void mgmt_add_adv_patterns_monitor_complete(struct hci_dev *hdev,
 
 	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode,
 			  mgmt_status(status), &rp, sizeof(rp));
-	mgmt_pending_remove(cmd);
+	mgmt_pending_free(cmd);
 
 	hci_dev_unlock(hdev);
 	bt_dev_dbg(hdev, "add monitor %d complete, status %d",

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -5343,7 +5343,7 @@ static void mgmt_add_adv_patterns_monitor_complete(struct hci_dev *hdev,
 	 * hci_adv_monitors_clear is about to be called which will take care of
 	 * freeing the adv_monitor instances.
 	 */
-	if (status == -ECANCELED && !mgmt_pending_valid(hdev, cmd))
+	if (status == -ECANCELED || !mgmt_pending_valid(hdev, cmd))
 		return;
 
 	monitor = cmd->user_data;

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -1317,8 +1317,7 @@ static void mgmt_set_powered_complete(struct hci_dev *hdev, void *data, int err)
 	struct mgmt_mode *cp;
 
 	/* Make sure cmd still outstanding. */
-	if (err == -ECANCELED ||
-	    cmd != pending_find(MGMT_OP_SET_POWERED, hdev))
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, cmd))
 		return;
 
 	cp = cmd->param;
@@ -1345,23 +1344,29 @@ static void mgmt_set_powered_complete(struct hci_dev *hdev, void *data, int err)
 				mgmt_status(err));
 	}
 
-	mgmt_pending_remove(cmd);
+	mgmt_pending_free(cmd);
 }
 
 static int set_powered_sync(struct hci_dev *hdev, void *data)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct mgmt_mode *cp;
+	struct mgmt_mode cp;
+
+	mutex_lock(&hdev->mgmt_pending_lock);
 
 	/* Make sure cmd still outstanding. */
-	if (cmd != pending_find(MGMT_OP_SET_POWERED, hdev))
+	if (!__mgmt_pending_listed(hdev, cmd)) {
+		mutex_unlock(&hdev->mgmt_pending_lock);
 		return -ECANCELED;
+	}
 
-	cp = cmd->param;
+	memcpy(&cp, cmd->param, sizeof(cp));
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
 
 	BT_DBG("%s", hdev->name);
 
-	return hci_set_powered_sync(hdev, cp->val);
+	return hci_set_powered_sync(hdev, cp.val);
 }
 
 static int set_powered(struct sock *sk, struct hci_dev *hdev, void *data,
@@ -1510,8 +1515,7 @@ static void mgmt_set_discoverable_complete(struct hci_dev *hdev, void *data,
 	bt_dev_dbg(hdev, "err %d", err);
 
 	/* Make sure cmd still outstanding. */
-	if (err == -ECANCELED ||
-	    cmd != pending_find(MGMT_OP_SET_DISCOVERABLE, hdev))
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, cmd))
 		return;
 
 	hci_dev_lock(hdev);
@@ -1533,12 +1537,15 @@ static void mgmt_set_discoverable_complete(struct hci_dev *hdev, void *data,
 	new_settings(hdev, cmd->sk);
 
 done:
-	mgmt_pending_remove(cmd);
+	mgmt_pending_free(cmd);
 	hci_dev_unlock(hdev);
 }
 
 static int set_discoverable_sync(struct hci_dev *hdev, void *data)
 {
+	if (!mgmt_pending_listed(hdev, data))
+		return -ECANCELED;
+
 	BT_DBG("%s", hdev->name);
 
 	return hci_update_discoverable_sync(hdev);
@@ -1685,8 +1692,7 @@ static void mgmt_set_connectable_complete(struct hci_dev *hdev, void *data,
 	bt_dev_dbg(hdev, "err %d", err);
 
 	/* Make sure cmd still outstanding. */
-	if (err == -ECANCELED ||
-	    cmd != pending_find(MGMT_OP_SET_CONNECTABLE, hdev))
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, cmd))
 		return;
 
 	hci_dev_lock(hdev);
@@ -1701,7 +1707,7 @@ static void mgmt_set_connectable_complete(struct hci_dev *hdev, void *data,
 	new_settings(hdev, cmd->sk);
 
 done:
-	mgmt_pending_remove(cmd);
+	mgmt_pending_free(cmd);
 
 	hci_dev_unlock(hdev);
 }
@@ -1737,6 +1743,9 @@ static int set_connectable_update_settings(struct hci_dev *hdev,
 
 static int set_connectable_sync(struct hci_dev *hdev, void *data)
 {
+	if (!mgmt_pending_listed(hdev, data))
+		return -ECANCELED;
+
 	BT_DBG("%s", hdev->name);
 
 	return hci_update_connectable_sync(hdev);
@@ -1913,13 +1922,16 @@ static void set_ssp_complete(struct hci_dev *hdev, void *data, int err)
 {
 	struct cmd_lookup match = { NULL, hdev };
 	struct mgmt_pending_cmd *cmd = data;
-	struct mgmt_mode *cp = cmd->param;
-	u8 enable = cp->val;
+	struct mgmt_mode *cp;
+	u8 enable;
 	bool changed;
 
 	/* Make sure cmd still outstanding. */
-	if (err == -ECANCELED || cmd != pending_find(MGMT_OP_SET_SSP, hdev))
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, cmd))
 		return;
+
+	cp = cmd->param;
+	enable = cp->val;
 
 	if (err) {
 		u8 mgmt_err = mgmt_status(err);
@@ -1929,8 +1941,7 @@ static void set_ssp_complete(struct hci_dev *hdev, void *data, int err)
 			new_settings(hdev, NULL);
 		}
 
-		mgmt_pending_foreach(MGMT_OP_SET_SSP, hdev, true,
-				     cmd_status_rsp, &mgmt_err);
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_err);
 		return;
 	}
 
@@ -1940,7 +1951,7 @@ static void set_ssp_complete(struct hci_dev *hdev, void *data, int err)
 		changed = hci_dev_test_and_clear_flag(hdev, HCI_SSP_ENABLED);
 	}
 
-	mgmt_pending_foreach(MGMT_OP_SET_SSP, hdev, true, settings_rsp, &match);
+	settings_rsp(cmd, &match);
 
 	if (changed)
 		new_settings(hdev, match.sk);
@@ -1954,14 +1965,25 @@ static void set_ssp_complete(struct hci_dev *hdev, void *data, int err)
 static int set_ssp_sync(struct hci_dev *hdev, void *data)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct mgmt_mode *cp = cmd->param;
+	struct mgmt_mode cp;
 	bool changed = false;
 	int err;
 
-	if (cp->val)
+	mutex_lock(&hdev->mgmt_pending_lock);
+
+	if (!__mgmt_pending_listed(hdev, cmd)) {
+		mutex_unlock(&hdev->mgmt_pending_lock);
+		return -ECANCELED;
+	}
+
+	memcpy(&cp, cmd->param, sizeof(cp));
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
+
+	if (cp.val)
 		changed = !hci_dev_test_and_set_flag(hdev, HCI_SSP_ENABLED);
 
-	err = hci_write_ssp_mode_sync(hdev, cp->val);
+	err = hci_write_ssp_mode_sync(hdev, cp.val);
 
 	if (!err && changed)
 		hci_dev_clear_flag(hdev, HCI_SSP_ENABLED);
@@ -2054,31 +2076,49 @@ static int set_hs(struct sock *sk, struct hci_dev *hdev, void *data, u16 len)
 
 static void set_le_complete(struct hci_dev *hdev, void *data, int err)
 {
+	struct mgmt_pending_cmd *cmd = data;
 	struct cmd_lookup match = { NULL, hdev };
 	u8 status = mgmt_status(err);
 
 	bt_dev_dbg(hdev, "err %d", err);
 
-	if (status) {
-		mgmt_pending_foreach(MGMT_OP_SET_LE, hdev, true, cmd_status_rsp,
-				     &status);
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, data))
 		return;
+
+	if (status) {
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode, status);
+		goto done;
 	}
 
-	mgmt_pending_foreach(MGMT_OP_SET_LE, hdev, true, settings_rsp, &match);
+	settings_rsp(cmd, &match);
 
 	new_settings(hdev, match.sk);
 
 	if (match.sk)
 		sock_put(match.sk);
+
+done:
+	mgmt_pending_free(cmd);
 }
 
 static int set_le_sync(struct hci_dev *hdev, void *data)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct mgmt_mode *cp = cmd->param;
-	u8 val = !!cp->val;
+	struct mgmt_mode cp;
+	u8 val;
 	int err;
+
+	mutex_lock(&hdev->mgmt_pending_lock);
+
+	if (!__mgmt_pending_listed(hdev, cmd)) {
+		mutex_unlock(&hdev->mgmt_pending_lock);
+		return -ECANCELED;
+	}
+
+	memcpy(&cp, cmd->param, sizeof(cp));
+	val = !!cp.val;
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
 
 	if (!val) {
 		hci_clear_adv_instance_sync(hdev, NULL, 0x00, true);
@@ -2121,7 +2161,12 @@ static void set_mesh_complete(struct hci_dev *hdev, void *data, int err)
 {
 	struct mgmt_pending_cmd *cmd = data;
 	u8 status = mgmt_status(err);
-	struct sock *sk = cmd->sk;
+	struct sock *sk;
+
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, cmd))
+		return;
+
+	sk = cmd->sk;
 
 	if (status) {
 		mgmt_pending_foreach(MGMT_OP_SET_MESH_RECEIVER, hdev, true,
@@ -2136,24 +2181,37 @@ static void set_mesh_complete(struct hci_dev *hdev, void *data, int err)
 static int set_mesh_sync(struct hci_dev *hdev, void *data)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct mgmt_cp_set_mesh *cp = cmd->param;
-	size_t len = cmd->param_len;
+	struct mgmt_cp_set_mesh cp;
+	size_t len;
+
+	mutex_lock(&hdev->mgmt_pending_lock);
+
+	if (!__mgmt_pending_listed(hdev, cmd)) {
+		mutex_unlock(&hdev->mgmt_pending_lock);
+		return -ECANCELED;
+	}
+
+	memcpy(&cp, cmd->param, sizeof(cp));
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
+
+	len = cmd->param_len;
 
 	memset(hdev->mesh_ad_types, 0, sizeof(hdev->mesh_ad_types));
 
-	if (cp->enable)
+	if (cp.enable)
 		hci_dev_set_flag(hdev, HCI_MESH);
 	else
 		hci_dev_clear_flag(hdev, HCI_MESH);
 
-	hdev->le_scan_interval = __le16_to_cpu(cp->period);
-	hdev->le_scan_window = __le16_to_cpu(cp->window);
+	hdev->le_scan_interval = __le16_to_cpu(cp.period);
+	hdev->le_scan_window = __le16_to_cpu(cp.window);
 
-	len -= sizeof(*cp);
+	len -= sizeof(cp);
 
 	/* If filters don't fit, forward all adv pkts */
 	if (len <= sizeof(hdev->mesh_ad_types))
-		memcpy(hdev->mesh_ad_types, cp->ad_types, len);
+		memcpy(hdev->mesh_ad_types, cp.ad_types, len);
 
 	hci_update_passive_scan_sync(hdev);
 	return 0;
@@ -3800,14 +3858,15 @@ static int name_changed_sync(struct hci_dev *hdev, void *data)
 static void set_name_complete(struct hci_dev *hdev, void *data, int err)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct mgmt_cp_set_local_name *cp = cmd->param;
+	struct mgmt_cp_set_local_name *cp;
 	u8 status = mgmt_status(err);
 
 	bt_dev_dbg(hdev, "err %d", err);
 
-	if (err == -ECANCELED ||
-	    cmd != pending_find(MGMT_OP_SET_LOCAL_NAME, hdev))
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, cmd))
 		return;
+
+	cp = cmd->param;
 
 	if (status) {
 		mgmt_cmd_status(cmd->sk, hdev->id, MGMT_OP_SET_LOCAL_NAME,
@@ -3820,16 +3879,27 @@ static void set_name_complete(struct hci_dev *hdev, void *data, int err)
 			hci_cmd_sync_queue(hdev, name_changed_sync, NULL, NULL);
 	}
 
-	mgmt_pending_remove(cmd);
+	mgmt_pending_free(cmd);
 }
 
 static int set_name_sync(struct hci_dev *hdev, void *data)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct mgmt_cp_set_local_name *cp = cmd->param;
+	struct mgmt_cp_set_local_name cp;
+
+	mutex_lock(&hdev->mgmt_pending_lock);
+
+	if (!__mgmt_pending_listed(hdev, cmd)) {
+		mutex_unlock(&hdev->mgmt_pending_lock);
+		return -ECANCELED;
+	}
+
+	memcpy(&cp, cmd->param, sizeof(cp));
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
 
 	if (lmp_bredr_capable(hdev)) {
-		hci_update_name_sync(hdev, cp->name);
+		hci_update_name_sync(hdev, cp.name);
 		hci_update_eir_sync(hdev);
 	}
 
@@ -3981,12 +4051,10 @@ int mgmt_phy_configuration_changed(struct hci_dev *hdev, struct sock *skip)
 static void set_default_phy_complete(struct hci_dev *hdev, void *data, int err)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct sk_buff *skb = cmd->skb;
+	struct sk_buff *skb;
 	u8 status = mgmt_status(err);
 
-	if (err == -ECANCELED ||
-	    cmd != pending_find(MGMT_OP_SET_PHY_CONFIGURATION, hdev))
-		return;
+	skb = cmd->skb;
 
 	if (!status) {
 		if (!skb)
@@ -4013,7 +4081,7 @@ static void set_default_phy_complete(struct hci_dev *hdev, void *data, int err)
 	if (skb && !IS_ERR(skb))
 		kfree_skb(skb);
 
-	mgmt_pending_remove(cmd);
+	mgmt_pending_free(cmd);
 }
 
 static int set_default_phy_sync(struct hci_dev *hdev, void *data)
@@ -4021,7 +4089,9 @@ static int set_default_phy_sync(struct hci_dev *hdev, void *data)
 	struct mgmt_pending_cmd *cmd = data;
 	struct mgmt_cp_set_phy_configuration *cp = cmd->param;
 	struct hci_cp_le_set_default_phy cp_phy;
-	u32 selected_phys = __le32_to_cpu(cp->selected_phys);
+	u32 selected_phys;
+
+	selected_phys = __le32_to_cpu(cp->selected_phys);
 
 	memset(&cp_phy, 0, sizeof(cp_phy));
 
@@ -4161,7 +4231,7 @@ static int set_phy_configuration(struct sock *sk, struct hci_dev *hdev,
 		goto unlock;
 	}
 
-	cmd = mgmt_pending_add(sk, MGMT_OP_SET_PHY_CONFIGURATION, hdev, data,
+	cmd = mgmt_pending_new(sk, MGMT_OP_SET_PHY_CONFIGURATION, hdev, data,
 			       len);
 	if (!cmd)
 		err = -ENOMEM;
@@ -5263,7 +5333,17 @@ static void mgmt_add_adv_patterns_monitor_complete(struct hci_dev *hdev,
 {
 	struct mgmt_rp_add_adv_patterns_monitor rp;
 	struct mgmt_pending_cmd *cmd = data;
-	struct adv_monitor *monitor = cmd->user_data;
+	struct adv_monitor *monitor;
+
+	/* This is likely the result of hdev being closed and mgmt_index_removed
+	 * is attempting to clean up any pending command so
+	 * hci_adv_monitors_clear is about to be called which will take care of
+	 * freeing the adv_monitor instances.
+	 */
+	if (status == -ECANCELED && !mgmt_pending_valid(hdev, cmd))
+		return;
+
+	monitor = cmd->user_data;
 
 	hci_dev_lock(hdev);
 
@@ -5289,9 +5369,20 @@ static void mgmt_add_adv_patterns_monitor_complete(struct hci_dev *hdev,
 static int mgmt_add_adv_patterns_monitor_sync(struct hci_dev *hdev, void *data)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct adv_monitor *monitor = cmd->user_data;
+	struct adv_monitor *mon;
 
-	return hci_add_adv_monitor(hdev, monitor);
+	mutex_lock(&hdev->mgmt_pending_lock);
+
+	if (!__mgmt_pending_listed(hdev, cmd)) {
+		mutex_unlock(&hdev->mgmt_pending_lock);
+		return -ECANCELED;
+	}
+
+	mon = cmd->user_data;
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
+
+	return hci_add_adv_monitor(hdev, mon);
 }
 
 static int __add_adv_patterns_monitor(struct sock *sk, struct hci_dev *hdev,
@@ -5553,7 +5644,8 @@ unlock:
 			       status);
 }
 
-static void read_local_oob_data_complete(struct hci_dev *hdev, void *data, int err)
+static void read_local_oob_data_complete(struct hci_dev *hdev, void *data,
+					 int err)
 {
 	struct mgmt_rp_read_local_oob_data mgmt_rp;
 	size_t rp_size = sizeof(mgmt_rp);
@@ -5573,7 +5665,8 @@ static void read_local_oob_data_complete(struct hci_dev *hdev, void *data, int e
 	bt_dev_dbg(hdev, "status %d", status);
 
 	if (status) {
-		mgmt_cmd_status(cmd->sk, hdev->id, MGMT_OP_READ_LOCAL_OOB_DATA, status);
+		mgmt_cmd_status(cmd->sk, hdev->id, MGMT_OP_READ_LOCAL_OOB_DATA,
+				status);
 		goto remove;
 	}
 
@@ -5878,17 +5971,12 @@ static void start_discovery_complete(struct hci_dev *hdev, void *data, int err)
 
 	bt_dev_dbg(hdev, "err %d", err);
 
-	if (err == -ECANCELED)
-		return;
-
-	if (cmd != pending_find(MGMT_OP_START_DISCOVERY, hdev) &&
-	    cmd != pending_find(MGMT_OP_START_LIMITED_DISCOVERY, hdev) &&
-	    cmd != pending_find(MGMT_OP_START_SERVICE_DISCOVERY, hdev))
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, cmd))
 		return;
 
 	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_status(err),
 			  cmd->param, 1);
-	mgmt_pending_remove(cmd);
+	mgmt_pending_free(cmd);
 
 	hci_discovery_set_state(hdev, err ? DISCOVERY_STOPPED:
 				DISCOVERY_FINDING);
@@ -5896,6 +5984,9 @@ static void start_discovery_complete(struct hci_dev *hdev, void *data, int err)
 
 static int start_discovery_sync(struct hci_dev *hdev, void *data)
 {
+	if (!mgmt_pending_listed(hdev, data))
+		return -ECANCELED;
+
 	return hci_start_discovery_sync(hdev);
 }
 
@@ -6118,15 +6209,14 @@ static void stop_discovery_complete(struct hci_dev *hdev, void *data, int err)
 {
 	struct mgmt_pending_cmd *cmd = data;
 
-	if (err == -ECANCELED ||
-	    cmd != pending_find(MGMT_OP_STOP_DISCOVERY, hdev))
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, cmd))
 		return;
 
 	bt_dev_dbg(hdev, "err %d", err);
 
 	mgmt_cmd_complete(cmd->sk, cmd->hdev->id, cmd->opcode, mgmt_status(err),
 			  cmd->param, 1);
-	mgmt_pending_remove(cmd);
+	mgmt_pending_free(cmd);
 
 	if (!err)
 		hci_discovery_set_state(hdev, DISCOVERY_STOPPED);
@@ -6134,6 +6224,9 @@ static void stop_discovery_complete(struct hci_dev *hdev, void *data, int err)
 
 static int stop_discovery_sync(struct hci_dev *hdev, void *data)
 {
+	if (!mgmt_pending_listed(hdev, data))
+		return -ECANCELED;
+
 	return hci_stop_discovery_sync(hdev);
 }
 
@@ -6343,14 +6436,18 @@ static void enable_advertising_instance(struct hci_dev *hdev, int err)
 
 static void set_advertising_complete(struct hci_dev *hdev, void *data, int err)
 {
+	struct mgmt_pending_cmd *cmd = data;
 	struct cmd_lookup match = { NULL, hdev };
 	u8 instance;
 	struct adv_info *adv_instance;
 	u8 status = mgmt_status(err);
 
+	if (err == -ECANCELED || !mgmt_pending_valid(hdev, data))
+		return;
+
 	if (status) {
-		mgmt_pending_foreach(MGMT_OP_SET_ADVERTISING, hdev, true,
-				     cmd_status_rsp, &status);
+		mgmt_cmd_status(cmd->sk, cmd->hdev->id, cmd->opcode, status);
+		mgmt_pending_free(cmd);
 		return;
 	}
 
@@ -6359,8 +6456,7 @@ static void set_advertising_complete(struct hci_dev *hdev, void *data, int err)
 	else
 		hci_dev_clear_flag(hdev, HCI_ADVERTISING);
 
-	mgmt_pending_foreach(MGMT_OP_SET_ADVERTISING, hdev, true, settings_rsp,
-			     &match);
+	settings_rsp(cmd, &match);
 
 	new_settings(hdev, match.sk);
 
@@ -6392,10 +6488,23 @@ static void set_advertising_complete(struct hci_dev *hdev, void *data, int err)
 static int set_adv_sync(struct hci_dev *hdev, void *data)
 {
 	struct mgmt_pending_cmd *cmd = data;
-	struct mgmt_mode *cp = cmd->param;
-	u8 val = !!cp->val;
+	struct mgmt_mode cp;
+	u8 val;
 
-	if (cp->val == 0x02)
+	mutex_lock(&hdev->mgmt_pending_lock);
+
+	if (!__mgmt_pending_listed(hdev, cmd)) {
+		mutex_unlock(&hdev->mgmt_pending_lock);
+		return -ECANCELED;
+	}
+
+	memcpy(&cp, cmd->param, sizeof(cp));
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
+
+	val = !!cp.val;
+
+	if (cp.val == 0x02)
 		hci_dev_set_flag(hdev, HCI_ADVERTISING_CONNECTABLE);
 	else
 		hci_dev_clear_flag(hdev, HCI_ADVERTISING_CONNECTABLE);
@@ -8112,10 +8221,6 @@ static void read_local_oob_ext_data_complete(struct hci_dev *hdev, void *data,
 	u8 status = mgmt_status(err);
 	u16 eir_len;
 
-	if (err == -ECANCELED ||
-	    cmd != pending_find(MGMT_OP_READ_LOCAL_OOB_EXT_DATA, hdev))
-		return;
-
 	if (!status) {
 		if (!skb)
 			status = MGMT_STATUS_FAILED;
@@ -8222,7 +8327,7 @@ done:
 		kfree_skb(skb);
 
 	kfree(mgmt_rp);
-	mgmt_pending_remove(cmd);
+	mgmt_pending_free(cmd);
 }
 
 static int read_local_ssp_oob_req(struct hci_dev *hdev, struct sock *sk,
@@ -8231,7 +8336,7 @@ static int read_local_ssp_oob_req(struct hci_dev *hdev, struct sock *sk,
 	struct mgmt_pending_cmd *cmd;
 	int err;
 
-	cmd = mgmt_pending_add(sk, MGMT_OP_READ_LOCAL_OOB_EXT_DATA, hdev,
+	cmd = mgmt_pending_new(sk, MGMT_OP_READ_LOCAL_OOB_EXT_DATA, hdev,
 			       cp, sizeof(*cp));
 	if (!cmd)
 		return -ENOMEM;

--- a/net/bluetooth/mgmt_util.c
+++ b/net/bluetooth/mgmt_util.c
@@ -217,14 +217,21 @@ int mgmt_cmd_complete(struct sock *sk, u16 index, u16 cmd, u8 status,
 struct mgmt_pending_cmd *mgmt_pending_find(unsigned short channel, u16 opcode,
 					   struct hci_dev *hdev)
 {
-	struct mgmt_pending_cmd *cmd;
+	struct mgmt_pending_cmd *cmd, *tmp;
 
-	list_for_each_entry(cmd, &hdev->mgmt_pending, list) {
+	mutex_lock(&hdev->mgmt_pending_lock);
+
+	list_for_each_entry_safe(cmd, tmp, &hdev->mgmt_pending, list) {
 		if (hci_sock_get_channel(cmd->sk) != channel)
 			continue;
-		if (cmd->opcode == opcode)
+
+		if (cmd->opcode == opcode) {
+			mutex_unlock(&hdev->mgmt_pending_lock);
 			return cmd;
+		}
 	}
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
 
 	return NULL;
 }
@@ -246,18 +253,28 @@ struct mgmt_pending_cmd *mgmt_pending_find_data(unsigned short channel,
 	return NULL;
 }
 
-void mgmt_pending_foreach(u16 opcode, struct hci_dev *hdev,
+void mgmt_pending_foreach(u16 opcode, struct hci_dev *hdev, bool remove,
 			  void (*cb)(struct mgmt_pending_cmd *cmd, void *data),
 			  void *data)
 {
 	struct mgmt_pending_cmd *cmd, *tmp;
 
+	mutex_lock(&hdev->mgmt_pending_lock);
+
 	list_for_each_entry_safe(cmd, tmp, &hdev->mgmt_pending, list) {
 		if (opcode > 0 && cmd->opcode != opcode)
 			continue;
 
+		if (remove)
+			list_del(&cmd->list);
+
 		cb(cmd, data);
+
+		if (remove)
+			mgmt_pending_free(cmd);
 	}
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
 }
 
 struct mgmt_pending_cmd *mgmt_pending_new(struct sock *sk, u16 opcode,
@@ -271,7 +288,7 @@ struct mgmt_pending_cmd *mgmt_pending_new(struct sock *sk, u16 opcode,
 		return NULL;
 
 	cmd->opcode = opcode;
-	cmd->index = hdev->id;
+	cmd->hdev = hdev;
 
 	cmd->param = kmemdup(data, len, GFP_KERNEL);
 	if (!cmd->param) {
@@ -297,7 +314,9 @@ struct mgmt_pending_cmd *mgmt_pending_add(struct sock *sk, u16 opcode,
 	if (!cmd)
 		return NULL;
 
+	mutex_lock(&hdev->mgmt_pending_lock);
 	list_add_tail(&cmd->list, &hdev->mgmt_pending);
+	mutex_unlock(&hdev->mgmt_pending_lock);
 
 	return cmd;
 }
@@ -311,7 +330,10 @@ void mgmt_pending_free(struct mgmt_pending_cmd *cmd)
 
 void mgmt_pending_remove(struct mgmt_pending_cmd *cmd)
 {
+	mutex_lock(&cmd->hdev->mgmt_pending_lock);
 	list_del(&cmd->list);
+	mutex_unlock(&cmd->hdev->mgmt_pending_lock);
+
 	mgmt_pending_free(cmd);
 }
 

--- a/net/bluetooth/mgmt_util.c
+++ b/net/bluetooth/mgmt_util.c
@@ -337,6 +337,52 @@ void mgmt_pending_remove(struct mgmt_pending_cmd *cmd)
 	mgmt_pending_free(cmd);
 }
 
+bool __mgmt_pending_listed(struct hci_dev *hdev, struct mgmt_pending_cmd *cmd)
+{
+	struct mgmt_pending_cmd *tmp;
+
+	lockdep_assert_held(&hdev->mgmt_pending_lock);
+
+	if (!cmd)
+		return false;
+
+	list_for_each_entry(tmp, &hdev->mgmt_pending, list) {
+		if (cmd == tmp)
+			return true;
+	}
+
+	return false;
+}
+
+bool mgmt_pending_listed(struct hci_dev *hdev, struct mgmt_pending_cmd *cmd)
+{
+	bool listed;
+
+	mutex_lock(&hdev->mgmt_pending_lock);
+	listed = __mgmt_pending_listed(hdev, cmd);
+	mutex_unlock(&hdev->mgmt_pending_lock);
+
+	return listed;
+}
+
+bool mgmt_pending_valid(struct hci_dev *hdev, struct mgmt_pending_cmd *cmd)
+{
+	bool listed;
+
+	if (!cmd)
+		return false;
+
+	mutex_lock(&hdev->mgmt_pending_lock);
+
+	listed = __mgmt_pending_listed(hdev, cmd);
+	if (listed)
+		list_del(&cmd->list);
+
+	mutex_unlock(&hdev->mgmt_pending_lock);
+
+	return listed;
+}
+
 void mgmt_mesh_foreach(struct hci_dev *hdev,
 		       void (*cb)(struct mgmt_mesh_tx *mesh_tx, void *data),
 		       void *data, struct sock *sk)

--- a/net/bluetooth/mgmt_util.h
+++ b/net/bluetooth/mgmt_util.h
@@ -33,7 +33,7 @@ struct mgmt_mesh_tx {
 struct mgmt_pending_cmd {
 	struct list_head list;
 	u16 opcode;
-	int index;
+	struct hci_dev *hdev;
 	void *param;
 	size_t param_len;
 	struct sock *sk;
@@ -58,7 +58,7 @@ struct mgmt_pending_cmd *mgmt_pending_find_data(unsigned short channel,
 						u16 opcode,
 						struct hci_dev *hdev,
 						const void *data);
-void mgmt_pending_foreach(u16 opcode, struct hci_dev *hdev,
+void mgmt_pending_foreach(u16 opcode, struct hci_dev *hdev, bool remove,
 			  void (*cb)(struct mgmt_pending_cmd *cmd, void *data),
 			  void *data);
 struct mgmt_pending_cmd *mgmt_pending_add(struct sock *sk, u16 opcode,

--- a/net/bluetooth/mgmt_util.h
+++ b/net/bluetooth/mgmt_util.h
@@ -69,6 +69,9 @@ struct mgmt_pending_cmd *mgmt_pending_new(struct sock *sk, u16 opcode,
 					  void *data, u16 len);
 void mgmt_pending_free(struct mgmt_pending_cmd *cmd);
 void mgmt_pending_remove(struct mgmt_pending_cmd *cmd);
+bool __mgmt_pending_listed(struct hci_dev *hdev, struct mgmt_pending_cmd *cmd);
+bool mgmt_pending_listed(struct hci_dev *hdev, struct mgmt_pending_cmd *cmd);
+bool mgmt_pending_valid(struct hci_dev *hdev, struct mgmt_pending_cmd *cmd);
 void mgmt_mesh_foreach(struct hci_dev *hdev,
 		       void (*cb)(struct mgmt_mesh_tx *mesh_tx, void *data),
 		       void *data, struct sock *sk);


### PR DESCRIPTION
[LTS 9.6]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2025-39981</td>
<td class="org-left">VULN-161958</td>
</tr>


<tr>
<td class="org-left">CVE-2025-38117</td>
<td class="org-left">VULN-162978</td>
</tr>


<tr>
<td class="org-left">CVE-2025-40213</td>
<td class="org-left">VULN-181745</td>
</tr>


<tr>
<td class="org-left">CVE-2025-68305</td>
<td class="org-left">VULN-170111</td>
</tr>


<tr>
<td class="org-left">CVE-2026-23151</td>
<td class="org-left">VULN-176260</td>
</tr>


<tr>
<td class="org-left">CVE-2026-31511</td>
<td class="org-left">VULN-182134</td>
</tr>
</tbody>
</table>


# Solution


## Overview

All CVEs in the bunch are related to the bluetooth module. The driving CVE was CVE-2025-39981. Its fixing commit `Bluetooth: MGMT: Fix possible UAFs` required 3 additional prerequisites, one of which - `Bluetooth: MGMT: Protect mgmt_pending list with its own lock` - happened to also be the fix for CVE-2025-38117. They both introduced 4 new CVEs: CVE-2025-40213, CVE-2025-68305, CVE-2026-23151, CVE-2026-31511, which were fixed in the included bugfixes. For details refer to [Commits relations](#org11649d0)


## Commits

(From the most recent)

    Bluetooth: MGMT: Fix dangling pointer on mgmt_add_adv_patterns_monitor_complete
    
    jira VULN-182134
    cve CVE-2026-31511
    commit-author Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
    commit 5f5fa4cd35f707344f65ce9e225b6528691dbbaa

>

    Bluetooth: MGMT: Fix list corruption and UAF in command complete handlers
    
    jira VULN-161958
    cve-bf CVE-2025-39981
    commit-author Wang Tao <wangtao554@huawei.com>
    commit 17f89341cb4281d1da0e2fb0de5406ab7c4e25ef

>

    Bluetooth: MGMT: Fix memory leak in set_ssp_complete
    
    jira VULN-176260
    cve CVE-2026-23151
    commit-author Jianpeng Chang <jianpeng.chang.cn@windriver.com>
    commit 1b9c17fd0a7fdcbe69ec5d6fe8e50bc5ed7f01f2
    commit 4db19bfd320f2124c820d3456aeae3953095ea8e

Note that 1b9c17fd0a7fdcbe69ec5d6fe8e50bc5ed7f01f2 and 4db19bfd320f2124c820d3456aeae3953095ea8e are the same change (message + diff) under two distinct commits, somehow both contained in the history of `kernel-mainline` (see `git branch kernel-mainline --contains …`). This may lead to confusion, for example 1b9c17fd0a7fdcbe69ec5d6fe8e50bc5ed7f01f2 [is associated](https://kernel.dance/#1b9c17fd0a7fdcbe69ec5d6fe8e50bc5ed7f01f2) with CVE-2026-23151 while 4db19bfd320f2124c820d3456aeae3953095ea8e [is not](https://kernel.dance/#4db19bfd320f2124c820d3456aeae3953095ea8e). Sometimes it's 1b9c17fd0a7fdcbe69ec5d6fe8e50bc5ed7f01f2 which is listed on files history

    git log --oneline -- net/bluetooth/mgmt.c

and sometimes it's 4db19bfd320f2124c820d3456aeae3953095ea8e:

    git log --oneline -- net/bluetooth/hci_core.c net/bluetooth/mgmt.c

Included both commits in the meta-data to make sure that the `ciqlts9_6` backport can be found no matter which hash was used to search for it.

    Bluetooth: hci_sock: Prevent race in socket write iter and sock bind
    
    jira VULN-170111
    cve CVE-2025-68305
    commit-author Edward Adam Davis <eadavis@qq.com>
    commit 89bb613511cc21ed5ba6bddc1c9b9ae9c0dad392

>

    Bluetooth: MGMT: fix crash in set_mesh_sync and set_mesh_complete
    
    jira VULN-181745
    cve CVE-2025-40213
    commit-author Pauli Virtanen <pav@iki.fi>
    commit e8785404de06a69d89dcdd1e9a0b6ea42dc6d327

>

    Bluetooth: MGMT: Fix possible UAFs
    
    jira VULN-161958
    cve CVE-2025-39981
    commit-author Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
    commit 302a1f674c00dd5581ab8e493ef44767c5101aab

>

    Bluetooth: hci_sync: fix set_local_name race condition
    
    jira VULN-161958
    cve-pre CVE-2025-39981
    commit-author Pavel Shpakovskiy <pashpakovskii@salutedevices.com>
    commit 6bbd0d3f0c23fc53c17409dd7476f38ae0ff0cd9

>

    Bluetooth: MGMT: set_mesh: update LE scan interval and window
    
    jira VULN-161958
    cve-pre CVE-2025-39981
    commit-author Christian Eggers <ceggers@arri.de>
    commit e5af67a870f738bb8a4594b6c60c2caf4c87a3c9

>

    Bluetooth: MGMT: Protect mgmt_pending list with its own lock
    
    jira VULN-162978
    cve CVE-2025-38117
    commit-author Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
    commit 6fe26f694c824b8a4dbf50c635bee1302e3f099c
    upstream-diff Context conflict resolution due to missing backport of
      276af34d82f13bda0b2a4d9786c90b8bbf1cd064 ("Bluetooth: MGMT: Remove
      unused mgmt_pending_find_data")


<a id="org11649d0"></a>

## Commits relations

The PR includes multiple CVEs and bugfixes which often overlap. To see the inner structure more clearly consult the following table ("Fixes" and "Fixed By" sets reduced to only those commits which are in the PR, `(F)` - fixing a CVE, `(I)` - introducing a CVE):

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Upstream</th>
<th scope="col" class="org-left">Subject</th>
<th scope="col" class="org-left">Fixes</th>
<th scope="col" class="org-left">Fixed By</th>
<th scope="col" class="org-left">Cves</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">5f5fa4cd35f</td>
<td class="org-left">`Bluetooth: MGMT: Fix dangling pointer on mgmt_add_adv_patterns_monitor_complete`</td>
<td class="org-left">302a1f674c0</td>
<td class="org-left">-</td>
<td class="org-left">CVE-2026-31511(F)</td>
</tr>
</tbody>

<tbody>
<tr>
<td class="org-left">17f89341cb4</td>
<td class="org-left">`Bluetooth: MGMT: Fix list corruption and UAF in command complete handlers`</td>
<td class="org-left">302a1f674c0</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>
</tbody>

<tbody>
<tr>
<td class="org-left">1b9c17fd0a7</td>
<td class="org-left">`Bluetooth: MGMT: Fix memory leak in set_ssp_complete`</td>
<td class="org-left">302a1f674c0</td>
<td class="org-left">-</td>
<td class="org-left">CVE-2026-23151(F)</td>
</tr>
</tbody>

<tbody>
<tr>
<td class="org-left">89bb613511c</td>
<td class="org-left">`Bluetooth: hci_sock: Prevent race in socket write iter and sock bind`</td>
<td class="org-left">6fe26f694c8</td>
<td class="org-left">-</td>
<td class="org-left">CVE-2025-68305(F)</td>
</tr>
</tbody>

<tbody>
<tr>
<td class="org-left">e8785404de0</td>
<td class="org-left">`Bluetooth: MGMT: fix crash in set_mesh_sync and set_mesh_complete`</td>
<td class="org-left">302a1f674c0</td>
<td class="org-left">-</td>
<td class="org-left">CVE-2025-40213(F)</td>
</tr>
</tbody>

<tbody>
<tr>
<td class="org-left">302a1f674c0</td>
<td class="org-left">`Bluetooth: MGMT: Fix possible UAFs`</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">5f5fa4cd35f 17f89341cb4 1b9c17fd0a7 e8785404de0</td>
<td class="org-left">CVE-2025-39981(F) CVE-2025-40213(I) CVE-2026-23151(I) CVE-2026-31511(I)</td>
</tr>
</tbody>

<tbody>
<tr>
<td class="org-left">6bbd0d3f0c2</td>
<td class="org-left">`Bluetooth: hci_sync: fix set_local_name race condition`</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>
</tbody>

<tbody>
<tr>
<td class="org-left">e5af67a870f</td>
<td class="org-left">`Bluetooth: MGMT: set_mesh: update LE scan interval and window`</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>
</tbody>

<tbody>
<tr>
<td class="org-left">6fe26f694c8</td>
<td class="org-left">`Bluetooth: MGMT: Protect mgmt_pending list with its own lock`</td>
<td class="org-left">-</td>
<td class="org-left">89bb613511c</td>
<td class="org-left">CVE-2025-38117(F) CVE-2025-68305(I)</td>
</tr>
</tbody>
</table>


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts9_6-CVE-batch-28]	_kabi_check_kernel__x86_64--test--ciqlts9_6-CVE-batch-28
    + dist_git_version=el-9.6
    + local_version=ciqlts9_6-CVE-batch-28
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts9_6
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-9.6
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts9_6-CVE-batch-28
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-9.6/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts9_6 ''\''/mnt/code/kernel-dist-git-el-9.6/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-9.6/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts9_6-CVE-batch-28/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts9_6-CVE-batch-28/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/27022293/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_6&#x2013;run1.log](<https://github.com/user-attachments/files/27022294/kselftests--ciqlts9_6--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_6-CVE-batch-28&#x2013;run1.log](<https://github.com/user-attachments/files/27022297/kselftests--ciqlts9_6-CVE-batch-28--run1.log>)
[kselftests&#x2013;ciqlts9\_6-CVE-batch-28&#x2013;run2.log](<https://github.com/user-attachments/files/27022298/kselftests--ciqlts9_6-CVE-batch-28--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff  kselftests*.log

    Column    File
    --------  --------------------------------------------
    Status0   kselftests--ciqlts9_6--run1.log
    Status1   kselftests--ciqlts9_6-CVE-batch-28--run1.log
    Status2   kselftests--ciqlts9_6-CVE-batch-28--run2.log
    
    TestCase                                               Status0  Status1  Status2  Summary
    bpf:test_cgroup_storage                                pass     pass     pass     same
    bpf:test_lru_map                                       pass     pass     pass     same
    bpf:test_sock                                          pass     pass     pass     same
    bpf:test_sysctl                                        pass     pass     pass     same
    bpf:test_tag                                           pass     pass     pass     same
    bpf:test_tcpnotify_user                                fail     fail     fail     same
    bpf:test_verifier                                      fail     fail     fail     same
    breakpoints:breakpoint_test                            pass     pass     pass     same
    capabilities:test_execve                               pass     pass     pass     same
    clone3:clone3                                          pass     pass     pass     same
    clone3:clone3_cap_checkpoint_restore                   pass     pass     pass     same
    clone3:clone3_clear_sighand                            pass     pass     pass     same
    clone3:clone3_set_tid                                  pass     pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh                         pass     pass     pass     same
    cpufreq:main.sh                                        fail     fail     fail     same
    drivers/dma-buf:udmabuf                                pass     pass     pass     same
    drivers/net/bonding:bond-arp-interval-causes-panic.sh  pass     pass     pass     same
    drivers/net/bonding:bond-break-lacpdu-tx.sh            fail     fail     fail     same
    drivers/net/bonding:bond-eth-type-change.sh            pass     pass     pass     same
    drivers/net/bonding:bond-lladdr-target.sh              pass     pass     pass     same
    drivers/net/bonding:bond_options.sh                    fail     fail     fail     same
    drivers/net/bonding:dev_addr_lists.sh                  pass     pass     pass     same
    drivers/net/bonding:mode-1-recovery-updelay.sh         pass     pass     pass     same
    drivers/net/bonding:mode-2-recovery-updelay.sh         pass     pass     pass     same
    drivers/net/team:dev_addr_lists.sh                     pass     pass     pass     same
    exec:binfmt_script                                     pass     pass     pass     same
    exec:execveat                                          pass     pass     pass     same
    exec:load_address_16777216                             fail     fail     fail     same
    exec:load_address_2097152                              pass     pass     pass     same
    exec:load_address_4096                                 pass     pass     pass     same
    exec:non-regular                                       fail     fail     fail     same
    exec:recursion-depth                                   pass     pass     pass     same
    filesystems/binderfs:binderfs_test                     fail     fail     fail     same
    filesystems/epoll:epoll_wakeup_test                    pass     pass     pass     same
    firmware:fw_run_tests.sh                               skip     skip     skip     same
    fpu:run_test_fpu.sh                                    skip     skip     skip     same
    fpu:test_fpu                                           pass     pass     pass     same
    ftrace:ftracetest                                      pass     pass     pass     same
    futex:run.sh                                           pass     pass     pass     same
    gpio:gpio-mockup.sh                                    fail     fail     fail     same
    intel_pstate:run.sh                                    pass     pass     pass     same
    iommu:iommufd                                          fail     fail     fail     same
    iommu:iommufd_fail_nth                                 pass     pass     pass     same
    ipc:msgque                                             pass     pass     pass     same
    ir:ir_loopback.sh                                      skip     skip     skip     same
    kcmp:kcmp_test                                         pass     pass     pass     same
    kexec:test_kexec_file_load.sh                          skip     skip     skip     same
    kexec:test_kexec_load.sh                               skip     skip     skip     same
    kvm:access_tracking_perf_test                          pass     pass     pass     same
    kvm:amx_test                                           fail     fail     fail     same
    kvm:cpuid_test                                         fail     fail     fail     same
    kvm:cr4_cpuid_sync_test                                fail     fail     fail     same
    kvm:debug_regs                                         fail     fail     fail     same
    kvm:demand_paging_test                                 pass     pass     pass     same
    kvm:dirty_log_page_splitting_test                      fail     fail     fail     same
    kvm:dirty_log_perf_test                                pass     pass     pass     same
    kvm:dirty_log_test                                     fail     fail     fail     same
    kvm:exit_on_emulation_failure_test                     fail     fail     fail     same
    kvm:fix_hypercall_test                                 fail     fail     fail     same
    kvm:get_msr_index_features                             fail     fail     fail     same
    kvm:guest_memfd_test                                   pass     pass     pass     same
    kvm:guest_print_test                                   pass     pass     pass     same
    kvm:hardware_disable_test                              pass     pass     pass     same
    kvm:hyperv_clock                                       fail     fail     fail     same
    kvm:hyperv_cpuid                                       fail     fail     fail     same
    kvm:hyperv_evmcs                                       fail     fail     fail     same
    kvm:hyperv_extended_hypercalls                         fail     fail     fail     same
    kvm:hyperv_features                                    fail     fail     fail     same
    kvm:hyperv_ipi                                         fail     fail     fail     same
    kvm:hyperv_svm_test                                    fail     fail     fail     same
    kvm:hyperv_tlb_flush                                   fail     fail     fail     same
    kvm:kvm_binary_stats_test                              pass     pass     pass     same
    kvm:kvm_clock_test                                     fail     fail     fail     same
    kvm:kvm_create_max_vcpus                               pass     pass     pass     same
    kvm:kvm_page_table_test                                pass     pass     pass     same
    kvm:kvm_pv_test                                        fail     fail     fail     same
    kvm:max_guest_memory_test                              pass     pass     pass     same
    kvm:max_vcpuid_cap_test                                fail     fail     fail     same
    kvm:memslot_modification_stress_test                   pass     pass     pass     same
    kvm:memslot_perf_test                                  pass     pass     pass     same
    kvm:mmio_warning_test                                  fail     fail     fail     same
    kvm:monitor_mwait_test                                 fail     fail     fail     same
    kvm:nested_exceptions_test                             fail     fail     fail     same
    kvm:nx_huge_pages_test.sh                              fail     fail     fail     same
    kvm:platform_info_test                                 fail     fail     fail     same
    kvm:pmu_event_filter_test                              fail     fail     fail     same
    kvm:private_mem_conversions_test                       fail     fail     fail     same
    kvm:private_mem_kvm_exits_test                         fail     fail     fail     same
    kvm:recalc_apic_map_test                               fail     fail     fail     same
    kvm:rseq_test                                          fail     fail     fail     same
    kvm:set_boot_cpu_id                                    fail     fail     fail     same
    kvm:set_memory_region_test                             pass     pass     pass     same
    kvm:set_sregs_test                                     fail     fail     fail     same
    kvm:sev_migrate_tests                                  fail     fail     fail     same
    kvm:smaller_maxphyaddr_emulation_test                  fail     fail     fail     same
    kvm:smm_test                                           fail     fail     fail     same
    kvm:state_test                                         fail     fail     fail     same
    kvm:steal_time                                         pass     pass     pass     same
    kvm:svm_int_ctl_test                                   fail     fail     fail     same
    kvm:svm_nested_shutdown_test                           fail     fail     fail     same
    kvm:svm_nested_soft_inject_test                        fail     fail     fail     same
    kvm:svm_vmcall_test                                    fail     fail     fail     same
    kvm:sync_regs_test                                     fail     fail     fail     same
    kvm:system_counter_offset_test                         pass     pass     pass     same
    kvm:triple_fault_event_test                            fail     fail     fail     same
    kvm:tsc_msrs_test                                      fail     fail     fail     same
    kvm:tsc_scaling_sync                                   fail     fail     fail     same
    kvm:ucna_injection_test                                fail     fail     fail     same
    kvm:userspace_io_test                                  fail     fail     fail     same
    kvm:userspace_msr_exit_test                            fail     fail     fail     same
    kvm:vmx_apic_access_test                               fail     fail     fail     same
    kvm:vmx_close_while_nested_test                        fail     fail     fail     same
    kvm:vmx_dirty_log_test                                 fail     fail     fail     same
    kvm:vmx_exception_with_invalid_guest_state             fail     fail     fail     same
    kvm:vmx_invalid_nested_guest_state                     fail     fail     fail     same
    kvm:vmx_msrs_test                                      fail     fail     fail     same
    kvm:vmx_nested_tsc_scaling_test                        fail     fail     fail     same
    kvm:vmx_pmu_caps_test                                  fail     fail     fail     same
    kvm:vmx_preemption_timer_test                          fail     fail     fail     same
    kvm:vmx_set_nested_state_test                          fail     fail     fail     same
    kvm:vmx_tsc_adjust_test                                fail     fail     fail     same
    kvm:xapic_ipi_test                                     fail     fail     fail     same
    kvm:xapic_state_test                                   fail     fail     fail     same
    kvm:xcr0_cpuid_test                                    fail     fail     fail     same
    kvm:xen_shinfo_test                                    fail     fail     fail     same
    kvm:xen_vmcall_test                                    fail     fail     fail     same
    kvm:xss_msr_test                                       fail     fail     fail     same
    landlock:base_test                                     fail     fail     fail     same
    landlock:fs_test                                       fail     fail     fail     same
    landlock:ptrace_test                                   pass     pass     pass     same
    lib:bitmap.sh                                          skip     skip     skip     same
    lib:prime_numbers.sh                                   pass     pass     pass     same
    lib:printf.sh                                          skip     skip     skip     same
    lib:scanf.sh                                           skip     skip     skip     same
    lib:strscpy.sh                                         skip     skip     skip     same
    livepatch:test-callbacks.sh                            pass     pass     pass     same
    livepatch:test-ftrace.sh                               pass     pass     pass     same
    livepatch:test-livepatch.sh                            pass     pass     pass     same
    livepatch:test-shadow-vars.sh                          pass     pass     pass     same
    livepatch:test-state.sh                                pass     pass     pass     same
    livepatch:test-sysfs.sh                                pass     pass     pass     same
    membarrier:membarrier_test_multi_thread                pass     pass     pass     same
    membarrier:membarrier_test_single_thread               pass     pass     pass     same
    memfd:memfd_test                                       pass     pass     pass     same
    memfd:run_fuse_test.sh                                 pass     pass     pass     same
    memfd:run_hugetlbfs_test.sh                            pass     pass     pass     same
    memory-hotplug:mem-on-off-test.sh                      pass     pass     pass     same
    mincore:mincore_selftest                               fail     fail     fail     same
    mount:run_nosymfollow.sh                               pass     pass     pass     same
    mount:run_unprivileged_remount.sh                      pass     pass     pass     same
    mqueue:mq_open_tests                                   pass     pass     pass     same
    mqueue:mq_perf_tests                                   pass     pass     pass     same
    nci:nci_dev                                            fail     fail     fail     same
    net/forwarding:bridge_locked_port.sh                   fail     fail     fail     same
    net/forwarding:bridge_mdb.sh                           fail     fail     fail     same
    net/forwarding:bridge_mdb_host.sh                      pass     pass     pass     same
    net/forwarding:bridge_mdb_max.sh                       pass     pass     pass     same
    net/forwarding:bridge_mdb_port_down.sh                 pass     pass     pass     same
    net/forwarding:bridge_mld.sh                           pass     pass     pass     same
    net/forwarding:bridge_port_isolation.sh                fail     fail     fail     same
    net/forwarding:bridge_sticky_fdb.sh                    pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh                    fail     fail     fail     same
    net/forwarding:bridge_vlan_mcast.sh                    pass     pass     pass     same
    net/forwarding:bridge_vlan_unaware.sh                  fail     fail     fail     same
    net/forwarding:custom_multipath_hash.sh                fail     fail     fail     same
    net/forwarding:ethtool.sh                              skip     skip     skip     same
    net/forwarding:ethtool_extended_state.sh               skip     skip     skip     same
    net/forwarding:gre_custom_multipath_hash.sh            fail     fail     fail     same
    net/forwarding:gre_inner_v4_multipath.sh               fail     fail     fail     same
    net/forwarding:gre_multipath.sh                        fail     fail     fail     same
    net/forwarding:gre_multipath_nh.sh                     fail     fail     fail     same
    net/forwarding:gre_multipath_nh_res.sh                 fail     fail     fail     same
    net/forwarding:hw_stats_l3.sh                          skip     skip     skip     same
    net/forwarding:hw_stats_l3_gre.sh                      skip     skip     skip     same
    net/forwarding:ip6_forward_instats_vrf.sh              skip     skip     skip     same
    net/forwarding:ip6gre_custom_multipath_hash.sh         fail     fail     fail     same
    net/forwarding:ip6gre_flat.sh                          fail     fail     fail     same
    net/forwarding:ip6gre_flat_key.sh                      fail     fail     fail     same
    net/forwarding:ip6gre_flat_keys.sh                     fail     fail     fail     same
    net/forwarding:ip6gre_hier.sh                          fail     fail     fail     same
    net/forwarding:ip6gre_hier_key.sh                      fail     fail     fail     same
    net/forwarding:ip6gre_hier_keys.sh                     fail     fail     fail     same
    net/forwarding:ip6gre_inner_v4_multipath.sh            fail     fail     fail     same
    net/forwarding:ipip_flat_gre.sh                        fail     fail     fail     same
    net/forwarding:ipip_flat_gre_key.sh                    fail     fail     fail     same
    net/forwarding:ipip_flat_gre_keys.sh                   fail     fail     fail     same
    net/forwarding:ipip_hier_gre.sh                        fail     fail     fail     same
    net/forwarding:ipip_hier_gre_key.sh                    fail     fail     fail     same
    net/forwarding:local_termination.sh                    skip     skip     skip     same
    net/forwarding:loopback.sh                             skip     skip     skip     same
    net/forwarding:mirror_gre.sh                           pass     pass     pass     same
    net/forwarding:mirror_gre_bound.sh                     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh                 pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh                 pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh             pass     pass     pass     same
    net/forwarding:mirror_gre_changes.sh                   pass     pass     pass     same
    net/forwarding:mirror_gre_flower.sh                    pass     pass     pass     same
    net/forwarding:mirror_gre_lag_lacp.sh                  pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh                     pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh                        pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh                      pass     pass     pass     same
    net/forwarding:mirror_vlan.sh                          pass     pass     pass     same
    net/forwarding:no_forwarding.sh                        pass     pass     pass     same
    net/forwarding:pedit_dsfield.sh                        fail     fail     fail     same
    net/forwarding:pedit_ip.sh                             fail     fail     fail     same
    net/forwarding:pedit_l4port.sh                         fail     fail     fail     same
    net/forwarding:q_in_vni_ipv6.sh                        fail     fail     fail     same
    net/forwarding:router.sh                               skip     skip     skip     same
    net/forwarding:router_bridge.sh                        fail     fail     fail     same
    net/forwarding:router_bridge_1d.sh                     fail     fail     fail     same
    net/forwarding:router_bridge_pvid_vlan_upper.sh        fail     fail     fail     same
    net/forwarding:router_bridge_vlan.sh                   fail     fail     fail     same
    net/forwarding:router_bridge_vlan_upper.sh             fail     fail     fail     same
    net/forwarding:router_bridge_vlan_upper_pvid.sh        fail     fail     fail     same
    net/forwarding:router_broadcast.sh                     fail     fail     fail     same
    net/forwarding:router_mpath_nh.sh                      fail     fail     fail     same
    net/forwarding:router_mpath_nh_res.sh                  fail     fail     fail     same
    net/forwarding:router_multicast.sh                     skip     skip     skip     same
    net/forwarding:router_multipath.sh                     fail     fail     fail     same
    net/forwarding:router_nh.sh                            fail     fail     fail     same
    net/forwarding:router_vid_1.sh                         fail     fail     fail     same
    net/forwarding:skbedit_priority.sh                     fail     fail     fail     same
    net/forwarding:tc_chains.sh                            pass     pass     pass     same
    net/forwarding:tc_flower.sh                            pass     pass     pass     same
    net/forwarding:tc_flower_cfm.sh                        pass     pass     pass     same
    net/forwarding:tc_flower_l2_miss.sh                    fail     fail     fail     same
    net/forwarding:tc_flower_router.sh                     pass     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh                        fail     fail     fail     same
    net/forwarding:tc_shblocks.sh                          pass     pass     pass     same
    net/forwarding:tc_tunnel_key.sh                        pass     pass     pass     same
    net/forwarding:tc_vlan_modify.sh                       fail     fail     fail     same
    net/forwarding:vxlan_asymmetric.sh                     fail     fail     fail     same
    net/forwarding:vxlan_asymmetric_ipv6.sh                fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d.sh                      fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1d_port_8472_ipv6.sh       fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q.sh                      fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_ipv6.sh                 fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh            fail     fail     fail     same
    net/forwarding:vxlan_bridge_1q_port_8472_ipv6.sh       fail     fail     fail     same
    net/forwarding:vxlan_symmetric.sh                      fail     fail     fail     same
    net/forwarding:vxlan_symmetric_ipv6.sh                 fail     fail     fail     same
    net/hsr:hsr_ping.sh                                    fail     fail     fail     same
    net/mptcp:diag.sh                                      pass     pass     pass     same
    net/mptcp:mptcp_connect.sh                             pass     pass     pass     same
    net/mptcp:mptcp_sockopt.sh                             skip     skip     skip     same
    net/mptcp:pm_netlink.sh                                pass     pass     pass     same
    net:altnames.sh                                        pass     pass     pass     same
    net:bareudp.sh                                         pass     pass     pass     same
    net:big_tcp.sh                                         skip     skip     skip     same
    net:cmsg_so_mark.sh                                    pass     pass     pass     same
    net:devlink_port_split.py                              skip     skip     skip     same
    net:drop_monitor_tests.sh                              skip     skip     skip     same
    net:fcnal-test.sh                                      skip     skip     skip     same
    net:fib-onlink-tests.sh                                pass     pass     pass     same
    net:fib_nexthop_multiprefix.sh                         pass     pass     pass     same
    net:fib_nexthop_nongw.sh                               pass     pass     pass     same
    net:fib_rule_tests.sh                                  pass     pass     pass     same
    net:fib_tests.sh                                       fail     fail     fail     same
    net:fin_ack_lat.sh                                     pass     pass     pass     same
    net:gre_gso.sh                                         pass     pass     pass     same
    net:icmp.sh                                            fail     fail     fail     same
    net:icmp_redirect.sh                                   pass     pass     pass     same
    net:io_uring_zerocopy_tx.sh                            fail     fail     fail     same
    net:ip6_gre_headroom.sh                                pass     pass     pass     same
    net:ipv6_flowlabel.sh                                  pass     pass     pass     same
    net:l2_tos_ttl_inherit.sh                              skip     skip     skip     same
    net:l2tp.sh                                            pass     pass     pass     same
    net:msg_zerocopy.sh                                    pass     pass     pass     same
    net:netdevice.sh                                       pass     pass     pass     same
    net:pmtu.sh                                            fail     fail     fail     same
    net:psock_snd.sh                                       pass     pass     pass     same
    net:reuseaddr_conflict                                 pass     pass     pass     same
    net:reuseaddr_ports_exhausted.sh                       pass     pass     pass     same
    net:reuseport_bpf                                      pass     pass     pass     same
    net:reuseport_bpf_cpu                                  pass     pass     pass     same
    net:reuseport_bpf_numa                                 pass     pass     pass     same
    net:reuseport_dualstack                                pass     pass     pass     same
    net:route_localnet.sh                                  pass     pass     pass     same
    net:rps_default_mask.sh                                pass     pass     pass     same
    net:rtnetlink.sh                                       skip     skip     skip     same
    net:run_afpackettests                                  pass     pass     pass     same
    net:run_netsocktests                                   pass     pass     pass     same
    net:rxtimestamp.sh                                     pass     pass     pass     same
    net:so_txtime.sh                                       pass     pass     pass     same
    net:srv6_end_next_csid_l3vpn_test.sh                   pass     pass     pass     same
    net:srv6_hencap_red_l3vpn_test.sh                      pass     pass     pass     same
    net:srv6_hl2encap_red_l2vpn_test.sh                    pass     pass     pass     same
    net:stress_reuseport_listen.sh                         pass     pass     pass     same
    net:tcp_fastopen_backup_key.sh                         pass     pass     pass     same
    net:test_blackhole_dev.sh                              fail     fail     fail     same
    net:test_bpf.sh                                        pass     pass     pass     same
    net:test_bridge_neigh_suppress.sh                      skip     skip     skip     same
    net:test_vxlan_fdb_changelink.sh                       pass     pass     pass     same
    net:test_vxlan_under_vrf.sh                            pass     pass     pass     same
    net:tls                                                pass     pass     pass     same
    net:traceroute.sh                                      pass     pass     pass     same
    net:udpgro.sh                                          fail     fail     fail     same
    net:udpgro_bench.sh                                    fail     fail     fail     same
    net:udpgso.sh                                          fail     fail     fail     same
    net:unicast_extensions.sh                              pass     pass     pass     same
    net:veth.sh                                            fail     fail     fail     same
    net:vrf-xfrm-tests.sh                                  pass     pass     pass     same
    net:vrf_route_leaking.sh                               pass     pass     pass     same
    net:vrf_strict_mode_test.sh                            pass     pass     pass     same
    netfilter:bridge_brouter.sh                            skip     skip     skip     same
    netfilter:conntrack_icmp_related.sh                    skip     skip     skip     same
    netfilter:conntrack_tcp_unreplied.sh                   skip     skip     skip     same
    netfilter:conntrack_vrf.sh                             skip     skip     skip     same
    netfilter:ipvs.sh                                      pass     pass     pass     same
    netfilter:nf_nat_edemux.sh                             skip     skip     skip     same
    netfilter:nft_audit.sh                                 skip     skip     skip     same
    netfilter:nft_concat_range.sh                          fail     fail     fail     same
    netfilter:nft_conntrack_helper.sh                      skip     skip     skip     same
    netfilter:nft_fib.sh                                   skip     skip     skip     same
    netfilter:nft_flowtable.sh                             skip     skip     skip     same
    netfilter:nft_meta.sh                                  skip     skip     skip     same
    netfilter:nft_nat.sh                                   skip     skip     skip     same
    netfilter:nft_queue.sh                                 skip     skip     skip     same
    netfilter:rpath.sh                                     skip     skip     skip     same
    nsfs:owner                                             pass     pass     pass     same
    nsfs:pidns                                             pass     pass     pass     same
    pid_namespace:regression_enomem                        pass     pass     pass     same
    pidfd:pidfd_fdinfo_test                                pass     pass     pass     same
    pidfd:pidfd_getfd_test                                 pass     pass     pass     same
    pidfd:pidfd_open_test                                  pass     pass     pass     same
    pidfd:pidfd_poll_test                                  pass     pass     pass     same
    pidfd:pidfd_setns_test                                 pass     pass     pass     same
    pidfd:pidfd_test                                       pass     pass     pass     same
    pidfd:pidfd_wait                                       pass     pass     pass     same
    proc:fd-001-lookup                                     pass     pass     pass     same
    proc:fd-002-posix-eq                                   pass     pass     pass     same
    proc:fd-003-kthread                                    pass     pass     pass     same
    proc:proc-fsconfig-hidepid                             pass     pass     pass     same
    proc:proc-loadavg-001                                  pass     pass     pass     same
    proc:proc-multiple-procfs                              pass     pass     pass     same
    proc:proc-self-map-files-001                           pass     pass     pass     same
    proc:proc-self-map-files-002                           pass     pass     pass     same
    proc:proc-self-syscall                                 pass     pass     pass     same
    proc:proc-self-wchan                                   pass     pass     pass     same
    proc:proc-subset-pid                                   pass     pass     pass     same
    proc:proc-uptime-002                                   pass     pass     pass     same
    proc:read                                              pass     pass     pass     same
    proc:self                                              pass     pass     pass     same
    proc:setns-dcache                                      pass     pass     pass     same
    proc:setns-sysvipc                                     pass     pass     pass     same
    proc:thread-self                                       pass     pass     pass     same
    pstore:pstore_post_reboot_tests                        skip     skip     skip     same
    pstore:pstore_tests                                    fail     fail     fail     same
    ptrace:get_syscall_info                                pass     pass     pass     same
    ptrace:peeksiginfo                                     pass     pass     pass     same
    ptrace:vmaccess                                        fail     fail     fail     same
    rlimits:rlimits-per-userns                             pass     pass     pass     same
    rseq:basic_percpu_ops_test                             pass     pass     pass     same
    rseq:basic_test                                        pass     pass     pass     same
    rseq:param_test                                        pass     pass     pass     same
    rseq:param_test_benchmark                              pass     pass     pass     same
    rseq:param_test_compare_twice                          pass     pass     pass     same
    rseq:run_param_test.sh                                 pass     pass     pass     same
    seccomp:seccomp_benchmark                              pass     pass     pass     same
    seccomp:seccomp_bpf                                    pass     pass     pass     same
    sgx:test_sgx                                           fail     fail     fail     same
    sigaltstack:sas                                        pass     pass     pass     same
    size:get_size                                          pass     pass     pass     same
    splice:default_file_splice_read.sh                     pass     pass     pass     same
    splice:short_splice_read.sh                            fail     fail     fail     same
    static_keys:test_static_keys.sh                        skip     skip     skip     same
    syscall_user_dispatch:sud_benchmark                    pass     pass     pass     same
    syscall_user_dispatch:sud_test                         pass     pass     pass     same
    tc-testing:tdc.sh                                      fail     fail     fail     same
    tdx:tdx_guest_test                                     fail     fail     fail     same
    timens:clock_nanosleep                                 pass     pass     pass     same
    timens:exec                                            pass     pass     pass     same
    timens:futex                                           pass     pass     pass     same
    timens:procfs                                          pass     pass     pass     same
    timens:timens                                          pass     pass     pass     same
    timens:timer                                           pass     pass     pass     same
    timens:timerfd                                         pass     pass     pass     same
    timens:vfork_exec                                      pass     pass     pass     same
    timers:inconsistency-check                             pass     pass     pass     same
    timers:mqueue-lat                                      pass     pass     pass     same
    timers:nanosleep                                       pass     pass     pass     same
    timers:nsleep-lat                                      pass     pass     pass     same
    timers:posix_timers                                    pass     pass     pass     same
    timers:rtcpie                                          pass     pass     pass     same
    timers:set-timer-lat                                   pass     pass     pass     same
    timers:threadtest                                      pass     pass     pass     same
    tmpfs:bug-link-o-tmpfile                               pass     pass     pass     same
    tpm2:test_smoke.sh                                     skip     skip     skip     same
    tpm2:test_space.sh                                     skip     skip     skip     same
    tty:tty_tstamp_update                                  skip     skip     skip     same
    vDSO:vdso_standalone_test_x86                          pass     pass     pass     same
    vDSO:vdso_test_abi                                     pass     pass     pass     same
    vDSO:vdso_test_clock_getres                            pass     pass     pass     same
    vDSO:vdso_test_correctness                             pass     pass     pass     same
    vDSO:vdso_test_getcpu                                  pass     pass     pass     same
    vDSO:vdso_test_gettimeofday                            pass     pass     pass     same
    x86:amx_64                                             fail     fail     fail     same
    x86:check_initial_reg_state_64                         fail     fail     fail     same
    x86:corrupt_xstate_header_64                           fail     fail     fail     same
    x86:fsgsbase_64                                        fail     fail     fail     same
    x86:fsgsbase_restore_64                                fail     fail     fail     same
    x86:ioperm_64                                          fail     fail     fail     same
    x86:iopl_64                                            fail     fail     fail     same
    x86:lam_64                                             fail     fail     fail     same
    x86:mov_ss_trap_64                                     fail     fail     fail     same
    x86:sigaltstack_64                                     fail     fail     fail     same
    x86:sigreturn_64                                       fail     fail     fail     same
    x86:single_step_syscall_64                             fail     fail     fail     same
    x86:syscall_arg_fault_64                               fail     fail     fail     same
    x86:syscall_nt_64                                      fail     fail     fail     same
    x86:syscall_numbering_64                               fail     fail     fail     same
    x86:sysret_rip_64                                      fail     fail     fail     same
    x86:sysret_ss_attrs_64                                 fail     fail     fail     same
    x86:test_mremap_vdso_64                                fail     fail     fail     same
    x86:test_vsyscall_64                                   fail     fail     fail     same
    zram:zram.sh                                           pass     pass     pass     same

