### PR TITLE
[LTS 9.4] CVE-2025-38129, CVE-2024-47727, CVE-2026-31402

### DIFF
--- a/arch/x86/coco/tdx/tdx.c
+++ b/arch/x86/coco/tdx/tdx.c
@@ -14,6 +14,7 @@
 #include <asm/insn.h>
 #include <asm/insn-eval.h>
 #include <asm/pgtable.h>
+#include <asm/traps.h>
 
 /* MMIO direction */
 #define EPT_READ	0
@@ -428,6 +429,11 @@ static int handle_mmio(struct pt_regs *regs, struct ve_info *ve)
 		reg = insn_get_modrm_reg_ptr(&insn, regs);
 		if (!reg)
 			return -EINVAL;
+	}
+
+	if (!fault_in_kernel_space(ve->gla)) {
+		WARN_ONCE(1, "Access to userspace address is not supported");
+		return -EINVAL;
 	}
 
 	/*

--- a/fs/nfsd/nfs4xdr.c
+++ b/fs/nfsd/nfs4xdr.c
@@ -5441,9 +5441,14 @@ nfsd4_encode_operation(struct nfsd4_compoundres *resp, struct nfsd4_op *op)
 		int len = xdr->buf->len - post_err_offset;
 
 		so->so_replay.rp_status = op->status;
-		so->so_replay.rp_buflen = len;
-		read_bytes_from_xdr_buf(xdr->buf, post_err_offset,
+		if (len <= NFSD4_REPLAY_ISIZE) {
+			so->so_replay.rp_buflen = len;
+			read_bytes_from_xdr_buf(xdr->buf,
+						post_err_offset,
 						so->so_replay.rp_buf, len);
+		} else {
+			so->so_replay.rp_buflen = 0;
+		}
 	}
 status:
 	*p = op->status;

--- a/fs/nfsd/state.h
+++ b/fs/nfsd/state.h
@@ -430,11 +430,18 @@ struct nfs4_client_reclaim {
 	struct xdr_netobj	cr_princhash;
 };
 
-/* A reasonable value for REPLAY_ISIZE was estimated as follows:  
- * The OPEN response, typically the largest, requires 
- *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +  8(verifier) + 
- *   4(deleg. type) + 8(deleg. stateid) + 4(deleg. recall flag) + 
- *   20(deleg. space limit) + ~32(deleg. ace) = 112 bytes 
+/*
+ * REPLAY_ISIZE is sized for an OPEN response with delegation:
+ *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +
+ *   8(verifier) + 4(deleg. type) + 8(deleg. stateid) +
+ *   4(deleg. recall flag) + 20(deleg. space limit) +
+ *   ~32(deleg. ace) = 112 bytes
+ *
+ * Some responses can exceed this. A LOCK denial includes the conflicting
+ * lock owner, which can be up to 1024 bytes (NFS4_OPAQUE_LIMIT). Responses
+ * larger than REPLAY_ISIZE are not cached in rp_ibuf; only rp_status is
+ * saved. Enlarging this constant increases the size of every
+ * nfs4_stateowner.
  */
 
 #define NFSD4_REPLAY_ISIZE       112 

--- a/net/core/page_pool.c
+++ b/net/core/page_pool.c
@@ -140,9 +140,9 @@ u64 *page_pool_ethtool_stats_get(u64 *data, void *stats)
 EXPORT_SYMBOL(page_pool_ethtool_stats_get);
 
 #else
-#define alloc_stat_inc(pool, __stat)
-#define recycle_stat_inc(pool, __stat)
-#define recycle_stat_add(pool, __stat, val)
+#define alloc_stat_inc(...)	do { } while (0)
+#define recycle_stat_inc(...)	do { } while (0)
+#define recycle_stat_add(...)	do { } while (0)
 #endif
 
 static bool page_pool_producer_lock(struct page_pool *pool)
@@ -553,19 +553,16 @@ static void page_pool_return_page(struct page_pool *pool, struct page *page)
 
 static bool page_pool_recycle_in_ring(struct page_pool *pool, struct page *page)
 {
-	int ret;
+	bool in_softirq, ret;
+
 	/* BH protection not needed if current is softirq */
-	if (in_softirq())
-		ret = ptr_ring_produce(&pool->ring, page);
-	else
-		ret = ptr_ring_produce_bh(&pool->ring, page);
-
-	if (!ret) {
+	in_softirq = page_pool_producer_lock(pool);
+	ret = !__ptr_ring_produce(&pool->ring, page);
+	if (ret)
 		recycle_stat_inc(pool, ring);
-		return true;
-	}
+	page_pool_producer_unlock(pool, in_softirq);
 
-	return false;
+	return ret;
 }
 
 /* Only allow direct recycling in special circumstances, into the
@@ -854,10 +851,14 @@ static void page_pool_scrub(struct page_pool *pool)
 
 static int page_pool_release(struct page_pool *pool)
 {
+	bool in_softirq;
 	int inflight;
 
 	page_pool_scrub(pool);
 	inflight = page_pool_inflight(pool);
+	/* Acquire producer lock to make sure producers have exited. */
+	in_softirq = page_pool_producer_lock(pool);
+	page_pool_producer_unlock(pool, in_softirq);
 	if (!inflight)
 		page_pool_free(pool);
 


### PR DESCRIPTION
[LTS 9.4]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2025-38129</td>
<td class="org-left">VULN-71839</td>
</tr>


<tr>
<td class="org-left">CVE-2024-47727</td>
<td class="org-left">VULN-8574</td>
</tr>


<tr>
<td class="org-left">CVE-2026-31402</td>
<td class="org-left">VULN-180164</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2025-38129

    page_pool: Fix use-after-free in page_pool_recycle_in_ring
    
    jira VULN-71839
    cve CVE-2025-38129
    commit-author Dong Chenchen <dongchenchen2@huawei.com>
    commit 271683bb2cf32e5126c592b5d5e6a756fa374fd9
    upstream-diff |
      page_pool_recycle_in_ring()
            Accounted for the non-backported
            4dec64c52e24c2c9a15f81c115f1be5ea35121cb ("page_pool: convert to
            use netmem")
      page_pool_release()
            (The following were the context conflicts, no actual diffs from
            the upstream in the strict sense)
            - Retained the single-argument `page_pool_inflight()' call instead
              of passing additional `true' as it is in the upstream. The
              boolean argument relates to the reporting feature introduced in
              the non-backported commit
              7aee8429eedd0970d8add2fb5b856bfc5f5f1fc1 ("net: page_pool:
              report amount of memory held by page pools").
            - LTS 9.4 lacks the backport of
              de97502e16fc406a74edee8359612e518986cf59 ("page_pool: introduce
              page_pool_alloc() API"). Without it the `__page_pool_destroy()'
              call in upstream is equivalent to `page_pool_free()' in
              ciqlts9_4. Retained the ciqlts9_4-native `page_pool_free()'
              call.

To see that `netmem_ref` equals `struct page *` refer to the docstring of `netmem_ref` at the time of 271683bb2cf32e5126c592b5d5e6a756fa374fd9 fix:

<https://github.com/ctrliq/kernel-src-tree/blob/271683bb2cf32e5126c592b5d5e6a756fa374fd9/include/net/netmem.h#L88-L97>


## CVE-2024-47727

    x86/tdx: Fix "in-kernel MMIO" check
    
    jira VULN-8574
    cve CVE-2024-47727
    commit-author Alexey Gladkov (Intel) <legion@kernel.org>
    commit d4fc4d01471528da8a9797a065982e05090e1d81
    upstream-diff Context conflicts in header files inclusion only


## CVE-2026-31402

    nfsd: fix heap overflow in NFSv4.0 LOCK replay cache
    
    jira VULN-180164
    cve CVE-2026-31402
    commit-author Jeff Layton <jlayton@kernel.org>
    commit 5133b61aaf437e5f25b1b396b14242a6bb0508e2
    upstream-diff Used `post_err_offset' instead of `op_status_offset +
      XDR_UNIT' in the `read_bytes_from_xdr_buf()' call, as the LTS 9.4
      version is missing ef3675b45bcb6c17cabbbde620c6cea52ffb21ac ("NFSD:
      Encode COMPOUND operation status on page boundaries")

The non-backported commit ef3675b45bcb6c17cabbbde620c6cea52ffb21ac made some changes to the core, buffer length-related variables used in the fix, so the lack of it may raise some doubts whether the LTS 9.4 adaptation could have been made in such a straightforward manner. It could, because 

    post_err_offset = op_status_offset + XDR_UNIT

(Here the `=` sign should be understood as mathematical equality, not C assignement. Similarly in the code comments below)

To see why, take into account that the `xdr_reserve_space(xdr, N)` call, if successfull, increases `xdr->buf->len` by `N`. See 

<https://github.com/ctrliq/kernel-src-tree/blob/d0d2f2439897d00964f13d836dc8f7520a9e4e82/net/sunrpc/xdr.c#L1069>

and

<https://github.com/ctrliq/kernel-src-tree/blob/d0d2f2439897d00964f13d836dc8f7520a9e4e82/net/sunrpc/xdr.c#L1036>

Also that the `xdr_stream_encode_u32(xdr, X)` call increases `xdr->buf->len` by `sizeof(X)`, through the `xdr_reserve_space(xdr, N)` call inside:

<https://github.com/ctrliq/kernel-src-tree/blob/d0d2f2439897d00964f13d836dc8f7520a9e4e82/include/linux/sunrpc/xdr.h#L470>

In the upstream-fixed affected function `nfsd4_encode_operation()` we have:

<https://github.com/ctrliq/kernel-src-tree/blob/5133b61aaf437e5f25b1b396b14242a6bb0508e2/fs/nfsd/nfs4xdr.c#L6231-L6238>

Tracking the `op_status_offset` value:

    unsigned int op_status_offset;
    nfsd4_enc encoder;
    
    // (xdr->buf->len)_0
    if (xdr_stream_encode_u32(xdr, op->opnum) != XDR_UNIT)
    	goto release;
    // (xdr->buf->len)_1 = (xdr->buf->len)_0 + sizeof(op->opnum)
    op_status_offset = xdr->buf->len;
    // op_status_offset = (xdr->buf->len)_1
    //                  = (xdr->buf->len)_0 + sizeof(op->opnum)
    //                  = (xdr->buf->len)_0 + 4
    if (!xdr_reserve_space(xdr, XDR_UNIT))
    	goto release;

The last step comes from:

<https://github.com/ctrliq/kernel-src-tree/blob/d0d2f2439897d00964f13d836dc8f7520a9e4e82/fs/nfsd/xdr4.h#L635>

In the LTS 9.4 version the `nfsd4_encode_operation()` function starts with:

<https://github.com/ctrliq/kernel-src-tree/blob/d0d2f2439897d00964f13d836dc8f7520a9e4e82/fs/nfsd/nfs4xdr.c#L5389-L5397>

Tracking the `post_err_offset` value:

    int post_err_offset;
    nfsd4_enc encoder;
    __be32 *p;
    
    // (xdr->buf->len)_0
    p = xdr_reserve_space(xdr, 8);
    if (!p)
    	goto release;
    // (xdr->buf->len)_1 = (xd->buf->len)_0 + 8
    *p++ = cpu_to_be32(op->opnum);
    post_err_offset = xdr->buf->len;
    // post_err_offset = (xdr->buf->len)_1
    //                 = (xdr->buf->len)_0 + 8
    //                 = op_status_offset + 4
    //                 = op_status_offset + XDR_UNIT

The last step is because of

<https://github.com/ctrliq/kernel-src-tree/blob/d0d2f2439897d00964f13d836dc8f7520a9e4e82/include/linux/sunrpc/xdr.h#L27>

This means that neither the `len` value used in the special-case-catching condition nor the `base` argument for the `read_bytes_from_xdr_buf()` call differ between the upstream fix and the LTS 9.4 backport.


# kABI check: passed

    [1/2] kabi_check_kernel	Check ABI of kernel [ciqlts9_4-CVE-batch-30]	_kabi_check_kernel__x86_64--test--ciqlts9_4-CVE-batch-30
    + dist_git_version=el-9.4
    + local_version=ciqlts9_4-CVE-batch-30
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts9_4
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-9.4
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts9_4-CVE-batch-30
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-9.4/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts9_4 ''\''/mnt/code/kernel-dist-git-el-9.4/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-9.4/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts9_4-CVE-batch-30/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts9_4-CVE-batch-30/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/27131155/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_4&#x2013;run1.log](<https://github.com/user-attachments/files/27131156/kselftests--ciqlts9_4--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_4-CVE-batch-30&#x2013;run1.log](<https://github.com/user-attachments/files/27131161/kselftests--ciqlts9_4-CVE-batch-30--run1.log>)
[kselftests&#x2013;ciqlts9\_4-CVE-batch-30&#x2013;run2.log](<https://github.com/user-attachments/files/27131163/kselftests--ciqlts9_4-CVE-batch-30--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff  kselftests*.log

    Column    File
    --------  --------------------------------------------
    Status0   kselftests--ciqlts9_4--run1.log
    Status1   kselftests--ciqlts9_4-CVE-batch-30--run1.log
    Status2   kselftests--ciqlts9_4-CVE-batch-30--run2.log
    
    TestCase                                               Status0  Status1  Status2  Summary
    bpf:get_cgroup_id_user                                 pass     pass     pass     same
    bpf:test_cgroup_storage                                pass     pass     pass     same
    bpf:test_dev_cgroup                                    pass     pass     pass     same
    bpf:test_lpm_map                                       pass     pass     pass     same
    bpf:test_lru_map                                       pass     pass     pass     same
    bpf:test_sock                                          pass     pass     pass     same
    bpf:test_sysctl                                        pass     pass     pass     same
    bpf:test_tag                                           pass     pass     pass     same
    bpf:test_tcpnotify_user                                pass     pass     pass     same
    bpf:test_verifier                                      fail     fail     fail     same
    breakpoints:breakpoint_test                            pass     pass     pass     same
    capabilities:test_execve                               pass     pass     pass     same
    clone3:clone3                                          pass     pass     pass     same
    clone3:clone3_cap_checkpoint_restore                   pass     pass     pass     same
    clone3:clone3_clear_sighand                            pass     pass     pass     same
    clone3:clone3_set_tid                                  pass     pass     pass     same
    cpu-hotplug:cpu-on-off-test.sh                         pass     pass     pass     same
    cpufreq:main.sh                                        fail     fail     fail     same
    drivers/dma-buf:udmabuf                                pass     pass     pass     same
    drivers/net/bonding:bond-arp-interval-causes-panic.sh  pass     pass     pass     same
    drivers/net/bonding:bond-break-lacpdu-tx.sh            fail     fail     fail     same
    drivers/net/bonding:bond-eth-type-change.sh            pass     pass     pass     same
    drivers/net/bonding:bond-lladdr-target.sh              pass     pass     pass     same
    drivers/net/bonding:bond_options.sh                    fail     fail     fail     same
    drivers/net/bonding:dev_addr_lists.sh                  pass     pass     pass     same
    drivers/net/bonding:mode-1-recovery-updelay.sh         pass     pass     pass     same
    drivers/net/bonding:mode-2-recovery-updelay.sh         pass     pass     pass     same
    drivers/net/team:dev_addr_lists.sh                     pass     pass     pass     same
    exec:binfmt_script                                     pass     pass     pass     same
    exec:execveat                                          pass     pass     pass     same
    exec:load_address_16777216                             fail     fail     fail     same
    exec:load_address_2097152                              pass     pass     pass     same
    exec:load_address_4096                                 pass     pass     pass     same
    exec:non-regular                                       fail     fail     fail     same
    exec:recursion-depth                                   pass     pass     pass     same
    filesystems/binderfs:binderfs_test                     fail     fail     fail     same
    filesystems/epoll:epoll_wakeup_test                    pass     pass     pass     same
    firmware:fw_run_tests.sh                               skip     skip     skip     same
    fpu:run_test_fpu.sh                                    skip     skip     skip     same
    fpu:test_fpu                                           pass     pass     pass     same
    ftrace:ftracetest                                      fail     fail     fail     same
    futex:run.sh                                           pass     pass     pass     same
    gpio:gpio-mockup.sh                                    fail     fail     fail     same
    intel_pstate:run.sh                                    pass     pass     pass     same
    iommu:iommufd                                          fail     fail     fail     same
    iommu:iommufd_fail_nth                                 pass     pass     pass     same
    ipc:msgque                                             pass     pass     pass     same
    ir:ir_loopback.sh                                      skip     skip     skip     same
    kcmp:kcmp_test                                         pass     pass     pass     same
    kexec:test_kexec_file_load.sh                          skip     skip     skip     same
    kexec:test_kexec_load.sh                               skip     skip     skip     same
    kvm:access_tracking_perf_test                          pass     pass     pass     same
    kvm:amx_test                                           fail     fail     fail     same
    kvm:cpuid_test                                         fail     fail     fail     same
    kvm:cr4_cpuid_sync_test                                fail     fail     fail     same
    kvm:debug_regs                                         fail     fail     fail     same
    kvm:demand_paging_test                                 pass     pass     pass     same
    kvm:dirty_log_page_splitting_test                      fail     fail     fail     same
    kvm:dirty_log_perf_test                                pass     pass     pass     same
    kvm:dirty_log_test                                     fail     fail     fail     same
    kvm:exit_on_emulation_failure_test                     fail     fail     fail     same
    kvm:fix_hypercall_test                                 fail     fail     fail     same
    kvm:get_msr_index_features                             fail     fail     fail     same
    kvm:guest_memfd_test                                   pass     pass     pass     same
    kvm:guest_print_test                                   pass     pass     pass     same
    kvm:hardware_disable_test                              pass     pass     pass     same
    kvm:hyperv_clock                                       fail     fail     fail     same
    kvm:hyperv_cpuid                                       fail     fail     fail     same
    kvm:hyperv_evmcs                                       fail     fail     fail     same
    kvm:hyperv_extended_hypercalls                         fail     fail     fail     same
    kvm:hyperv_features                                    fail     fail     fail     same
    kvm:hyperv_ipi                                         fail     fail     fail     same
    kvm:hyperv_svm_test                                    fail     fail     fail     same
    kvm:hyperv_tlb_flush                                   fail     fail     fail     same
    kvm:kvm_binary_stats_test                              pass     pass     pass     same
    kvm:kvm_clock_test                                     fail     fail     fail     same
    kvm:kvm_create_max_vcpus                               pass     pass     pass     same
    kvm:kvm_page_table_test                                pass     pass     pass     same
    kvm:kvm_pv_test                                        fail     fail     fail     same
    kvm:max_guest_memory_test                              pass     pass     pass     same
    kvm:max_vcpuid_cap_test                                fail     fail     fail     same
    kvm:memslot_modification_stress_test                   pass     pass     pass     same
    kvm:memslot_perf_test                                  pass     pass     pass     same
    kvm:mmio_warning_test                                  fail     fail     fail     same
    kvm:monitor_mwait_test                                 fail     fail     fail     same
    kvm:nested_exceptions_test                             fail     fail     fail     same
    kvm:nx_huge_pages_test.sh                              fail     fail     fail     same
    kvm:platform_info_test                                 fail     fail     fail     same
    kvm:pmu_event_filter_test                              fail     fail     fail     same
    kvm:private_mem_conversions_test                       fail     fail     fail     same
    kvm:private_mem_kvm_exits_test                         fail     fail     fail     same
    kvm:recalc_apic_map_test                               fail     fail     fail     same
    kvm:rseq_test                                          fail     fail     fail     same
    kvm:set_boot_cpu_id                                    fail     fail     fail     same
    kvm:set_memory_region_test                             pass     pass     pass     same
    kvm:set_sregs_test                                     fail     fail     fail     same
    kvm:sev_migrate_tests                                  fail     fail     fail     same
    kvm:smaller_maxphyaddr_emulation_test                  fail     fail     fail     same
    kvm:smm_test                                           fail     fail     fail     same
    kvm:state_test                                         fail     fail     fail     same
    kvm:steal_time                                         pass     pass     pass     same
    kvm:svm_int_ctl_test                                   fail     fail     fail     same
    kvm:svm_nested_shutdown_test                           fail     fail     fail     same
    kvm:svm_nested_soft_inject_test                        fail     fail     fail     same
    kvm:svm_vmcall_test                                    fail     fail     fail     same
    kvm:sync_regs_test                                     fail     fail     fail     same
    kvm:system_counter_offset_test                         pass     pass     pass     same
    kvm:triple_fault_event_test                            fail     fail     fail     same
    kvm:tsc_msrs_test                                      fail     fail     fail     same
    kvm:tsc_scaling_sync                                   fail     fail     fail     same
    kvm:ucna_injection_test                                fail     fail     fail     same
    kvm:userspace_io_test                                  fail     fail     fail     same
    kvm:userspace_msr_exit_test                            fail     fail     fail     same
    kvm:vmx_apic_access_test                               fail     fail     fail     same
    kvm:vmx_close_while_nested_test                        fail     fail     fail     same
    kvm:vmx_dirty_log_test                                 fail     fail     fail     same
    kvm:vmx_exception_with_invalid_guest_state             fail     fail     fail     same
    kvm:vmx_invalid_nested_guest_state                     fail     fail     fail     same
    kvm:vmx_msrs_test                                      fail     fail     fail     same
    kvm:vmx_nested_tsc_scaling_test                        fail     fail     fail     same
    kvm:vmx_pmu_caps_test                                  fail     fail     fail     same
    kvm:vmx_preemption_timer_test                          fail     fail     fail     same
    kvm:vmx_set_nested_state_test                          fail     fail     fail     same
    kvm:vmx_tsc_adjust_test                                fail     fail     fail     same
    kvm:xapic_ipi_test                                     fail     fail     fail     same
    kvm:xapic_state_test                                   fail     fail     fail     same
    kvm:xcr0_cpuid_test                                    fail     fail     fail     same
    kvm:xen_shinfo_test                                    fail     fail     fail     same
    kvm:xen_vmcall_test                                    fail     fail     fail     same
    kvm:xss_msr_test                                       fail     fail     fail     same
    landlock:base_test                                     fail     fail     fail     same
    landlock:fs_test                                       fail     fail     fail     same
    landlock:ptrace_test                                   fail     fail     fail     same
    lib:bitmap.sh                                          skip     skip     skip     same
    lib:prime_numbers.sh                                   pass     pass     pass     same
    lib:printf.sh                                          skip     skip     skip     same
    lib:scanf.sh                                           skip     skip     skip     same
    lib:strscpy.sh                                         skip     skip     skip     same
    livepatch:test-callbacks.sh                            pass     pass     pass     same
    livepatch:test-ftrace.sh                               pass     pass     pass     same
    livepatch:test-livepatch.sh                            pass     pass     pass     same
    livepatch:test-shadow-vars.sh                          pass     pass     pass     same
    livepatch:test-state.sh                                pass     pass     pass     same
    livepatch:test-sysfs.sh                                pass     pass     pass     same
    membarrier:membarrier_test_multi_thread                pass     pass     pass     same
    membarrier:membarrier_test_single_thread               pass     pass     pass     same
    memfd:memfd_test                                       pass     pass     pass     same
    memfd:run_fuse_test.sh                                 pass     pass     pass     same
    memfd:run_hugetlbfs_test.sh                            pass     pass     pass     same
    memory-hotplug:mem-on-off-test.sh                      pass     pass     pass     same
    mincore:mincore_selftest                               fail     fail     fail     same
    mount:run_nosymfollow.sh                               pass     pass     pass     same
    mount:run_unprivileged_remount.sh                      pass     pass     pass     same
    mqueue:mq_open_tests                                   pass     pass     pass     same
    mqueue:mq_perf_tests                                   pass     pass     pass     same
    nci:nci_dev                                            fail     fail     fail     same
    net/forwarding:bridge_locked_port.sh                   pass     pass     pass     same
    net/forwarding:bridge_mdb.sh                           skip     skip     skip     same
    net/forwarding:bridge_mdb_host.sh                      pass     pass     pass     same
    net/forwarding:bridge_mdb_max.sh                       skip     skip     skip     same
    net/forwarding:bridge_mdb_port_down.sh                 pass     pass     pass     same
    net/forwarding:bridge_mld.sh                           pass     pass     pass     same
    net/forwarding:bridge_port_isolation.sh                pass     pass     pass     same
    net/forwarding:bridge_sticky_fdb.sh                    pass     pass     pass     same
    net/forwarding:bridge_vlan_aware.sh                    pass     pass     pass     same
    net/forwarding:bridge_vlan_mcast.sh                    pass     pass     pass     same
    net/forwarding:bridge_vlan_unaware.sh                  pass     pass     pass     same
    net/forwarding:custom_multipath_hash.sh                fail     fail     fail     same
    net/forwarding:ethtool.sh                              skip     skip     skip     same
    net/forwarding:ethtool_extended_state.sh               skip     skip     skip     same
    net/forwarding:gre_custom_multipath_hash.sh            fail     fail     fail     same
    net/forwarding:gre_inner_v4_multipath.sh               pass     pass     pass     same
    net/forwarding:gre_multipath.sh                        pass     pass     pass     same
    net/forwarding:gre_multipath_nh.sh                     fail     fail     fail     same
    net/forwarding:gre_multipath_nh_res.sh                 fail     fail     fail     same
    net/forwarding:hw_stats_l3.sh                          skip     skip     skip     same
    net/forwarding:hw_stats_l3_gre.sh                      skip     skip     skip     same
    net/forwarding:ip6_forward_instats_vrf.sh              skip     skip     skip     same
    net/forwarding:ip6gre_custom_multipath_hash.sh         fail     fail     fail     same
    net/forwarding:ip6gre_flat.sh                          pass     pass     pass     same
    net/forwarding:ip6gre_flat_key.sh                      pass     pass     pass     same
    net/forwarding:ip6gre_flat_keys.sh                     pass     pass     pass     same
    net/forwarding:ip6gre_hier.sh                          pass     pass     pass     same
    net/forwarding:ip6gre_hier_key.sh                      pass     pass     pass     same
    net/forwarding:ip6gre_hier_keys.sh                     pass     pass     pass     same
    net/forwarding:ip6gre_inner_v4_multipath.sh            pass     pass     pass     same
    net/forwarding:ipip_flat_gre.sh                        pass     pass     pass     same
    net/forwarding:ipip_flat_gre_key.sh                    pass     pass     pass     same
    net/forwarding:ipip_flat_gre_keys.sh                   pass     pass     pass     same
    net/forwarding:ipip_hier_gre.sh                        pass     pass     pass     same
    net/forwarding:ipip_hier_gre_key.sh                    pass     pass     pass     same
    net/forwarding:local_termination.sh                    skip     skip     skip     same
    net/forwarding:loopback.sh                             skip     skip     skip     same
    net/forwarding:mirror_gre.sh                           pass     pass     pass     same
    net/forwarding:mirror_gre_bound.sh                     pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1d.sh                 pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q.sh                 pass     pass     pass     same
    net/forwarding:mirror_gre_bridge_1q_lag.sh             pass     pass     pass     same
    net/forwarding:mirror_gre_changes.sh                   pass     pass     pass     same
    net/forwarding:mirror_gre_flower.sh                    pass     pass     pass     same
    net/forwarding:mirror_gre_lag_lacp.sh                  pass     pass     pass     same
    net/forwarding:mirror_gre_neigh.sh                     pass     pass     pass     same
    net/forwarding:mirror_gre_nh.sh                        pass     pass     pass     same
    net/forwarding:mirror_gre_vlan.sh                      pass     pass     pass     same
    net/forwarding:mirror_vlan.sh                          pass     pass     pass     same
    net/forwarding:no_forwarding.sh                        pass     pass     pass     same
    net/forwarding:pedit_dsfield.sh                        pass     pass     pass     same
    net/forwarding:pedit_ip.sh                             pass     pass     pass     same
    net/forwarding:pedit_l4port.sh                         pass     pass     pass     same
    net/forwarding:q_in_vni_ipv6.sh                        pass     pass     pass     same
    net/forwarding:router.sh                               skip     skip     skip     same
    net/forwarding:router_bridge.sh                        pass     pass     pass     same
    net/forwarding:router_bridge_1d.sh                     pass     pass     pass     same
    net/forwarding:router_bridge_pvid_vlan_upper.sh        pass     pass     pass     same
    net/forwarding:router_bridge_vlan.sh                   pass     pass     pass     same
    net/forwarding:router_bridge_vlan_upper.sh             pass     pass     pass     same
    net/forwarding:router_bridge_vlan_upper_pvid.sh        pass     pass     pass     same
    net/forwarding:router_broadcast.sh                     pass     pass     pass     same
    net/forwarding:router_mpath_nh.sh                      fail     fail     fail     same
    net/forwarding:router_mpath_nh_res.sh                  pass     pass     pass     same
    net/forwarding:router_multicast.sh                     skip     skip     skip     same
    net/forwarding:router_multipath.sh                     fail     fail     fail     same
    net/forwarding:router_nh.sh                            pass     pass     pass     same
    net/forwarding:router_vid_1.sh                         pass     pass     pass     same
    net/forwarding:skbedit_priority.sh                     pass     pass     pass     same
    net/forwarding:tc_chains.sh                            pass     pass     pass     same
    net/forwarding:tc_flower.sh                            pass     pass     pass     same
    net/forwarding:tc_flower_cfm.sh                        fail     fail     fail     same
    net/forwarding:tc_flower_l2_miss.sh                    fail     fail     fail     same
    net/forwarding:tc_flower_router.sh                     pass     pass     pass     same
    net/forwarding:tc_mpls_l2vpn.sh                        pass     pass     pass     same
    net/forwarding:tc_shblocks.sh                          pass     pass     pass     same
    net/forwarding:tc_tunnel_key.sh                        skip     skip     skip     same
    net/forwarding:tc_vlan_modify.sh                       pass     pass     pass     same
    net/forwarding:vxlan_asymmetric.sh                     pass     pass     pass     same
    net/forwarding:vxlan_asymmetric_ipv6.sh                pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d.sh                      pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472.sh            pass     pass     pass     same
    net/forwarding:vxlan_bridge_1d_port_8472_ipv6.sh       pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q.sh                      pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q_ipv6.sh                 pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472.sh            pass     pass     pass     same
    net/forwarding:vxlan_bridge_1q_port_8472_ipv6.sh       pass     pass     pass     same
    net/forwarding:vxlan_symmetric.sh                      pass     pass     pass     same
    net/forwarding:vxlan_symmetric_ipv6.sh                 pass     pass     pass     same
    net/hsr:hsr_ping.sh                                    fail     fail     fail     same
    net/mptcp:diag.sh                                      pass     pass     pass     same
    net/mptcp:mptcp_connect.sh                             pass     pass     pass     same
    net/mptcp:mptcp_sockopt.sh                             pass     pass     pass     same
    net/mptcp:pm_netlink.sh                                pass     pass     pass     same
    net:altnames.sh                                        pass     pass     pass     same
    net:bareudp.sh                                         pass     pass     pass     same
    net:big_tcp.sh                                         skip     skip     skip     same
    net:cmsg_so_mark.sh                                    pass     pass     pass     same
    net:devlink_port_split.py                              skip     skip     skip     same
    net:drop_monitor_tests.sh                              skip     skip     skip     same
    net:fcnal-test.sh                                      skip     skip     skip     same
    net:fib-onlink-tests.sh                                pass     pass     pass     same
    net:fib_nexthop_multiprefix.sh                         pass     pass     pass     same
    net:fib_nexthop_nongw.sh                               pass     pass     pass     same
    net:fib_rule_tests.sh                                  pass     pass     pass     same
    net:fib_tests.sh                                       fail     fail     fail     same
    net:fin_ack_lat.sh                                     pass     pass     pass     same
    net:gre_gso.sh                                         pass     pass     pass     same
    net:icmp.sh                                            fail     fail     fail     same
    net:icmp_redirect.sh                                   pass     pass     pass     same
    net:io_uring_zerocopy_tx.sh                            fail     fail     fail     same
    net:ip6_gre_headroom.sh                                pass     pass     pass     same
    net:ipv6_flowlabel.sh                                  pass     pass     pass     same
    net:l2_tos_ttl_inherit.sh                              skip     skip     skip     same
    net:l2tp.sh                                            pass     pass     pass     same
    net:msg_zerocopy.sh                                    pass     pass     pass     same
    net:netdevice.sh                                       pass     pass     pass     same
    net:pmtu.sh                                            fail     fail     fail     same
    net:psock_snd.sh                                       pass     pass     pass     same
    net:reuseaddr_conflict                                 pass     pass     pass     same
    net:reuseaddr_ports_exhausted.sh                       pass     pass     pass     same
    net:reuseport_bpf                                      pass     pass     pass     same
    net:reuseport_bpf_cpu                                  pass     pass     pass     same
    net:reuseport_bpf_numa                                 pass     pass     pass     same
    net:reuseport_dualstack                                pass     pass     pass     same
    net:route_localnet.sh                                  pass     pass     pass     same
    net:rps_default_mask.sh                                pass     pass     pass     same
    net:rtnetlink.sh                                       skip     skip     skip     same
    net:run_afpackettests                                  pass     pass     pass     same
    net:run_netsocktests                                   pass     pass     pass     same
    net:rxtimestamp.sh                                     pass     pass     pass     same
    net:so_txtime.sh                                       pass     pass     pass     same
    net:srv6_end_next_csid_l3vpn_test.sh                   pass     pass     pass     same
    net:srv6_hencap_red_l3vpn_test.sh                      pass     pass     pass     same
    net:srv6_hl2encap_red_l2vpn_test.sh                    pass     pass     pass     same
    net:stress_reuseport_listen.sh                         pass     pass     pass     same
    net:tcp_fastopen_backup_key.sh                         pass     pass     pass     same
    net:test_blackhole_dev.sh                              fail     fail     fail     same
    net:test_bpf.sh                                        pass     pass     pass     same
    net:test_bridge_neigh_suppress.sh                      skip     skip     skip     same
    net:test_vxlan_fdb_changelink.sh                       pass     pass     pass     same
    net:test_vxlan_under_vrf.sh                            pass     pass     pass     same
    net:tls                                                pass     pass     pass     same
    net:traceroute.sh                                      pass     pass     pass     same
    net:udpgro.sh                                          fail     fail     fail     same
    net:udpgro_bench.sh                                    fail     fail     fail     same
    net:udpgso.sh                                          pass     pass     pass     same
    net:unicast_extensions.sh                              pass     pass     pass     same
    net:veth.sh                                            fail     fail     fail     same
    net:vrf-xfrm-tests.sh                                  pass     pass     pass     same
    net:vrf_route_leaking.sh                               pass     pass     pass     same
    net:vrf_strict_mode_test.sh                            pass     pass     pass     same
    netfilter:bridge_brouter.sh                            skip     skip     skip     same
    netfilter:conntrack_icmp_related.sh                    fail     fail     fail     same
    netfilter:conntrack_tcp_unreplied.sh                   pass     pass     pass     same
    netfilter:conntrack_vrf.sh                             pass     pass     pass     same
    netfilter:ipvs.sh                                      pass     pass     pass     same
    netfilter:nf_nat_edemux.sh                             fail     fail     fail     same
    netfilter:nft_audit.sh                                 fail     fail     fail     same
    netfilter:nft_concat_range.sh                          fail     fail     fail     same
    netfilter:nft_conntrack_helper.sh                      skip     skip     skip     same
    netfilter:nft_fib.sh                                   skip     skip     skip     same
    netfilter:nft_flowtable.sh                             fail     fail     fail     same
    netfilter:nft_meta.sh                                  pass     pass     pass     same
    netfilter:nft_nat.sh                                   skip     skip     skip     same
    netfilter:nft_queue.sh                                 skip     skip     skip     same
    netfilter:rpath.sh                                     pass     pass     pass     same
    nsfs:owner                                             pass     pass     pass     same
    nsfs:pidns                                             pass     pass     pass     same
    pid_namespace:regression_enomem                        pass     pass     pass     same
    pidfd:pidfd_fdinfo_test                                pass     pass     pass     same
    pidfd:pidfd_getfd_test                                 pass     pass     pass     same
    pidfd:pidfd_open_test                                  pass     pass     pass     same
    pidfd:pidfd_poll_test                                  pass     pass     pass     same
    pidfd:pidfd_setns_test                                 pass     pass     pass     same
    pidfd:pidfd_test                                       pass     pass     pass     same
    pidfd:pidfd_wait                                       pass     pass     pass     same
    proc:fd-001-lookup                                     pass     pass     pass     same
    proc:fd-002-posix-eq                                   pass     pass     pass     same
    proc:fd-003-kthread                                    pass     pass     pass     same
    proc:proc-fsconfig-hidepid                             pass     pass     pass     same
    proc:proc-loadavg-001                                  pass     pass     pass     same
    proc:proc-multiple-procfs                              pass     pass     pass     same
    proc:proc-self-map-files-001                           pass     pass     pass     same
    proc:proc-self-map-files-002                           pass     pass     pass     same
    proc:proc-self-syscall                                 pass     pass     pass     same
    proc:proc-self-wchan                                   pass     pass     pass     same
    proc:proc-subset-pid                                   pass     pass     pass     same
    proc:proc-uptime-002                                   pass     pass     pass     same
    proc:read                                              pass     pass     pass     same
    proc:self                                              pass     pass     pass     same
    proc:setns-dcache                                      pass     pass     pass     same
    proc:setns-sysvipc                                     pass     pass     pass     same
    proc:thread-self                                       pass     pass     pass     same
    pstore:pstore_post_reboot_tests                        skip     skip     skip     same
    pstore:pstore_tests                                    fail     fail     fail     same
    ptrace:get_syscall_info                                pass     pass     pass     same
    ptrace:peeksiginfo                                     pass     pass     pass     same
    ptrace:vmaccess                                        fail     fail     fail     same
    rlimits:rlimits-per-userns                             pass     pass     pass     same
    rseq:basic_percpu_ops_test                             pass     pass     pass     same
    rseq:basic_test                                        pass     pass     pass     same
    rseq:param_test                                        pass     pass     pass     same
    rseq:param_test_benchmark                              pass     pass     pass     same
    rseq:param_test_compare_twice                          pass     pass     pass     same
    rseq:run_param_test.sh                                 pass     pass     pass     same
    seccomp:seccomp_benchmark                              pass     pass     pass     same
    seccomp:seccomp_bpf                                    pass     pass     pass     same
    sgx:test_sgx                                           fail     fail     fail     same
    sigaltstack:sas                                        pass     pass     pass     same
    size:get_size                                          pass     pass     pass     same
    splice:default_file_splice_read.sh                     pass     pass     pass     same
    splice:short_splice_read.sh                            fail     fail     fail     same
    static_keys:test_static_keys.sh                        skip     skip     skip     same
    syscall_user_dispatch:sud_benchmark                    pass     pass     pass     same
    syscall_user_dispatch:sud_test                         pass     pass     pass     same
    tc-testing:tdc.sh                                      fail     fail     fail     same
    tdx:tdx_guest_test                                     fail     fail     fail     same
    timens:clock_nanosleep                                 pass     pass     pass     same
    timens:exec                                            pass     pass     pass     same
    timens:futex                                           pass     pass     pass     same
    timens:procfs                                          pass     pass     pass     same
    timens:timens                                          pass     pass     pass     same
    timens:timer                                           pass     pass     pass     same
    timens:timerfd                                         pass     pass     pass     same
    timens:vfork_exec                                      pass     pass     pass     same
    timers:inconsistency-check                             pass     pass     pass     same
    timers:mqueue-lat                                      pass     pass     pass     same
    timers:nanosleep                                       pass     pass     pass     same
    timers:nsleep-lat                                      pass     pass     pass     same
    timers:posix_timers                                    pass     pass     pass     same
    timers:rtcpie                                          pass     pass     pass     same
    timers:set-timer-lat                                   pass     pass     pass     same
    timers:threadtest                                      pass     pass     pass     same
    tmpfs:bug-link-o-tmpfile                               pass     pass     pass     same
    tpm2:test_smoke.sh                                     skip     skip     skip     same
    tpm2:test_space.sh                                     skip     skip     skip     same
    tty:tty_tstamp_update                                  skip     skip     skip     same
    vDSO:vdso_standalone_test_x86                          pass     pass     pass     same
    vDSO:vdso_test_abi                                     pass     pass     pass     same
    vDSO:vdso_test_clock_getres                            pass     pass     pass     same
    vDSO:vdso_test_correctness                             pass     pass     pass     same
    vDSO:vdso_test_getcpu                                  pass     pass     pass     same
    vDSO:vdso_test_gettimeofday                            pass     pass     pass     same
    x86:amx_64                                             fail     fail     fail     same
    x86:check_initial_reg_state_64                         fail     fail     fail     same
    x86:corrupt_xstate_header_64                           fail     fail     fail     same
    x86:fsgsbase_64                                        fail     fail     fail     same
    x86:fsgsbase_restore_64                                fail     fail     fail     same
    x86:ioperm_64                                          fail     fail     fail     same
    x86:iopl_64                                            fail     fail     fail     same
    x86:lam_64                                             fail     fail     fail     same
    x86:mov_ss_trap_64                                     fail     fail     fail     same
    x86:sigaltstack_64                                     fail     fail     fail     same
    x86:sigreturn_64                                       fail     fail     fail     same
    x86:single_step_syscall_64                             fail     fail     fail     same
    x86:syscall_arg_fault_64                               fail     fail     fail     same
    x86:syscall_nt_64                                      fail     fail     fail     same
    x86:syscall_numbering_64                               fail     fail     fail     same
    x86:sysret_rip_64                                      fail     fail     fail     same
    x86:sysret_ss_attrs_64                                 fail     fail     fail     same
    x86:test_mremap_vdso_64                                fail     fail     fail     same
    x86:test_vsyscall_64                                   fail     fail     fail     same
    zram:zram.sh                                           pass     pass     pass     same

