### PR TITLE
CLK 6.18 Namespacing (continued)

### DIFF
--- a/ciq/SOURCES/bundle_bindgen.sh
+++ b/ciq/SOURCES/bundle_bindgen.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Bundle the bindgen-cli source code to be included in the kernel build.
 # https://crates.io/crates/bindgen-cli
@@ -12,9 +13,19 @@ SOURCES=$1
 BINDGEN_CLI=bindgen-cli
 BINDGEN_CLI_VERSION="0.71.1"
 BINDGEN_CLI_CRATE=bindgen-cli.crate
+BINDGEN_CLI_SHA256="fded10ca0956afd0cbe5cf89cc71ae1a679e65b8216c651fca17ba7de8ac54dc"
 CRATESIO_API_ENDPOINT=https://crates.io/api/v1/crates/bindgen-cli/${BINDGEN_CLI_VERSION}/download
 
-curl -sL $CRATESIO_API_ENDPOINT -o $SOURCES/$BINDGEN_CLI_CRATE
+curl -sfL $CRATESIO_API_ENDPOINT -o $SOURCES/$BINDGEN_CLI_CRATE
+
+echo "$BINDGEN_CLI_SHA256  $SOURCES/$BINDGEN_CLI_CRATE" | sha256sum -c - || {
+    echo "Error: SHA256 checksum mismatch for $BINDGEN_CLI_CRATE"
+    echo "Expected: $BINDGEN_CLI_SHA256"
+    echo "Got:      $(sha256sum $SOURCES/$BINDGEN_CLI_CRATE | awk '{print $1}')"
+    rm -f $SOURCES/$BINDGEN_CLI_CRATE
+    exit 1
+}
+
 tar -xf $SOURCES/$BINDGEN_CLI_CRATE -C $SOURCES
 mv $SOURCES/$BINDGEN_CLI-$BINDGEN_CLI_VERSION $SOURCES/$BINDGEN_CLI
 

--- a/ciq/SPECS/kernel-clk6.18.spec
+++ b/ciq/SPECS/kernel-clk6.18.spec
@@ -702,6 +702,7 @@ Requires: %{name}-modules-uname-r = %{KVERREL}
 Requires: %{name}-modules-core-uname-r = %{KVERREL}
 Requires: ((%{name}-modules-extra-uname-r = %{KVERREL}) if %{name}-modules-extra-matched)
 Provides: installonlypkg(kernel)
+Provides: kernel = %{specversion}-%{pkg_release}
 %endif
 
 

--- a/ciq/SPECS/kernel-clk6.18.spec
+++ b/ciq/SPECS/kernel-clk6.18.spec
@@ -1485,6 +1485,8 @@ This is required to use SystemTap with %{name}%{?1:-%{1}}-%{KVERREL}.\
 Summary: Development package for building kernel modules to match the %{?2:%{2} }kernel\
 Provides: %{name}%{?1:-%{1}}-devel-%{_target_cpu} = %{specversion}-%{release}\
 Provides: %{name}-devel-%{_target_cpu} = %{specversion}-%{release}%{uname_suffix %{?1}}\
+Provides: kernel-devel = %{specversion}-%{release}\
+Provides: kernel-devel-%{_target_cpu} = %{specversion}-%{release}\
 Provides: kernel-devel-uname-r = %{KVERREL}%{uname_suffix %{?1}}\
 Provides: %{name}-devel-uname-r = %{KVERREL}%{uname_suffix %{?1}}\
 Provides: installonlypkg(kernel)\


### PR DESCRIPTION
CLK 6.18 has already been namespaced, but based on the current namespacing design needs a couple of additional tweaks.  This brings it in line with the proposed CLK 6.12 namespacing PR here: https://github.com/ctrliq/kernel-src-tree/pull/1065 as well as the Namespace Kernel Package Design document here: https://ciqinc.atlassian.net/wiki/spaces/ENG/pages/2327904257/Namespaced+Kernel+Package+Design