### PR TITLE
[LTS 9.6] CVE-2025-38248, CVE-2025-39933, CVE-2025-38730, CVE-2025-38415

### DIFF
--- a/fs/smb/client/smbdirect.c
+++ b/fs/smb/client/smbdirect.c
@@ -446,7 +446,9 @@ static void recv_done(struct ib_cq *cq, struct ib_wc *wc)
 	struct smbd_response *response =
 		container_of(wc->wr_cqe, struct smbd_response, cqe);
 	struct smbd_connection *info = response->info;
-	int data_length = 0;
+	u32 data_offset = 0;
+	u32 data_length = 0;
+	u32 remaining_data_length = 0;
 
 	log_rdma_recv(INFO, "response=0x%p type=%d wc status=%d wc opcode %d byte_len=%d pkey_index=%u\n",
 		      response, response->type, wc->status, wc->opcode,
@@ -478,7 +480,22 @@ static void recv_done(struct ib_cq *cq, struct ib_wc *wc)
 	/* SMBD data transfer packet */
 	case SMBD_TRANSFER_DATA:
 		data_transfer = smbd_response_payload(response);
+
+		if (wc->byte_len <
+		    offsetof(struct smbd_data_transfer, padding))
+			goto error;
+
+		remaining_data_length = le32_to_cpu(data_transfer->remaining_data_length);
+		data_offset = le32_to_cpu(data_transfer->data_offset);
 		data_length = le32_to_cpu(data_transfer->data_length);
+		if (wc->byte_len < data_offset ||
+		    (u64)wc->byte_len < (u64)data_offset + data_length)
+			goto error;
+
+		if (remaining_data_length > info->max_fragmented_recv_size ||
+		    data_length > info->max_fragmented_recv_size ||
+		    (u64)remaining_data_length + (u64)data_length > (u64)info->max_fragmented_recv_size)
+			goto error;
 
 		/*
 		 * If this is a packet with data playload place the data in

--- a/fs/squashfs/super.c
+++ b/fs/squashfs/super.c
@@ -170,6 +170,11 @@ static int squashfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	msblk->panic_on_errors = (opts->errors == Opt_errors_panic);
 
 	msblk->devblksize = sb_min_blocksize(sb, SQUASHFS_DEVBLK_SIZE);
+	if (!msblk->devblksize) {
+		errorf(fc, "squashfs: unable to set blocksize\n");
+		return -EINVAL;
+	}
+
 	msblk->devblksize_log2 = ffz(~msblk->devblksize);
 
 	mutex_init(&msblk->meta_index_mutex);

--- a/fs/squashfs/super.c
+++ b/fs/squashfs/super.c
@@ -142,9 +142,14 @@ static int squashfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	unsigned short flags;
 	unsigned int fragments;
 	u64 lookup_table_start, xattr_id_table_start, next_table;
-	int err;
+	int err, devblksize = sb_min_blocksize(sb, SQUASHFS_DEVBLK_SIZE);
 
 	TRACE("Entered squashfs_fill_superblock\n");
+
+	if (!devblksize) {
+		errorf(fc, "squashfs: unable to set blocksize\n");
+		return -EINVAL;
+	}
 
 	/*
 	 * squashfs provides 'backing_dev_info' in order to disable read-ahead. For
@@ -169,12 +174,7 @@ static int squashfs_fill_super(struct super_block *sb, struct fs_context *fc)
 
 	msblk->panic_on_errors = (opts->errors == Opt_errors_panic);
 
-	msblk->devblksize = sb_min_blocksize(sb, SQUASHFS_DEVBLK_SIZE);
-	if (!msblk->devblksize) {
-		errorf(fc, "squashfs: unable to set blocksize\n");
-		return -EINVAL;
-	}
-
+	msblk->devblksize = devblksize;
 	msblk->devblksize_log2 = ffz(~msblk->devblksize);
 
 	mutex_init(&msblk->meta_index_mutex);

--- a/io_uring/kbuf.c
+++ b/io_uring/kbuf.c
@@ -298,7 +298,7 @@ int io_buffers_select(struct io_kiocb *req, struct buf_sel_arg *arg,
 		 */
 		if (ret > 0) {
 			req->flags |= REQ_F_BL_NO_RECYCLE;
-			req->buf_list->head += ret;
+			bl->head += ret;
 		}
 	} else {
 		ret = io_provided_buffers_select(req, &arg->out_len, bl, arg->iovs);

--- a/io_uring/kbuf.c
+++ b/io_uring/kbuf.c
@@ -171,9 +171,8 @@ static void __user *io_ring_buffer_select(struct io_kiocb *req, size_t *len,
 		 * the transfer completes (or if we get -EAGAIN and must poll of
 		 * retry).
 		 */
-		req->flags &= ~REQ_F_BUFFERS_COMMIT;
+		io_kbuf_commit(req, bl, 1);
 		req->buf_list = NULL;
-		bl->head++;
 	}
 	return u64_to_user_ptr(buf->addr);
 }
@@ -297,8 +296,8 @@ int io_buffers_select(struct io_kiocb *req, struct buf_sel_arg *arg,
 		 * committed them, they cannot be put back in the queue.
 		 */
 		if (ret > 0) {
-			req->flags |= REQ_F_BL_NO_RECYCLE;
-			bl->head += ret;
+			req->flags |= REQ_F_BUFFERS_COMMIT | REQ_F_BL_NO_RECYCLE;
+			io_kbuf_commit(req, bl, ret);
 		}
 	} else {
 		ret = io_provided_buffers_select(req, &arg->out_len, bl, arg->iovs);

--- a/io_uring/kbuf.h
+++ b/io_uring/kbuf.h
@@ -117,15 +117,21 @@ static inline bool io_kbuf_recycle(struct io_kiocb *req, unsigned issue_flags)
 	return false;
 }
 
+static inline void io_kbuf_commit(struct io_kiocb *req,
+				  struct io_buffer_list *bl, int nr)
+{
+	if (unlikely(!(req->flags & REQ_F_BUFFERS_COMMIT)))
+		return;
+	bl->head += nr;
+	req->flags &= ~REQ_F_BUFFERS_COMMIT;
+}
+
 static inline void __io_put_kbuf_ring(struct io_kiocb *req, int nr)
 {
 	struct io_buffer_list *bl = req->buf_list;
 
 	if (bl) {
-		if (req->flags & REQ_F_BUFFERS_COMMIT) {
-			bl->head += nr;
-			req->flags &= ~REQ_F_BUFFERS_COMMIT;
-		}
+		io_kbuf_commit(req, bl, nr);
 		req->buf_index = bl->bgid;
 	}
 	req->flags &= ~REQ_F_BUFFER_RING;

--- a/io_uring/net.c
+++ b/io_uring/net.c
@@ -478,6 +478,15 @@ static int io_bundle_nbufs(struct io_async_msghdr *kmsg, int ret)
 	return nbufs;
 }
 
+static int io_net_kbuf_recyle(struct io_kiocb *req,
+			      struct io_async_msghdr *kmsg, int len)
+{
+	req->flags |= REQ_F_BL_NO_RECYCLE;
+	if (req->flags & REQ_F_BUFFERS_COMMIT)
+		io_kbuf_commit(req, req->buf_list, io_bundle_nbufs(kmsg, len));
+	return -EAGAIN;
+}
+
 static inline bool io_send_finish(struct io_kiocb *req, int *ret,
 				  struct io_async_msghdr *kmsg,
 				  unsigned issue_flags)
@@ -546,8 +555,7 @@ int io_sendmsg(struct io_kiocb *req, unsigned int issue_flags)
 			kmsg->msg.msg_controllen = 0;
 			kmsg->msg.msg_control = NULL;
 			sr->done_io += ret;
-			req->flags |= REQ_F_BL_NO_RECYCLE;
-			return -EAGAIN;
+			return io_net_kbuf_recyle(req, kmsg, ret);
 		}
 		if (ret == -ERESTARTSYS)
 			ret = -EINTR;
@@ -635,8 +643,7 @@ retry_bundle:
 			sr->len -= ret;
 			sr->buf += ret;
 			sr->done_io += ret;
-			req->flags |= REQ_F_BL_NO_RECYCLE;
-			return -EAGAIN;
+			return io_net_kbuf_recyle(req, kmsg, ret);
 		}
 		if (ret == -ERESTARTSYS)
 			ret = -EINTR;
@@ -1018,8 +1025,7 @@ retry_multishot:
 		}
 		if (ret > 0 && io_net_retry(sock, flags)) {
 			sr->done_io += ret;
-			req->flags |= REQ_F_BL_NO_RECYCLE;
-			return -EAGAIN;
+			return io_net_kbuf_recyle(req, kmsg, ret);
 		}
 		if (ret == -ERESTARTSYS)
 			ret = -EINTR;
@@ -1158,8 +1164,7 @@ retry_multishot:
 			sr->len -= ret;
 			sr->buf += ret;
 			sr->done_io += ret;
-			req->flags |= REQ_F_BL_NO_RECYCLE;
-			return -EAGAIN;
+			return io_net_kbuf_recyle(req, kmsg, ret);
 		}
 		if (ret == -ERESTARTSYS)
 			ret = -EINTR;
@@ -1395,8 +1400,7 @@ int io_send_zc(struct io_kiocb *req, unsigned int issue_flags)
 			zc->len -= ret;
 			zc->buf += ret;
 			zc->done_io += ret;
-			req->flags |= REQ_F_BL_NO_RECYCLE;
-			return -EAGAIN;
+			return io_net_kbuf_recyle(req, kmsg, ret);
 		}
 		if (ret == -ERESTARTSYS)
 			ret = -EINTR;
@@ -1455,8 +1459,7 @@ int io_sendmsg_zc(struct io_kiocb *req, unsigned int issue_flags)
 
 		if (ret > 0 && io_net_retry(sock, flags)) {
 			sr->done_io += ret;
-			req->flags |= REQ_F_BL_NO_RECYCLE;
-			return -EAGAIN;
+			return io_net_kbuf_recyle(req, kmsg, ret);
 		}
 		if (ret == -ERESTARTSYS)
 			ret = -EINTR;

--- a/net/bridge/br_mst.c
+++ b/net/bridge/br_mst.c
@@ -80,10 +80,10 @@ static void br_mst_vlan_set_state(struct net_bridge_vlan_group *vg,
 	if (br_vlan_get_state(v) == state)
 		return;
 
-	br_vlan_set_state(v, state);
-
 	if (v->vid == vg->pvid)
 		br_vlan_set_pvid_state(vg, state);
+
+	br_vlan_set_state(v, state);
 }
 
 int br_mst_set_state(struct net_bridge_port *p, u16 msti, u8 state,

--- a/net/bridge/br_multicast.c
+++ b/net/bridge/br_multicast.c
@@ -2014,10 +2014,19 @@ void br_multicast_port_ctx_init(struct net_bridge_port *port,
 
 void br_multicast_port_ctx_deinit(struct net_bridge_mcast_port *pmctx)
 {
+	struct net_bridge *br = pmctx->port->br;
+	bool del = false;
+
 #if IS_ENABLED(CONFIG_IPV6)
 	del_timer_sync(&pmctx->ip6_mc_router_timer);
 #endif
 	del_timer_sync(&pmctx->ip4_mc_router_timer);
+
+	spin_lock_bh(&br->multicast_lock);
+	del |= br_ip6_multicast_rport_del(pmctx);
+	del |= br_ip4_multicast_rport_del(pmctx);
+	br_multicast_rport_del_notify(pmctx, del);
+	spin_unlock_bh(&br->multicast_lock);
 }
 
 int br_multicast_add_port(struct net_bridge_port *port)

--- a/net/bridge/br_multicast.c
+++ b/net/bridge/br_multicast.c
@@ -4272,6 +4272,32 @@ static void __br_multicast_stop(struct net_bridge_mcast *brmctx)
 #endif
 }
 
+void br_multicast_update_vlan_mcast_ctx(struct net_bridge_vlan *v, u8 state)
+{
+#if IS_ENABLED(CONFIG_BRIDGE_VLAN_FILTERING)
+	struct net_bridge *br;
+
+	if (!br_vlan_should_use(v))
+		return;
+
+	if (br_vlan_is_master(v))
+		return;
+
+	br = v->port->br;
+
+	if (!br_opt_get(br, BROPT_MCAST_VLAN_SNOOPING_ENABLED))
+		return;
+
+	if (br_vlan_state_allowed(state, true))
+		br_multicast_enable_port_ctx(&v->port_mcast_ctx);
+
+	/* Multicast is not disabled for the vlan when it goes in
+	 * blocking state because the timers will expire and stop by
+	 * themselves without sending more queries.
+	 */
+#endif
+}
+
 void br_multicast_toggle_one_vlan(struct net_bridge_vlan *vlan, bool on)
 {
 	struct net_bridge *br;

--- a/net/bridge/br_multicast.c
+++ b/net/bridge/br_multicast.c
@@ -2105,12 +2105,17 @@ static void __br_multicast_enable_port_ctx(struct net_bridge_mcast_port *pmctx)
 	}
 }
 
-void br_multicast_enable_port(struct net_bridge_port *port)
+static void br_multicast_enable_port_ctx(struct net_bridge_mcast_port *pmctx)
 {
-	struct net_bridge *br = port->br;
+	struct net_bridge *br = pmctx->port->br;
 
 	spin_lock_bh(&br->multicast_lock);
-	__br_multicast_enable_port_ctx(&port->multicast_ctx);
+	if (br_multicast_port_ctx_is_vlan(pmctx) &&
+	    !(pmctx->vlan->priv_flags & BR_VLFLAG_MCAST_ENABLED)) {
+		spin_unlock_bh(&br->multicast_lock);
+		return;
+	}
+	__br_multicast_enable_port_ctx(pmctx);
 	spin_unlock_bh(&br->multicast_lock);
 }
 
@@ -2137,11 +2142,67 @@ static void __br_multicast_disable_port_ctx(struct net_bridge_mcast_port *pmctx)
 	br_multicast_rport_del_notify(pmctx, del);
 }
 
+static void br_multicast_disable_port_ctx(struct net_bridge_mcast_port *pmctx)
+{
+	struct net_bridge *br = pmctx->port->br;
+
+	spin_lock_bh(&br->multicast_lock);
+	if (br_multicast_port_ctx_is_vlan(pmctx) &&
+	    !(pmctx->vlan->priv_flags & BR_VLFLAG_MCAST_ENABLED)) {
+		spin_unlock_bh(&br->multicast_lock);
+		return;
+	}
+
+	__br_multicast_disable_port_ctx(pmctx);
+	spin_unlock_bh(&br->multicast_lock);
+}
+
+static void br_multicast_toggle_port(struct net_bridge_port *port, bool on)
+{
+#if IS_ENABLED(CONFIG_BRIDGE_VLAN_FILTERING)
+	if (br_opt_get(port->br, BROPT_MCAST_VLAN_SNOOPING_ENABLED)) {
+		struct net_bridge_vlan_group *vg;
+		struct net_bridge_vlan *vlan;
+
+		rcu_read_lock();
+		vg = nbp_vlan_group_rcu(port);
+		if (!vg) {
+			rcu_read_unlock();
+			return;
+		}
+
+		/* iterate each vlan, toggle vlan multicast context */
+		list_for_each_entry_rcu(vlan, &vg->vlan_list, vlist) {
+			struct net_bridge_mcast_port *pmctx =
+						&vlan->port_mcast_ctx;
+			u8 state = br_vlan_get_state(vlan);
+			/* enable vlan multicast context when state is
+			 * LEARNING or FORWARDING
+			 */
+			if (on && br_vlan_state_allowed(state, true))
+				br_multicast_enable_port_ctx(pmctx);
+			else
+				br_multicast_disable_port_ctx(pmctx);
+		}
+		rcu_read_unlock();
+		return;
+	}
+#endif
+	/* toggle port multicast context when vlan snooping is disabled */
+	if (on)
+		br_multicast_enable_port_ctx(&port->multicast_ctx);
+	else
+		br_multicast_disable_port_ctx(&port->multicast_ctx);
+}
+
+void br_multicast_enable_port(struct net_bridge_port *port)
+{
+	br_multicast_toggle_port(port, true);
+}
+
 void br_multicast_disable_port(struct net_bridge_port *port)
 {
-	spin_lock_bh(&port->br->multicast_lock);
-	__br_multicast_disable_port_ctx(&port->multicast_ctx);
-	spin_unlock_bh(&port->br->multicast_lock);
+	br_multicast_toggle_port(port, false);
 }
 
 static int __grp_src_delete_marked(struct net_bridge_port_group *pg)
@@ -4304,9 +4365,9 @@ int br_multicast_toggle_vlan_snooping(struct net_bridge *br, bool on,
 		__br_multicast_open(&br->multicast_ctx);
 	list_for_each_entry(p, &br->port_list, list) {
 		if (on)
-			br_multicast_disable_port(p);
+			br_multicast_disable_port_ctx(&p->multicast_ctx);
 		else
-			br_multicast_enable_port(p);
+			br_multicast_enable_port_ctx(&p->multicast_ctx);
 	}
 
 	list_for_each_entry(vlan, &vg->vlan_list, vlist)

--- a/net/bridge/br_private.h
+++ b/net/bridge/br_private.h
@@ -1052,6 +1052,7 @@ void br_multicast_port_ctx_init(struct net_bridge_port *port,
 				struct net_bridge_vlan *vlan,
 				struct net_bridge_mcast_port *pmctx);
 void br_multicast_port_ctx_deinit(struct net_bridge_mcast_port *pmctx);
+void br_multicast_update_vlan_mcast_ctx(struct net_bridge_vlan *v, u8 state);
 void br_multicast_toggle_one_vlan(struct net_bridge_vlan *vlan, bool on);
 int br_multicast_toggle_vlan_snooping(struct net_bridge *br, bool on,
 				      struct netlink_ext_ack *extack);
@@ -1502,6 +1503,11 @@ static inline void br_multicast_port_ctx_deinit(struct net_bridge_mcast_port *pm
 {
 }
 
+static inline void br_multicast_update_vlan_mcast_ctx(struct net_bridge_vlan *v,
+						      u8 state)
+{
+}
+
 static inline void br_multicast_toggle_one_vlan(struct net_bridge_vlan *vlan,
 						bool on)
 {
@@ -1852,7 +1858,9 @@ bool br_vlan_global_opts_can_enter_range(const struct net_bridge_vlan *v_curr,
 bool br_vlan_global_opts_fill(struct sk_buff *skb, u16 vid, u16 vid_range,
 			      const struct net_bridge_vlan *v_opts);
 
-/* vlan state manipulation helpers using *_ONCE to annotate lock-free access */
+/* vlan state manipulation helpers using *_ONCE to annotate lock-free access,
+ * while br_vlan_set_state() may access data protected by multicast_lock.
+ */
 static inline u8 br_vlan_get_state(const struct net_bridge_vlan *v)
 {
 	return READ_ONCE(v->state);
@@ -1861,6 +1869,7 @@ static inline u8 br_vlan_get_state(const struct net_bridge_vlan *v)
 static inline void br_vlan_set_state(struct net_bridge_vlan *v, u8 state)
 {
 	WRITE_ONCE(v->state, state);
+	br_multicast_update_vlan_mcast_ctx(v, state);
 }
 
 static inline u8 br_vlan_get_pvid_state(const struct net_bridge_vlan_group *vg)


### PR DESCRIPTION
[LTS 9.6]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2025-38248</td>
<td class="org-left">VULN-162934</td>
</tr>


<tr>
<td class="org-left">CVE-2025-39933</td>
<td class="org-left">VULN-161396</td>
</tr>


<tr>
<td class="org-left">CVE-2025-38730</td>
<td class="org-left">VULN-163643</td>
</tr>


<tr>
<td class="org-left">CVE-2025-38415</td>
<td class="org-left">VULN-163295</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2025-38248

    bridge: mcast: Fix use-after-free during router port configuration
    
    jira VULN-162934
    cve CVE-2025-38248
    commit-author Ido Schimmel <idosch@nvidia.com>
    commit 7544f3f5b0b58c396f374d060898b5939da31709
    upstream-diff Context conflicts resolved

>

    net: bridge: mcast: update multicast contex when vlan state is changed
    
    jira VULN-162934
    cve-pre CVE-2025-38248
    commit-author Yong Wang <yongwang@nvidia.com>
    commit 6c131043eaf1be2a6cc2d228f92ceb626fbcc0f3

>

    net: bridge: mcast: re-implement br_multicast_{enable, disable}_port functions
    
    jira VULN-162934
    cve-pre CVE-2025-38248
    commit-author Yong Wang <yongwang@nvidia.com>
    commit 4b30ae9adb047dd0a7982975ec3933c529537026

The [Linux kernel advisory page](https://lore.kernel.org/linux-cve-announce/2025070934-CVE-2025-38248-003c@gregkh/T/#u) for CVE-2025-38248 points to the commit 2796d846d74a18cc6563e96eff8bf28c5e06f912 as introducing the bug:

> Issue introduced in 5.15 with commit 2796d846d74a18cc6563e96eff8bf28c5e06f912 and fixed in 6.15.5 with commit f05a4f9e959e0fc098046044c650acf897ea52d2
> Issue introduced in 5.15 with commit 2796d846d74a18cc6563e96eff8bf28c5e06f912 and fixed in 6.16-rc4 with commit 7544f3f5b0b58c396f374d060898b5939da31709

However, the fixing commit 7544f3f5b0b58c396f374d060898b5939da31709 lists another commit which it "Fixes", two in total:
> Fixes: 2796d846d74a ("net: bridge: vlan: convert mcast router global option to per-vlan entry")
> Fixes: 4b30ae9adb04 ("net: bridge: mcast: re-implement br\_multicast\_{enable, disable}\_port functions")

Additionally, the commit message says

> Since commit 4b30ae9adb04 ("net: bridge: mcast: re-implement
> br\_multicast\_{enable, disable}\_port functions"), when per-VLAN multicast
> snooping is enabled, multicast disablement on a port will disable the
> per-{port, VLAN} multicast contexts and not the per-port one. As a
> result, a port will remain in the global router port list even after it
> is deleted. This will lead to a use-after-free [1] when the list is
> traversed

This explicitly says that at least one of the two UAFs addressed in the fix happens after the change introduced by the second commit 4b30ae9adb047dd0a7982975ec3933c529537026.

The issue is that the first bug-introducing commit 2796d846d74a18cc6563e96eff8bf28c5e06f912 was ported to LTS 9.6 as f5b0bea501c15cdc4625fb9b418e9a1260c2af75, but the second 4b30ae9adb047dd0a7982975ec3933c529537026 was not. This makes it unclear whether LTS 9.6 is affected by CVE-2025-38248 and to what extent.

None of the commits 2796d846d74a18cc6563e96eff8bf28c5e06f912 and 4b30ae9adb047dd0a7982975ec3933c529537026 share code changes with the CVE-2025-38248 fix 7544f3f5b0b58c396f374d060898b5939da31709, so the problem of bug applicability cannot be resolved by simple code analysis (eg. "affected code not present", etc.)

Commit 4b30ae9adb047dd0a7982975ec3933c529537026 is a bugfix, not an introduction of new feature. This may not be obvious from the tags, because it doesn't contain any `Fixes`, but the message clearly contains a statement of a problem and a solution proposition:

> When a bridge port STP state is changed from BLOCKING/DISABLED to
> FORWARDING, the port's igmp query timer will NOT re-arm itself if the
> bridge has been configured as per-VLAN multicast snooping.
> 
> Solve this by choosing the correct multicast context(s) to enable/disable
> port multicast based on whether per-VLAN multicast snooping is enabled or
> not, i.e. using per-{port, VLAN} context in case of per-VLAN multicast
> snooping by re-implementing br\_multicast\_enable\_port() and
> br\_multicast\_disable\_port() functions.

Given, that:

1.  commit 4b30ae9adb047dd0a7982975ec3933c529537026 is a bugfix,
2.  commit 4b30ae9adb047dd0a7982975ec3933c529537026 backports easily (no conflicts),
3.  all other checked versions backporting CVE-2025-38248 fix 7544f3f5b0b58c396f374d060898b5939da31709 also had commit 4b30ae9adb047dd0a7982975ec3933c529537026 backported (more on this later),
4.  it's not clear whether the fix 7544f3f5b0b58c396f374d060898b5939da31709 backported without 4b30ae9adb047dd0a7982975ec3933c529537026 would not introduce new issues,
5.  it's not clear whether the lack of 4b30ae9adb047dd0a7982975ec3933c529537026 makes LTS 9.6 not affected by CVE-2025-38248, since the other bug-introducing commit 2796d846d74a18cc6563e96eff8bf28c5e06f912 *is* present,
6.  figuring out (4) and (5) was far more costly than doing (2),

it was decided to simply backport 4b30ae9adb047dd0a7982975ec3933c529537026 `net: bridge: mcast: re-implement br_multicast_{enable, disable}_port functions` as the prerequisite for CVE-2025-38248 solution.

The other commit - 6c131043eaf1be2a6cc2d228f92ceb626fbcc0f3 `net: bridge: mcast: update multicast contex when vlan state is changed` - was implied by 4b30ae9adb047dd0a7982975ec3933c529537026, as they both address the same issue triggered in different places: bridge port STP state change and vlan STP state change. See commit 88922fe7854091a50e831fefdae674433c5b261e description:

> bridge: multicast: per vlan query improvement when port or vlan state changes
> 
> The current implementation of br\_multicast\_enable\_port() only operates on
> port's multicast context, which doesn't take into account in case of vlan
> snooping, one downside is the port's igmp query timer will NOT resume when
> port state gets changed from BR\_STATE\_BLOCKING to BR\_STATE\_FORWARDING etc.

They were part of a single upstream-merged branch devoted to this problem:

    git log -n 5 --oneline --graph 88922fe7854091a50e831fefdae674433c5b261e

    *   88922fe7854 Merge branch 'bridge-mc-per-vlan-qquery'
    |\  
    | * aea45363e29 selftests: net/bridge : add tests for per vlan snooping with stp state changes
    | * 6c131043eaf net: bridge: mcast: update multicast contex when vlan state is changed
    | * 4b30ae9adb0 net: bridge: mcast: re-implement br_multicast_{enable, disable}_port functions
    |/  
    * 0e0a7e3719b xdp: create locked/unlocked instances of xdp redirect target setters

The selftest commit was omitted in the solution proposed in this PR.

Compare the backporting situation between other Linux versions

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-right" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-right">0</td>
<td class="org-left">CVE-2025-38248 fix</td>
</tr>


<tr>
<td class="org-right">1</td>
<td class="org-left">Fix bundled with (2) in the upstream</td>
</tr>


<tr>
<td class="org-right">2</td>
<td class="org-left">Second "Fixes" of the CVE-2025-38248 fix, missing from LTS 9.6</td>
</tr>


<tr>
<td class="org-right">3</td>
<td class="org-left">Commit introducing the CVE-2025-38248 bug officially</td>
</tr>
</tbody>
</table>

       Label    File
       -------  -------------------------
       A        net/bridge/br_multicast.c
       
       INFO:common:gitHistoriesCommand: Preparing the timeline table
       A    kernel-mainline                                                                                                                              ciqlts9_4                 ciqlts9_6                 centos9                   rocky9_7                  linux-6.1.y               linux-6.6.y               linux-6.15.y              linux-6.16.y
       ---  -------------------------------------------------------------------------------------------------------------------------------------------  ------------------------  ------------------------  ------------------------  ------------------------  ------------------------  ------------------------  ------------------------  ------------------------
       #    69050f8d6d075dc01af7a5f2f550a8067510366f 2026-02-21 treewide: Replace kmalloc with kmalloc_obj for non-scalar types
       #    8b769e311a86bb9d15c5658ad283b86fc8f080a2 2026-02-17 net: bridge: mcast: always update mdb_n_entries for vlan contexts                                                                                                                                                          ~ d0fdad1bdd2 2026-03-04
       #    dd7fca9f49d3e7ab7e48d9c616bff0c84148a7e0 2026-01-25 net: bridge: mcast: fix memcpy with u64_stats
       #    68800bbf583f26f71491141e4b3c8582f9cfcbde 2025-10-27 net: bridge: Flush multicast groups when snooping is disabled
       #    7de0eebbb4c3bb44c296f66679ad37480139dc6e 2025-08-15 net: bridge: remove unused argument of br_multicast_query_expired()
       #    d1547bf460baec718b3398365f8de33d25c5f36f 2025-08-14 net: bridge: fix soft lockup in br_multicast_query_expired()                                                                                                                                                               ~ 96476b043ef 2025-08-28                            ~ 5bf5fce8a0c 2025-08-28
    0> #    7544f3f5b0b58c396f374d060898b5939da31709 2025-06-23 bridge: mcast: Fix use-after-free during router port configuration                                                                           ~ b3186b0cc3c 2025-07-22  ~ b3186b0cc3c 2025-07-22                            ~ 4d3c2a1d4c7 2026-01-30  ~ f05a4f9e959 2025-07-06  = 7544f3f5b0b 2025-06-23
       #    41cb08555c4164996d67c78b3bf1c658075b75f1 2025-06-08 treewide, timers: Rename from_timer() to timer_container_of()                                                                                ~ 5ef8e209710 2025-11-05                                                                                                          = 41cb08555c4 2025-06-08
       #    367ed4e35734d6e7bce1dbca426a5bf150d76905 2025-05-08 treewide, timers: Rename try_to_del_timer_sync() as timer_delete_sync_try()                                                                                                                                                                                                    = 367ed4e3573 2025-05-08
    1> #    6c131043eaf1be2a6cc2d228f92ceb626fbcc0f3 2025-04-23 net: bridge: mcast: update multicast contex when vlan state is changed                                                                       ~ 4498c33a144 2025-07-22  ~ 4498c33a144 2025-07-22  ~ c5327af6e0e 2025-06-27  ~ cd97899361b 2025-06-27  ~ 7d5b9db370c 2025-06-27  = 6c131043eaf 2025-04-23
    2> #    4b30ae9adb047dd0a7982975ec3933c529537026 2025-04-23 net: bridge: mcast: re-implement br_multicast_{enable, disable}_port functions                                                               ~ c443c7bd541 2025-07-22  ~ c443c7bd541 2025-07-22  ~ c6d16eab122 2025-06-27  ~ b4c83b37490 2025-06-27  ~ c996e25df0b 2025-06-27  = 4b30ae9adb0 2025-04-23
       #    8fa7292fee5c5240402371ea89ab285ec856c916 2025-04-05 treewide: Switch/rename to timer_delete[_sync]()                                                                                                                                                                                                     = 8fa7292fee5 2025-04-05  = 8fa7292fee5 2025-04-05
       #    92c4ee25208d0f35dafc3213cdf355fbe449e078 2024-08-05 net: bridge: mcast: wait for previous gc cycles when removing port                                                 ~ e56d4cdd9af 2024-08-27  ~ e56d4cdd9af 2024-08-27  ~ e56d4cdd9af 2024-08-27  ~ 0d8b26e10e6 2024-08-14  ~ e3145ca904f 2024-08-14  = 92c4ee25208 2024-08-05  = 92c4ee25208 2024-08-05
       #    2947a4567f3a79127d2d540384e7f042106c1a24 2024-02-22 treewide: update LLVM Bugzilla links                                                                                                                                                                                                                 = 2947a4567f3 2024-02-22  = 2947a4567f3 2024-02-22
       #    f5c3eb4b7251baba5cd72c9e93920e710ac8194a 2024-01-30 bridge: mcast: fix disabled snooping after long uptime                                                             ~ 90d64eeb87b 2024-05-17  ~ 90d64eeb87b 2024-05-17  ~ 90d64eeb87b 2024-05-17  ~ 04a553d8ac1 2024-02-05  ~ d99971ec1b3 2024-02-05  = f5c3eb4b725 2024-01-30  = f5c3eb4b725 2024-01-30
       #    6d0259dd6c533e4ccc41b40075c1bdfd0f1efbd7 2023-10-27 bridge: mcast: Rename MDB entry get function                                                                       ~ 743df487561 2024-05-17  ~ 743df487561 2024-05-17  ~ 743df487561 2024-05-17                                                      = 6d0259dd6c5 2023-10-27  = 6d0259dd6c5 2023-10-27
       #    a1aee20d5db29dc73331067b6a338eb650f0b5f1 2023-02-06 net: bridge: Add netlink knobs for number / maximum MDB entries                          ~ 67a7e6210b4 2023-05-17  ~ 67a7e6210b4 2023-05-17  ~ 67a7e6210b4 2023-05-17  ~ 67a7e6210b4 2023-05-17                            = a1aee20d5db 2023-02-06  = a1aee20d5db 2023-02-06  = a1aee20d5db 2023-02-06
       #    b57e8d870d522d905720052e6fd9c3bc9bc5f6fb 2023-02-06 net: bridge: Maintain number of MDB entries in net_bridge_mcast_port                     ~ da251cef95a 2023-05-17  ~ da251cef95a 2023-05-17  ~ da251cef95a 2023-05-17  ~ da251cef95a 2023-05-17                            = b57e8d870d5 2023-02-06  = b57e8d870d5 2023-02-06  = b57e8d870d5 2023-02-06
       #    eceb30854f6b7d354ae52551b11aef2e2fa3e82e 2023-02-06 net: bridge: Change a cleanup in br_multicast_new_port_group() to goto                   ~ fa7bd1d6b9c 2023-05-17  ~ fa7bd1d6b9c 2023-05-17  ~ fa7bd1d6b9c 2023-05-17  ~ fa7bd1d6b9c 2023-05-17                            = eceb30854f6 2023-02-06  = eceb30854f6 2023-02-06  = eceb30854f6 2023-02-06
       #    976b3858dd14914c5a9254535ad7440c99467944 2023-02-06 net: bridge: Add br_multicast_del_port_group()                                           ~ e2c8560e461 2023-05-17  ~ e2c8560e461 2023-05-17  ~ e2c8560e461 2023-05-17  ~ e2c8560e461 2023-05-17                            = 976b3858dd1 2023-02-06  = 976b3858dd1 2023-02-06  = 976b3858dd1 2023-02-06
       #    1c85b80b20a13d07ec3a7d746ad52b7972c8c730 2023-02-06 net: bridge: Move extack-setting to br_multicast_new_port_group()                        ~ 70bdf0834aa 2023-05-17  ~ 70bdf0834aa 2023-05-17  ~ 70bdf0834aa 2023-05-17  ~ 70bdf0834aa 2023-05-17                            = 1c85b80b20a 2023-02-06  = 1c85b80b20a 2023-02-06  = 1c85b80b20a 2023-02-06
       #    60977a0c63373bfc596b562b1e34e64ede6ef492 2023-02-06 net: bridge: Add extack to br_multicast_new_port_group()                                 ~ 95b6cfb7d00 2023-05-17  ~ 95b6cfb7d00 2023-05-17  ~ 95b6cfb7d00 2023-05-17  ~ 95b6cfb7d00 2023-05-17                            = 60977a0c633 2023-02-06  = 60977a0c633 2023-02-06  = 60977a0c633 2023-02-06
       #    292a089d78d3e2f7944e60bb897c977785a321e3 2022-12-25 treewide: Convert del_timer*() to timer_shutdown*()                                      ~ c442caf155a 2023-05-11  ~ c442caf155a 2023-05-11  ~ c442caf155a 2023-05-11  ~ c442caf155a 2023-05-11                            = 292a089d78d 2022-12-25  = 292a089d78d 2022-12-25  = 292a089d78d 2022-12-25
                                                                                                                                                         ~ 30247fa579f 2023-05-08  ~ 30247fa579f 2023-05-08  ~ 30247fa579f 2023-05-08  ~ 30247fa579f 2023-05-08
       #    a01ecb1712ddbcd41360ad0c554b460adbac0528 2022-12-12 bridge: mcast: Add a flag for user installed source entries                              ~ 0a9858b76b9 2023-05-11  ~ 0a9858b76b9 2023-05-11  ~ 0a9858b76b9 2023-05-11  ~ 0a9858b76b9 2023-05-11                            = a01ecb1712d 2022-12-12  = a01ecb1712d 2022-12-12  = a01ecb1712d 2022-12-12
       #    083e353482b4c9b727846643ad6ca7b784dd486b 2022-12-12 bridge: mcast: Expose __br_multicast_del_group_src()                                     ~ 9d2959c3549 2023-05-11  ~ 9d2959c3549 2023-05-11  ~ 9d2959c3549 2023-05-11  ~ 9d2959c3549 2023-05-11                            = 083e353482b 2022-12-12  = 083e353482b 2022-12-12  = 083e353482b 2022-12-12
       #    fd0c696164cf13ae0128f14209e2dbfcd86584b8 2022-12-12 bridge: mcast: Expose br_multicast_new_group_src()                                       ~ f74c439eb12 2023-05-11  ~ f74c439eb12 2023-05-11  ~ f74c439eb12 2023-05-11  ~ f74c439eb12 2023-05-11                            = fd0c696164c 2022-12-12  = fd0c696164c 2022-12-12  = fd0c696164c 2022-12-12
       #    f86c3e2c1b5ea5c959ef176541c2f831231fa631 2022-12-07 bridge: mcast: Constify 'group' argument in br_multicast_new_port_group()                ~ ad2a0e6722b 2023-05-11  ~ ad2a0e6722b 2023-05-11  ~ ad2a0e6722b 2023-05-11  ~ ad2a0e6722b 2023-05-11                            = f86c3e2c1b5 2022-12-07  = f86c3e2c1b5 2022-12-07  = f86c3e2c1b5 2022-12-07
       #    d120d1a63b2c484d6175873d8ee736a633f74b70 2022-10-28 net: Remove the obsolte u64_stats_fetch_*_irq() users (net).                             ~ 1cb324e3ccd 2023-06-08  ~ 1cb324e3ccd 2023-06-08  ~ 1cb324e3ccd 2023-06-08  ~ 1cb324e3ccd 2023-06-08                            = d120d1a63b2 2022-10-28  = d120d1a63b2 2022-10-28  = d120d1a63b2 2022-10-28
       #    262985fad1bd819d1323c6dbd72a8d9ed1c6090c 2022-10-19 bridge: mcast: Use spin_lock() instead of spin_lock_bh()                                 ~ 624f8507962 2023-05-11  ~ 624f8507962 2023-05-11  ~ 624f8507962 2023-05-11  ~ 624f8507962 2023-05-11                            = 262985fad1b 2022-10-19  = 262985fad1b 2022-10-19  = 262985fad1b 2022-10-19
       #    c832962ac972082b3a1f89775c9d4274c8cb5670 2022-02-16 net: bridge: multicast: notify switchdev driver whenever MC processing gets disabled     ~ 2e7fec660b5 2022-05-04  ~ 2e7fec660b5 2022-05-04  ~ 2e7fec660b5 2022-05-04  ~ 2e7fec660b5 2022-05-04  = c832962ac97 2022-02-16  = c832962ac97 2022-02-16  = c832962ac97 2022-02-16  = c832962ac97 2022-02-16
       #    f83a112bd91a494cdee671aec74e777470fb4a07 2021-12-29 net: bridge: mcast: add and enforce startup query interval minimum                       ~ d2141be2601 2022-01-05  ~ d2141be2601 2022-01-05  ~ d2141be2601 2022-01-05  ~ d2141be2601 2022-01-05  = f83a112bd91 2021-12-29  = f83a112bd91 2021-12-29  = f83a112bd91 2021-12-29  = f83a112bd91 2021-12-29
       #    99b40610956a8a8755653a67392e2a8b772453be 2021-12-29 net: bridge: mcast: add and enforce query interval minimum                               ~ f4d0eb3c8d4 2022-01-05  ~ f4d0eb3c8d4 2022-01-05  ~ f4d0eb3c8d4 2022-01-05  ~ f4d0eb3c8d4 2022-01-05  = 99b40610956 2021-12-29  = 99b40610956 2021-12-29  = 99b40610956 2021-12-29  = 99b40610956 2021-12-29
       #    f936bb42aeb94a069bec7c9e04100d199c372956 2021-09-28 net: bridge: mcast: Associate the seqcount with its protecting lock.                     ~ 3f80abc59ab 2022-01-05  ~ 3f80abc59ab 2022-01-05  ~ 3f80abc59ab 2022-01-05  ~ 3f80abc59ab 2022-01-05  = f936bb42aeb 2021-09-28  = f936bb42aeb 2021-09-28  = f936bb42aeb 2021-09-28  = f936bb42aeb 2021-09-28
       #    ddd0d5293810c1882e2a96f8cce1678823b1dd38 2021-09-03 net: bridge: mcast: fix vlan port router deadlock                                        ~ c9c281210cb 2022-01-05  ~ c9c281210cb 2022-01-05  ~ c9c281210cb 2022-01-05  ~ c9c281210cb 2022-01-05  = ddd0d529381 2021-09-03  = ddd0d529381 2021-09-03  = ddd0d529381 2021-09-03  = ddd0d529381 2021-09-03
       #    6baeb3951c271cff30828c4763fa1362da56454a 2021-08-31 net: bridge: use mld2r_ngrec instead of icmpv6_dataun                                    ~ b2bb0ecf791 2022-01-05  ~ b2bb0ecf791 2022-01-05  ~ b2bb0ecf791 2022-01-05  ~ b2bb0ecf791 2022-01-05  = 6baeb3951c2 2021-08-31  = 6baeb3951c2 2021-08-31  = 6baeb3951c2 2021-08-31  = 6baeb3951c2 2021-08-31
    3> #    2796d846d74a18cc6563e96eff8bf28c5e06f912 2021-08-20 net: bridge: vlan: convert mcast router global option to per-vlan entry                  ~ f5b0bea501c 2022-01-05  ~ f5b0bea501c 2022-01-05  ~ f5b0bea501c 2022-01-05  ~ f5b0bea501c 2022-01-05  = 2796d846d74 2021-08-20  = 2796d846d74 2021-08-20  = 2796d846d74 2021-08-20  = 2796d846d74 2021-08-20
       #    a53581d5559eaacaac1b4aed8e2f22c40efa5acc 2021-08-20 net: bridge: mcast: br_multicast_set_port_router takes multicast context as argument     ~ 770192b6df3 2022-01-05  ~ 770192b6df3 2022-01-05  ~ 770192b6df3 2022-01-05  ~ 770192b6df3 2022-01-05  = a53581d5559 2021-08-20  = a53581d5559 2021-08-20  = a53581d5559 2021-08-20  = a53581d5559 2021-08-20
       #    affce9a774ca2514aaa5638fde92c57a476dfd79 2021-08-17 net: bridge: mcast: toggle also host vlan state in br_multicast_toggle_vlan              ~ 51477574398 2022-01-05  ~ 51477574398 2022-01-05  ~ 51477574398 2022-01-05  ~ 51477574398 2022-01-05  = affce9a774c 2021-08-17  = affce9a774c 2021-08-17  = affce9a774c 2021-08-17  = affce9a774c 2021-08-17

The fix in this PR basically syncs the `net/bridge/br_multicast.c` file with `rocky9_7`.


## CVE-2025-39933

    smb: client: let recv_done verify data_offset, data_length and remaining_data_length
    
    jira VULN-161396
    cve CVE-2025-39933
    commit-author Stefan Metzmacher <metze@samba.org>
    commit f57e53ea252363234f86674db475839e5b87102e
    upstream-diff |
      - Ignored the extraction of `sc->parameters' into the local variable
        `sp'. In the upstream it was only needed to get
        `max_fragmented_recv_size', which in ciqlts9_6 can be found in the
        `smbd_connection' struct, saved in the `info' variable. Used direct
        access `info->max_fragmented_recv_size' where needed. (On upstream the
        field was moved to `smbdirect_socket_parameters' struct in the
        non-backported commit cc55f65dd352bdb7bdf8db1c36fb348c294c3b66 ("smb:
        client: make use of common smbdirect_socket_parameters")).
      - The offset of `padding' is calculated for the `smbd_data_transfer'
        struct instead of `smbdirect_data_transfer'. Smenatically it's the
        same struct, just renamed (introduced in
        00fab6cf323fa5850e6cbe283b23e605e6e97912 ("smb: smbdirect: add
        smbdirect_pdu.h with protocol definitions"), swapped with
        `smbd_data_transfer' in 64946d5be665ddac6b5bf11f5b5ff319aae0f4c6
        ("smb: client: make use of common smbdirect_pdu.h"))

Changing the type of local variable `data_length` from `int` to `u32` may raise suspicion, but it doesn't influence the logic of code existing before this patch. Apart from conditionals it's only used as the argument in `enqueue_reassembly()` call accepting it as `int`. Upstream body of the modified function also passes this variable to `enqueue_reassembly()` and its signature is the same as in `ciqlts9_6`, so - assuming the upstream code is correct in this regard - the backported version should be correct as well.


## CVE-2025-38730

0:

    io_uring/net: commit partial buffers on retry
    
    jira VULN-163643
    cve CVE-2025-38730
    commit-author Jens Axboe <axboe@kernel.dk>
    commit 41b70df5b38bc80967d2e0ed55cc3c3896bba781
    upstream-diff |
      - In the `io_net_kbuf_recyle()' function
        - Used `-EAGAIN' as the return value instead of `IOU_RETRY', which was
          defined in the upstream as `-EAGAIN' anyway (see non-backported
          7a9dcb05f5501b07a2ef7d0ef743f4f17e9f3055 ("io_uring: return -EAGAIN
          to continue multishot")).
        - Omitted the `len' argument in the `io_kbuf_commit()' call. The
          upstream patch uses the extended version of this function, defined
          in ae98dbf43d755b4e111fcd086e53939bef3e9a1a ("io_uring/kbuf: add
          support for incremental buffer consumption"), which was compound
          with the introduction of new feature. Original version is enough for
          this patch - see the solution of CVE-2025-38730 in rocky9_7.
      - Resolved conflict in the `io_recvmsg()' function where `return
        IOU_RETRY' was expected instead of `return -EAGAIN'.

1:

    io_uring/kbuf: add io_kbuf_commit() helper
    
    jira VULN-163643
    cve-pre CVE-2025-38730
    commit-author Jens Axboe <axboe@kernel.dk>
    commit ecd5c9b29643f383d39320e30d21b8615bd893da

2:

    io_uring/kbuf: use 'bl' directly rather than req->buf_list
    
    jira VULN-163643
    cve-pre CVE-2025-38730
    commit-author Jens Axboe <axboe@kernel.dk>
    commit 03e02e8f95fee0f45124976993ed2121e2369a12

While this prerequisite wasn't strictly necessary (the change is overwriteen by the next commit anyway), it allowed for clean cherry picks.

This solution is identical to what can be found in `rocky9_7`. Consider the comparative history of relevant files in `ciqlts9_6` and `rocky9_7` (ellipsis `[...]` hide parts of history which are the same for both):

       Label    File
       -------  ---------------
       A        io_uring/kbuf.c
       B        io_uring/kbuf.h
       C        io_uring/net.c
       
       INFO:common:gitHistoriesCommand: Preparing the timeline table
       ABC    kernel-mainline                                                                                                                 ciqlts9_6                 rocky9_7
       -----  ------------------------------------------------------------------------------------------------------------------------------  ------------------------  ------------------------
       #--    418eab7a6f3c002d8e64d6e95ec27118017019af 2026-03-19 io_uring/kbuf: propagate BUF_MORE through early buffer commit path
       #--    3ecd3e03144b38a21a3b70254f1b9d2e16629b09 2026-03-19 io_uring/kbuf: fix missing BUF_MORE for incremental buffers at EOF
       #--    c2c185be5c85d37215397c8e8781abf0a69bec1f 2026-03-12 io_uring/kbuf: check if target buffer list is still legacy on recycle
       --#    c36e28becd0586ac98318fd335e5e91d19cd2623 2026-03-02 io_uring/net: reject SEND_VECTORIZED when unsupported
       #--    bf4afc53b77aeaa48b5409da5c8da6bb4eff7f43 2026-02-21 Convert 'alloc_obj' family to use the new default GFP_KERNEL argument
       #--    69050f8d6d075dc01af7a5f2f550a8067510366f 2026-02-21 treewide: Replace kmalloc with kmalloc_obj for non-scalar types
       #--    42a6bd57ee9f930a72c26f863c72f666d6ed9ea5 2026-02-19 io_uring: add IORING_OP_URING_CMD128 to opcode checks
       --#    046fcc83ac1ba8747f0bcae13f5e433802735245 2026-02-16 io_uring: remove unneeded io_send_zc accounting
       #--    442ae406603a94f1a263654494f425302ceb0445 2026-02-05 io_uring/kbuf: fix memory leak if io_buffer_add_list fails
       --#    806ae939c41e5da1d94a1e2b31f5702e96b6c3e3 2026-01-27 io_uring/net: don't continue send bundle if poll was required for retry
       --#    cff1c26b4223820431129696b45525e5928e6409 2026-01-27 io_uring/net: allow filtering on IORING_OP_SOCKET data
       #--    a4c694bfc2455e82b7caf6045ca893d123e0ed11 2025-12-05 io_uring/kbuf: use WRITE_ONCE() for userspace-shared buffer ring fields
       #--    78385c7299f7514697d196b3233a91bd5e485591 2025-12-04 io_uring/kbuf: use READ_ONCE() for userspace-mapped memory
       --#    f6041803a831266a2a5a5b5af66f7de0845bcbf3 2025-11-24 io_uring/net: ensure vectored buffer node import is tied to notification
       -#-    84692a1519b32d61ff882cf24a9eda900961acad 2025-11-20 io_uring/kbuf: remove obsolete buf_nr_pages and update comments
       --#    1b8b5d0316da7468ae4d40f6c2102d559d9e3ca2 2025-11-13 io_uring/zcrx: elide passing msg flags
       #--    1fa7a34131110e3c41a13b19127da132dea32dcd 2025-11-06 io_uring/memmap: refactor io_free_region() to take user_struct param
       #--    6f1cbf6d6fd13fc169dde14e865897924cdc4bbd 2025-10-23 io_uring: fix buffer auto-commit for multishot uring_cmd
       --#    915651b7c9473fd23d0e56fe227a97eda483cf7c 2025-10-22 io_uring: Fix code indentation error
       #--    dec10a1ad1d5f9d46e7f6e7c8b414a805e00717c 2025-10-20 io_uring/kbuf: use io_create_region for kbuf creation
       --#    5d4c52bfa8cdc1dc1ff701246e662be3f43a3fe1 2025-09-08 io_uring: don't include filetable.h in io_uring.h
       --#    37500634d0a8f931e15879760fb70f9b6f5d5370 2025-09-02 io_uring/net: correct type for min_not_zero() cast
       #--    98b6fa62c84f2e129161e976a5b9b3cb4ccd117b 2025-08-28 io_uring/kbuf: always use READ_ONCE() to read ring provided buffer lengths
       --#    4c0b26e23c79ecf934a92b2d9a516bffbb61c3e4 2025-08-27 io_uring: add async data clear/free helpers
       #--    c64eff368ac676e8540344d27a3de47e0ad90d21 2025-08-27 io_uring/kbuf: fix signedness in this_len calculation
       -#-    d589bcddaa3f8b1668499c3f0466863df3abe37a 2025-08-24 io-uring: move `struct io_br_sel` into io_uring_types.h
       -#-    fe524b06843c19cf8d0025b644d56c4c31e60bc9 2025-08-24 io_uring/kbuf: check for ring provided buffers first in recycling
       ###    5fda51255439addd1c9059098e30847a375a1008 2025-08-24 io_uring/kbuf: switch to storing struct io_buffer_list locally
       --#    461382a51fb83a9c4b7c50e1f10d3ca94edff25e 2025-08-24 io_uring/net: use struct io_br_sel->val as the send finish value
       --#    58d815091890e83aa2f83a9cce1fdfe3af02c7b4 2025-08-24 io_uring/net: use struct io_br_sel->val as the recv finish value
       ###    429884ff35f75a8ac3e8f822f483e220e3ea6394 2025-08-24 io_uring/kbuf: use struct io_br_sel for multiple buffers picking
       ###    ab6559bdbb08f6bee606435cd014fc5ba0f7b750 2025-08-24 io_uring/kbuf: introduce struct io_br_sel
       ###    1b5add75d7c894c62506c9b55f1d9eaadae50ef1 2025-08-24 io_uring/kbuf: pass in struct io_buffer_list to commit/recycle helpers
       --#    b22743f29b7d3dc68c68f9bd39a1b2600ec6434e 2025-08-24 io_uring/net: clarify io_recv_buf_select() return value
       --#    15ba5e51e689ceb1c2e921c5180a70c88cfdc8e9 2025-08-24 io_uring/net: don't use io_net_kbuf_recyle() for non-provided cases
       -##    5e73b402cbbea51bcab90fc5ee6c6d06af76ae1b 2025-08-24 io_uring/kbuf: drop 'issue_flags' from io_put_kbuf(s)() arguments
    0> --#    41b70df5b38bc80967d2e0ed55cc3c3896bba781 2025-08-12 io_uring/net: commit partial buffers on retry                                                         # 03845562c1a 2026-02-12
       --#    6f02527729bd31ca4e473bff19fda4ccd5889148 2025-07-30 io_uring/net: Allow to do vectorized send
       --#    c7cafd5b81cc07fb402e3068d134c21e60ea688c 2025-07-16 io_uring/poll: fix POLLERR handling
              [...]
       --#    51c967c6c9ea6c4d480e4778ace5243db22aa27b 2024-10-29 io_uring/net: move send zc fixed buffer import to issue path
       --#    1caa00d6b61651e04c04c2b50b3e149f24c6764d 2024-10-29 io_uring: remove 'issue_flags' argument for io_req_set_rsrc_node()
       --#    c314094cb4cfa6fc5a17f4881ead2dfebfa717a7 2024-09-30 io_uring/net: harden multishot termination case for recv                    ~ 192d6b9fca7 2024-12-02  ~ 192d6b9fca7 2024-12-02
       #--    f274495aea7b15225b3d83837121b22ef96e560c 2024-08-30 io_uring/kbuf: return correct iovec count from classic buffer peek          ~ 5663e997724 2024-12-02  ~ 5663e997724 2024-12-02
       ##-    ae98dbf43d755b4e111fcd086e53939bef3e9a1a 2024-08-29 io_uring/kbuf: add support for incremental buffer consumption
       ###    6733e678ba1226ad0df94f0bb095df121c54d701 2024-08-29 io_uring/kbuf: pass in 'len' argument for buffer commit
       --#    641a6816795b208aa7ccac751acaae580897db10 2024-08-29 Revert "io_uring: Require zeroed sqe->len on provided-buffers send"
       ##-    2c8fa70bf3e981193ecda0eedf2100f933ef7085 2024-08-29 io_uring/kbuf: move io_ring_head_to_buf() to kbuf.h
    1> ##-    ecd5c9b29643f383d39320e30d21b8615bd893da 2024-08-29 io_uring/kbuf: add io_kbuf_commit() helper                                                            ~ 76469aa0411 2026-02-12
       -#-    120443321dfaaab8eb9290af617abcc37734c1e2 2024-08-25 io_uring/kbuf: shrink nr_iovs/mode in struct buf_sel_arg
       ##-    a69307a55454060b5795e68d249157f2961049c2 2024-08-25 io_uring/kbuf: turn io_buffer_list booleans into flags
       --#    566a424212d79b90e3a8fe6b5c7bd8f69174105c 2024-08-25 io_uring/net: use ITER_UBUF for single segment send maps
    2> #--    03e02e8f95fee0f45124976993ed2121e2369a12 2024-08-25 io_uring/kbuf: use 'bl' directly rather than req->buf_list                                            ~ 52538f50909 2026-02-12
       #--    e0ee967630c8ee67bb47a5b38d235cd5a8789c48 2024-08-21 io_uring/kbuf: sanitize peek buffer setup                                   ~ 64604cf7d59 2024-12-02  ~ 64604cf7d59 2024-12-02
       --#    8fe8ac24adcd76b12edbfdefa078567bfff117d4 2024-08-07 io_uring/net: don't pick multiple buffers for non-bundle send               ~ c1986a7572c 2024-12-02  ~ c1986a7572c 2024-12-02
       --#    70ed519ed59da3a92c3acedeb84a30e5a66051ce 2024-08-07 io_uring/net: ensure expanded bundle send gets marked for cleanup           ~ 5dfd23310f7 2024-12-02  ~ 5dfd23310f7 2024-12-02
       --#    11893e144ed75be55d99349760513ca104781fc0 2024-08-07 io_uring/net: ensure expanded bundle recv gets marked for cleanup           ~ 7f6552b1f1a 2024-12-02  ~ 7f6552b1f1a 2024-12-02
       #--    bcc87d978b834c298bbdd9c52454c5d0a946e97e 2024-07-20 io_uring: fix error pbuf checking                                           ~ 95babcb3db0 2024-12-02  ~ 95babcb3db0 2024-12-02
       --#    ad00e629145b2b9f0d78aa46e204a9df7d628978 2024-07-13 io_uring/net: check socket is valid in io_bind()/io_listen()
       --#    93d8032f4143c8d2ac3e10c6504385c26acc511f 2024-07-02 io_uring/net: cleanup io_recv_finish() bundle handling
       --#    6e92c646f5a4230d939a0882f879fc50dfa116c5 2024-07-02 io_uring/net: don't clear msg_inq before io_recv_buf_select() needs it      ~ c78661e6f0c 2024-12-02  ~ c78661e6f0c 2024-12-02
       --#    060f4ba6e40338a70932603a3564903acf5f5734 2024-07-02 io_uring/net: move charging socket out of zc io_uring
       --#    ff140cc8628abfb1755691d16cfa8788d8820ef7 2024-06-19 io_uring: Introduce IORING_OP_LISTEN
       --#    7481fd93fa0a851740e26026485f56a1305454ce 2024-06-19 io_uring: Introduce IORING_OP_BIND
       --#    18414a4a2eabb0281d12d374c92874327e0e3fe3 2024-05-30 io_uring/net: assign kmsg inq/flags before buffer selection                 ~ ade423a5e6a 2024-12-02  ~ ade423a5e6a 2024-12-02
       --#    ac287da2e0ea5be2523222981efec86f0ca977cd 2024-05-13 io_uring/net: wire up IORING_CQE_F_SOCK_NONEMPTY for accept                 ~ 12e997c3e61 2024-12-02  ~ 12e997c3e61 2024-12-02
       --#    0645fbe760afcc5332c858d1cbf416bf77ef3c29 2024-05-13 net: have do_accept() take a struct proto_accept_arg argument               ~ 8ba710b1a79 2024-12-02  ~ 8ba710b1a79 2024-12-02
       --#    d3da8e98592693811c14c31f05380f378411fea1 2024-05-09 io_uring/net: add IORING_ACCEPT_POLL_FIRST flag                             ~ aa0b488ee2c 2024-11-28  ~ aa0b488ee2c 2024-11-28
       --#    7dcc758cca432510f77b2fe1077be2314bc3785b 2024-05-09 io_uring/net: add IORING_ACCEPT_DONTWAIT flag                               ~ 2ba805570e0 2024-11-28  ~ 2ba805570e0 2024-11-28
       --#    79996b45f7b28c0e3e08a95bab80119e95317e28 2024-05-01 io_uring: Require zeroed sqe->len on provided-buffers send
              [...]
       --#    f9ead18c10589a351f395ac5aa107360f2f6ce53 2022-07-24 io_uring: split network related opcodes into its own file                   ~ 38ad21ddaf9 2023-04-29  ~ 38ad21ddaf9 2023-04-29

With this fix the gaps are filled and the three files are identical in both versions.


### The `io_kbuf_commit()` function

In the upsteram fix 41b70df5b38bc80967d2e0ed55cc3c3896bba781 the newly introduced function `io_net_kbuf_recyle()` uses `io_kbuf_commit()` which is considerably different from when it was introduced in ecd5c9b29643f383d39320e30d21b8615bd893da - the version used in this solution. Compare the PR's:

<https://github.com/ctrliq/kernel-src-tree/blob/ecd5c9b29643f383d39320e30d21b8615bd893da/io_uring/kbuf.h#L124-L131>

with the version used by upstream:

<https://github.com/ctrliq/kernel-src-tree/blob/5d3e51240d89678b87b5dc6987ea572048a0f0eb/io_uring/kbuf.c#L35-L61>

The full timeline of `io_kbuf_commit()` function definition is:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-right" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-right">1</td>
<td class="org-left">ecd5c9b29643f383d39320e30d21b8615bd893da</td>
<td class="org-left">Introduction</td>
</tr>


<tr>
<td class="org-right">2</td>
<td class="org-left">6733e678ba1226ad0df94f0bb095df121c54d701</td>
<td class="org-left">Addition of an unused (yet) `len` argument</td>
</tr>


<tr>
<td class="org-right">3</td>
<td class="org-left">ae98dbf43d755b4e111fcd086e53939bef3e9a1a</td>
<td class="org-left">Logic extension</td>
</tr>


<tr>
<td class="org-right">4</td>
<td class="org-left">5d3e51240d89678b87b5dc6987ea572048a0f0eb</td>
<td class="org-left">Transfer from the header file to the `.c` file</td>
</tr>
</tbody>
</table>

This may raise the question about the validity of using `io_kbuf_commit()` from ecd5c9b29643f383d39320e30d21b8615bd893da instead of 5d3e51240d89678b87b5dc6987ea572048a0f0eb.

From the `ciqlts9_6`'s perspective there is no difference, because the only logical change in ae98dbf43d755b4e111fcd086e53939bef3e9a1a boils down to

1.  checking the `len` argument,
2.  branching in case of `IOBL_INC` flag being set,
3.  returning `bool` instead of `void`,

and (1) and (3) are only really a consequence of (2). The `IOBL_INC` flag was only introduced in the very same commit which extended `io_kbuf_commit()` functionality - `io_uring/kbuf: add support for incremental buffer consumption` - which was not backported to `ciqlts9_6` and therefore the conditional `bl->flags & IOBL_INC` for the introduced branch could not be true in this version anyway.


## CVE-2025-38415

    squashfs: fix memory leak in squashfs_fill_super
    
    jira VULN-163295
    cve-bf CVE-2025-38415
    commit-author Phillip Lougher <phillip@squashfs.org.uk>
    commit b64700d41bdc4e9f82f1346c15a3678ebb91a89c
    upstream-diff Had to maneuver around the code deleted in the non-
      backported commit 0c12185728d602c27cd12a845249e7f37197f71f ('Revert
      "squashfs: provide backing_dev_info in order to disable read-ahead"')

>

    Squashfs: check return result of sb_min_blocksize
    
    jira VULN-163295
    cve CVE-2025-38415
    commit-author Phillip Lougher <phillip@squashfs.org.uk>
    commit 734aa85390ea693bb7eaf2240623d41b03705c84


# kABI check: passed

    ninja: Entering directory `/data/build/rocky-patching-haskell'
    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts9_6-CVE-batch-29]	_kabi_check_kernel__x86_64--test--ciqlts9_6-CVE-batch-29
    ninja explain: output state/kernels/ciqlts9_6-CVE-batch-29/x86_64/kabi_checked older than most recent input state/kernels/ciqlts9_6-CVE-batch-29/x86_64/compiled (1777490989710869835 vs 1777505205056454469)
    ninja explain: state/kernels/ciqlts9_6-CVE-batch-29/x86_64/kabi_checked is dirty
    + dist_git_version=el-9.6
    + local_version=ciqlts9_6-CVE-batch-29
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts9_6
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-9.6
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts9_6-CVE-batch-29
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-9.6/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts9_6 ''\''/mnt/code/kernel-dist-git-el-9.6/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-9.6/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts9_6-CVE-batch-29/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts9_6-CVE-batch-29/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/27253475/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_6&#x2013;run1.log](<https://github.com/user-attachments/files/27253476/kselftests--ciqlts9_6--run1.log>)
[kselftests&#x2013;ciqlts9\_6&#x2013;run2.log](<https://github.com/user-attachments/files/27253479/kselftests--ciqlts9_6--run2.log>)


## Patch

[kselftests&#x2013;ciqlts9\_6-CVE-batch-29&#x2013;run1.log](<https://github.com/user-attachments/files/27253486/kselftests--ciqlts9_6-CVE-batch-29--run1.log>)
[kselftests&#x2013;ciqlts9\_6-CVE-batch-29&#x2013;run2.log](<https://github.com/user-attachments/files/27253487/kselftests--ciqlts9_6-CVE-batch-29--run2.log>)


## Comparison

There is one test having different results - `kvm:memslot_perf_test` - but it's for the patch's advantage.

    $ ktests.xsh diff --where-diff kselftests*.log

    Column    File
    --------  --------------------------------------------
    Status0   kselftests--ciqlts9_6--run1.log
    Status1   kselftests--ciqlts9_6--run2.log
    Status2   kselftests--ciqlts9_6-CVE-batch-29--run1.log
    Status3   kselftests--ciqlts9_6-CVE-batch-29--run2.log
    
    TestCase               Status0  Status1  Status2  Status3  Summary
    kvm:memslot_perf_test  fail     fail     pass     fail     diff

[selftests-full-results.txt](<https://github.com/user-attachments/files/27253759/selftests-full-results.txt>)

