### PR TITLE
chore(ci): bump GitHub Actions off Node 20 runtimes

### DIFF
--- a/.github/workflows/clk-rebase.yml
+++ b/.github/workflows/clk-rebase.yml
@@ -30,9 +30,9 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: |
             kernel-src-tree

--- a/.github/workflows/clk-rebase.yml
+++ b/.github/workflows/clk-rebase.yml
@@ -56,7 +56,7 @@ jobs:
           dnf install -y git python3-GitPython
 
       - name: Checkout kernel-src-tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ctrliq/kernel-src-tree
           token: ${{ steps.generate-token.outputs.token }}
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: true
 
       - name: Checkout kernel-src-tree-tools
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ctrliq/kernel-src-tree-tools
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
@@ -229,7 +229,7 @@ jobs:
           fi
 
       - name: Upload check results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()  # Upload even if checks fail
         with:
           name: check-results

--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Download check results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: check-results
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload head_ref for baseline search
         if: steps.pr_metadata.outputs.skip_ci != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: head-ref
           path: pr_metadata/head_ref.txt
@@ -267,7 +267,7 @@ jobs:
           kernel-container-build
 
     - name: Checkout kernel source
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 1
         path: kernel-src-tree
@@ -281,7 +281,7 @@ jobs:
         git checkout -b "$HEAD_REF"
 
     - name: Checkout kernel-container-build
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
         ref: main
@@ -338,7 +338,7 @@ jobs:
 
     # Upload kernel compilation logs
     - name: Upload kernel compilation logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: kernel-compilation-logs-${{ matrix.arch }}
@@ -347,7 +347,7 @@ jobs:
 
     # Upload kselftests qcow2 image
     - name: Upload kselftests qcow2 image
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: ${{ always() && needs.pre-setup.outputs.skip_kselftests == 'false' }}
       with:
         name: kernel-qcow2-kselftests-${{ matrix.arch }}
@@ -358,7 +358,7 @@ jobs:
 
     # Upload LTP qcow2 image
     - name: Upload LTP qcow2 image
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: ${{ always() && needs.pre-setup.outputs.skip_ltp == 'false' }}
       with:
         name: kernel-qcow2-ltp-${{ matrix.arch }}
@@ -370,7 +370,7 @@ jobs:
 
     # Upload plain boot qcow2 image (only when both kselftests and LTP are skipped)
     - name: Upload plain boot qcow2 image
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: ${{ always() && needs.pre-setup.outputs.skip_kselftests == 'true' && needs.pre-setup.outputs.skip_ltp == 'true' }}
       with:
         name: kernel-qcow2-boot-${{ matrix.arch }}
@@ -398,7 +398,7 @@ jobs:
           kernel-container-build
 
     - name: Checkout kernel-container-build
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
         ref: main
@@ -417,21 +417,21 @@ jobs:
 
     - name: Download qcow2 image (kselftests)
       if: ${{ needs.pre-setup.outputs.skip_kselftests == 'false' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kernel-qcow2-kselftests-${{ matrix.arch }}
         path: output
 
     - name: Download qcow2 image (LTP — kselftests skipped)
       if: ${{ needs.pre-setup.outputs.skip_kselftests == 'true' && needs.pre-setup.outputs.skip_ltp == 'false' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kernel-qcow2-ltp-${{ matrix.arch }}
         path: output
 
     - name: Download qcow2 image (plain boot — both skipped)
       if: ${{ needs.pre-setup.outputs.skip_kselftests == 'true' && needs.pre-setup.outputs.skip_ltp == 'true' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kernel-qcow2-boot-${{ matrix.arch }}
         path: output
@@ -453,7 +453,7 @@ jobs:
 
     # Upload boot logs
     - name: Upload boot logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: boot-logs-${{ matrix.arch }}
@@ -480,7 +480,7 @@ jobs:
           kernel-container-build
 
     - name: Checkout kernel-container-build
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
         ref: main
@@ -498,7 +498,7 @@ jobs:
         fi
 
     - name: Download qcow2 image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kernel-qcow2-kselftests-${{ matrix.arch }}
         path: output
@@ -520,7 +520,7 @@ jobs:
 
     # Upload kselftest logs
     - name: Upload kselftest logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: kselftest-logs-${{ matrix.arch }}
@@ -550,7 +550,7 @@ jobs:
           kernel-container-build
 
     - name: Checkout kernel-container-build
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
         ref: main
@@ -568,7 +568,7 @@ jobs:
         fi
 
     - name: Download qcow2 image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kernel-qcow2-ltp-${{ matrix.arch }}
         path: output
@@ -600,7 +600,7 @@ jobs:
         fi
 
     - name: Upload LTP logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: always()
       with:
         name: ltp-logs-${{ matrix.arch }}
@@ -634,7 +634,7 @@ jobs:
 
     steps:
     - name: Checkout kernel source
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 1
 
@@ -648,7 +648,7 @@ jobs:
           kernel-container-build
 
     - name: Checkout kernel-container-build
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
         ref: main
@@ -673,7 +673,7 @@ jobs:
 
     - name: Download current LTP results
       if: needs.test-ltp.result == 'success'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: ltp-logs-${{ matrix.arch }}
         path: output-current
@@ -862,14 +862,14 @@ jobs:
 
     steps:
     - name: Checkout kernel source
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 1  # Shallow clone - only current commit needed for comparison logic
         ref: ${{ needs.pre-setup.outputs.pr_number != '0' && format('refs/pull/{0}/head', needs.pre-setup.outputs.pr_number) || needs.pre-setup.outputs.head_sha }}
 
     - name: Download current kselftest logs
       if: ${{ needs.pre-setup.outputs.skip_kselftests == 'false' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kselftest-logs-${{ matrix.arch }}
         path: output-current
@@ -1227,7 +1227,7 @@ jobs:
         echo "All test stages passed and no regressions detected, proceeding with PR creation"
 
     - name: Checkout kernel source
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 100  # Fetch more history for commit counting
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -1275,42 +1275,42 @@ jobs:
 
     - name: Download kernel compilation logs (x86_64)
       if: steps.detect_arch.outputs.has_x86_64 == 'true'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kernel-compilation-logs-x86_64
         path: artifacts/build/x86_64
 
     - name: Download kernel compilation logs (aarch64)
       if: steps.detect_arch.outputs.has_aarch64 == 'true'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kernel-compilation-logs-aarch64
         path: artifacts/build/aarch64
 
     - name: Download boot logs (x86_64)
       if: steps.detect_arch.outputs.has_x86_64 == 'true'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: boot-logs-x86_64
         path: artifacts/boot/x86_64
 
     - name: Download boot logs (aarch64)
       if: steps.detect_arch.outputs.has_aarch64 == 'true'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: boot-logs-aarch64
         path: artifacts/boot/aarch64
 
     - name: Download kselftest logs (x86_64)
       if: steps.detect_arch.outputs.has_x86_64 == 'true' && needs.pre-setup.outputs.skip_kselftests == 'false'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kselftest-logs-x86_64
         path: artifacts/test/x86_64
 
     - name: Download kselftest logs (aarch64)
       if: steps.detect_arch.outputs.has_aarch64 == 'true' && needs.pre-setup.outputs.skip_kselftests == 'false'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: kselftest-logs-aarch64
         path: artifacts/test/aarch64

--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -259,9 +259,9 @@ jobs:
     steps:
     - name: Generate GitHub App token
       id: generate_token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         repositories: |
           kernel-container-build
@@ -390,9 +390,9 @@ jobs:
     steps:
     - name: Generate GitHub App token
       id: generate_token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         repositories: |
           kernel-container-build
@@ -472,9 +472,9 @@ jobs:
     steps:
     - name: Generate GitHub App token
       id: generate_token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         repositories: |
           kernel-container-build
@@ -542,9 +542,9 @@ jobs:
     steps:
     - name: Generate GitHub App token
       id: generate_token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         repositories: |
           kernel-container-build
@@ -640,9 +640,9 @@ jobs:
 
     - name: Generate GitHub App token
       id: generate_token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # 3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         repositories: |
           kernel-container-build
@@ -663,9 +663,9 @@ jobs:
 
     - name: Generate GitHub App token for comparison
       id: generate_token_compare
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # 3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         repositories: |
           kernel-src-tree
@@ -885,9 +885,9 @@ jobs:
 
     - name: Generate GitHub App token for comparison
       id: generate_token_compare
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # 3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         repositories: |
           kernel-src-tree
@@ -1235,9 +1235,9 @@ jobs:
 
     - name: Generate GitHub App token
       id: generate_token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # 3.1.1
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         repositories: |
           kernel-src-tree

--- a/.github/workflows/lt-rebase-merge.yml
+++ b/.github/workflows/lt-rebase-merge.yml
@@ -207,7 +207,7 @@ jobs:
           echo "✅ PR base branch is correct: $BASE_BRANCH"
 
       - name: Checkout kernel-src-tree
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ctrliq/kernel-src-tree
           token: ${{ steps.generate-token.outputs.token }}
@@ -216,7 +216,7 @@ jobs:
           persist-credentials: true
 
       - name: Checkout kernel-src-tree-tools
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ctrliq/kernel-src-tree-tools
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/lt-rebase-merge.yml
+++ b/.github/workflows/lt-rebase-merge.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: |
             kernel-src-tree

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -42,7 +42,7 @@ jobs:
           dnf install -y git
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.BRANCH }}
           path: ${{ env.BRANCH }}

--- a/.github/workflows/validate-kernel-commits-comment.yml
+++ b/.github/workflows/validate-kernel-commits-comment.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Download check results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: check-results
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -239,14 +239,14 @@ jobs:
           echo "✅ Checked out commit $HEAD_SHA to kernel-src-tree/ (on branch temp-pr-check)"
 
       - name: Checkout kernel-src-tree-tools for JIRA check
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ctrliq/kernel-src-tree-tools
           ref: 'mainline'
           path: kernel-src-tree-tools
 
       - name: Set up Python for JIRA check
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.x'
 

--- a/.github/workflows/validate-kernel-commits.yml
+++ b/.github/workflows/validate-kernel-commits.yml
@@ -124,14 +124,14 @@ jobs:
           echo "MAINLINE_SHA=$MAINLINE_SHA" >> "$GITHUB_ENV"
 
       - name: Checkout kernel-src-tree-tools
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ctrliq/kernel-src-tree-tools
           ref: 'mainline'
           path: kernel-src-tree-tools
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.x'
 
@@ -272,7 +272,7 @@ jobs:
           (cd pr_metadata && sha256sum *.txt > checksums.txt)
 
       - name: Upload check results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()  # Upload even if checks fail
         with:
           name: check-results


### PR DESCRIPTION
## Summary

Node 20 reached EOL on 2026-04-30. This PR bumps GitHub Actions to current stable releases, pinned by full commit SHA with the target tag in a trailing comment.

## ⚠️ Heads up — review these specifically

> [!WARNING]
> **Artifact actions changed semantics — review your upload/download steps before merging.**
>
> The breaking changes landed in `upload-artifact` v4 and `download-artifact` v4 and still apply through v7/v8. Bumps in this PR:
>
>   - `actions/download-artifact: v4 -> v8.0.1`
>   - `actions/upload-artifact: v4 -> v7.0.1`
>
> Common gotchas to verify in this repo:
> - **Matrix uploads with a literal `name:`** collide; v4+ no longer auto-merges. Interpolate (`name: build-${{ matrix.os }}`) or set `overwrite: true`.
> - **Multiple uploads in a job with no explicit `name:`** all collide on the default `artifact` name.
> - **Hidden files (e.g. `.coverage`, `.next/`, `.cache/`) are excluded by default** in v4+ — set `include-hidden-files: true` if you upload dotfiles.
> - **`download-artifact` no longer flattens** by default — without a `name:`, it creates a subdir per artifact. Set `merge-multiple: true` if a downstream `run:` step expects a flat path.
> - **Cross-run downloads** now require both `github-token:` and `run-id:`.

## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v6.0.2` |
| `actions/download-artifact` | `v4` | `v8.0.1` |
| `actions/setup-python` | `v5` | `v6.2.0` |
| `actions/upload-artifact` | `v4` | `v7.0.1` |
| `actions/create-github-app-token` | `v1` | `v3.1.1` |

### Changes - Actions
`actions/create-github-app-token v3.1.1` deprecates `app-id` to use `client-id` 

Files touched: **7** workflow file(s), **43** line change(s).

## Test plan

- [X] Existing CI runs on this PR and stays green.
- [ ] If this repo's workflows aren't PR-triggered, dispatch them manually after merge or via `workflow_dispatch`.

---

Part of an org-wide bulk update across ~135 ctrliq repos to escape Node 20 EOL.
