### PR TITLE
[RLC-10] Update GHA's

### DIFF
--- a/.github/workflows/build-check_aarch64-rt.yml
+++ b/.github/workflows/build-check_aarch64-rt.yml
@@ -35,4 +35,4 @@ jobs:
           git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
           cp configs/kernel-aarch64-rt-rhel.config .config
           make olddefconfig
-          make -j8
+          make -j$(nproc)

--- a/.github/workflows/build-check_aarch64-rt.yml
+++ b/.github/workflows/build-check_aarch64-rt.yml
@@ -26,7 +26,7 @@ jobs:
           dnf groupinstall 'Development Tools' -y
           dnf install openssl -y
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: 0

--- a/.github/workflows/build-check_aarch64.yml
+++ b/.github/workflows/build-check_aarch64.yml
@@ -26,7 +26,7 @@ jobs:
           dnf groupinstall 'Development Tools' -y
           dnf install openssl -y
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: 0

--- a/.github/workflows/build-check_aarch64.yml
+++ b/.github/workflows/build-check_aarch64.yml
@@ -35,4 +35,4 @@ jobs:
           git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
           cp configs/kernel-aarch64-rhel.config .config
           make olddefconfig
-          make -j8
+          make -j$(nproc)

--- a/.github/workflows/build-check_x86_64-rt.yml
+++ b/.github/workflows/build-check_x86_64-rt.yml
@@ -26,7 +26,7 @@ jobs:
           dnf groupinstall 'Development Tools' -y
           dnf install openssl -y
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: 0

--- a/.github/workflows/build-check_x86_64-rt.yml
+++ b/.github/workflows/build-check_x86_64-rt.yml
@@ -35,4 +35,4 @@ jobs:
           git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
           cp configs/kernel-x86_64-rt-rhel.config .config
           make olddefconfig
-          make -j8
+          make -j$(nproc)

--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -26,7 +26,7 @@ jobs:
           dnf groupinstall 'Development Tools' -y
           dnf install openssl -y
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: 0

--- a/.github/workflows/build-check_x86_64.yml
+++ b/.github/workflows/build-check_x86_64.yml
@@ -35,4 +35,4 @@ jobs:
           git config --global --add safe.directory /__w/kernel-src-tree/kernel-src-tree
           cp configs/kernel-x86_64-rhel.config .config
           make olddefconfig
-          make -j8
+          make -j$(nproc)


### PR DESCRIPTION
Updating git hub actions to recommended versions from internal teams.

Note we are `sha` pinning so immutable-ness of tags does not impact us should action repos become compromised.