### PR TITLE
[LTS 9.2] nfsd: CVE-2026-31402, CVE-2025-40324, CVE-2023-53241

### DIFF
--- a/fs/nfsd/blocklayout.c
+++ b/fs/nfsd/blocklayout.c
@@ -296,6 +296,7 @@ nfsd4_block_get_device_info_scsi(struct super_block *sb,
 
 out_free_dev:
 	kfree(dev);
+	gdp->gd_device = NULL;
 	return ret;
 }
 

--- a/fs/nfsd/nfs4proc.c
+++ b/fs/nfsd/nfs4proc.c
@@ -961,10 +961,11 @@ nfsd4_read(struct svc_rqst *rqstp, struct nfsd4_compound_state *cstate,
 static void
 nfsd4_read_release(union nfsd4_op_u *u)
 {
-	if (u->read.rd_nf)
+	if (u->read.rd_nf) {
+		trace_nfsd_read_done(u->read.rd_rqstp, u->read.rd_fhp,
+				     u->read.rd_offset, u->read.rd_length);
 		nfsd_file_put(u->read.rd_nf);
-	trace_nfsd_read_done(u->read.rd_rqstp, u->read.rd_fhp,
-			     u->read.rd_offset, u->read.rd_length);
+	}
 }
 
 static __be32

--- a/fs/nfsd/nfs4xdr.c
+++ b/fs/nfsd/nfs4xdr.c
@@ -5362,9 +5362,14 @@ nfsd4_encode_operation(struct nfsd4_compoundres *resp, struct nfsd4_op *op)
 		int len = xdr->buf->len - post_err_offset;
 
 		so->so_replay.rp_status = op->status;
-		so->so_replay.rp_buflen = len;
-		read_bytes_from_xdr_buf(xdr->buf, post_err_offset,
+		if (len <= NFSD4_REPLAY_ISIZE) {
+			so->so_replay.rp_buflen = len;
+			read_bytes_from_xdr_buf(xdr->buf,
+						post_err_offset,
 						so->so_replay.rp_buf, len);
+		} else {
+			so->so_replay.rp_buflen = 0;
+		}
 	}
 status:
 	*p = op->status;

--- a/fs/nfsd/nfs4xdr.c
+++ b/fs/nfsd/nfs4xdr.c
@@ -5312,10 +5312,8 @@ nfsd4_encode_operation(struct nfsd4_compoundres *resp, struct nfsd4_op *op)
 	__be32 *p;
 
 	p = xdr_reserve_space(xdr, 8);
-	if (!p) {
-		WARN_ON_ONCE(1);
-		return;
-	}
+	if (!p)
+		goto release;
 	*p++ = cpu_to_be32(op->opnum);
 	post_err_offset = xdr->buf->len;
 
@@ -5330,8 +5328,6 @@ nfsd4_encode_operation(struct nfsd4_compoundres *resp, struct nfsd4_op *op)
 	op->status = encoder(resp, op->status, &op->u);
 	if (op->status)
 		trace_nfsd_compound_encode_err(rqstp, op->opnum, op->status);
-	if (opdesc && opdesc->op_release)
-		opdesc->op_release(&op->u);
 	xdr_commit_encode(xdr);
 
 	/* nfsd4_check_resp_size guarantees enough room for error status */
@@ -5372,6 +5368,9 @@ nfsd4_encode_operation(struct nfsd4_compoundres *resp, struct nfsd4_op *op)
 	}
 status:
 	*p = op->status;
+release:
+	if (opdesc && opdesc->op_release)
+		opdesc->op_release(&op->u);
 }
 
 /* 

--- a/fs/nfsd/state.h
+++ b/fs/nfsd/state.h
@@ -399,11 +399,18 @@ struct nfs4_client_reclaim {
 	struct xdr_netobj	cr_princhash;
 };
 
-/* A reasonable value for REPLAY_ISIZE was estimated as follows:  
- * The OPEN response, typically the largest, requires 
- *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +  8(verifier) + 
- *   4(deleg. type) + 8(deleg. stateid) + 4(deleg. recall flag) + 
- *   20(deleg. space limit) + ~32(deleg. ace) = 112 bytes 
+/*
+ * REPLAY_ISIZE is sized for an OPEN response with delegation:
+ *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +
+ *   8(verifier) + 4(deleg. type) + 8(deleg. stateid) +
+ *   4(deleg. recall flag) + 20(deleg. space limit) +
+ *   ~32(deleg. ace) = 112 bytes
+ *
+ * Some responses can exceed this. A LOCK denial includes the conflicting
+ * lock owner, which can be up to 1024 bytes (NFS4_OPAQUE_LIMIT). Responses
+ * larger than REPLAY_ISIZE are not cached in rp_ibuf; only rp_status is
+ * saved. Enlarging this constant increases the size of every
+ * nfs4_stateowner.
  */
 
 #define NFSD4_REPLAY_ISIZE       112 


### PR DESCRIPTION
[LTS 9.2] 

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2026-31402</td>
<td class="org-left">VULN-180163</td>
</tr>


<tr>
<td class="org-left">CVE-2025-40324</td>
<td class="org-left">VULN-161290</td>
</tr>


<tr>
<td class="org-left">CVE-2023-53241</td>
<td class="org-left">VULN-154845</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2026-31402 (+ CVE-2023-53241, CVE-2025-40324)

    nfsd: fix heap overflow in NFSv4.0 LOCK replay cache
    
    jira VULN-180163
    cve CVE-2026-31402
    commit-author Jeff Layton <jlayton@kernel.org>
    commit 5133b61aaf437e5f25b1b396b14242a6bb0508e2
    upstream-diff Used linux-5.10.y backport
      f9fcb4441f6c02bb20c2eb340101e27dfe23607c for the clean cherry-pick.
      The modified function `nfsd4_encode_operation()' is identical in both
      versions

>

    NFSD: Fix crash in nfsd4_read_release()
    
    jira VULN-161290
    cve CVE-2025-40324
    commit-author Chuck Lever <chuck.lever@oracle.com>
    commit abb1f08a2121dd270193746e43b2a9373db9ad84

>

    nfsd: call op_release, even when op_func returns an error
    
    jira VULN-154845
    cve CVE-2023-53241
    commit-author Jeff Layton <jlayton@kernel.org>
    commit 15a8b55dbb1ba154d82627547c5761cac884d810

The solution is based on the `linux-5.10.y` backport, which itself doesn't differ from the recent LTS 9.4 fix (see <https://github.com/ctrliq/kernel-src-tree/pull/1153>). The `nfsd: call op_release, even when op_func returns an error` was picked as prerequisite to equalize `ciqlts9_2`'s `nfsd4_encode_operation()` function with that found in `linux-5.10.y` from right before the fix, with an added bonus of solving additional CVE. The middle commit `NFSD: Fix crash in nfsd4_read_release()` was pulled in as a bugfix for `nfsd: call op_release, even when op_func returns an error`, having its own CVE as well.


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts9_2-CVE-batch-33]	_kabi_check_kernel__x86_64--test--ciqlts9_2-CVE-batch-33
    ninja explain: output state/kernels/ciqlts9_2-CVE-batch-33/x86_64/kabi_checked doesn't exist
    ninja explain: state/kernels/ciqlts9_2-CVE-batch-33/x86_64/kabi_checked is dirty
    + dist_git_version=el-9.2
    + local_version=ciqlts9_2-CVE-batch-33
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts9_2
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-9.2
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts9_2-CVE-batch-33
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-9.2/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts9_2 ''\''/mnt/code/kernel-dist-git-el-9.2/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts9_2-CVE-batch-33/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-batch-33/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/27730676/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/27730678/kselftests--ciqlts9_2--run1.log>)
[kselftests&#x2013;ciqlts9\_2&#x2013;run2.log](<https://github.com/user-attachments/files/27730682/kselftests--ciqlts9_2--run2.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-batch-33&#x2013;run1.log](<https://github.com/user-attachments/files/27730683/kselftests--ciqlts9_2-CVE-batch-33--run1.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-batch-33&#x2013;run2.log](<https://github.com/user-attachments/files/27730684/kselftests--ciqlts9_2-CVE-batch-33--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff -d  kselftests*.log

    Column    File
    --------  --------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2--run2.log
    Status2   kselftests--ciqlts9_2-CVE-batch-33--run1.log
    Status3   kselftests--ciqlts9_2-CVE-batch-33--run2.log

[tests-comparison.txt](<https://github.com/user-attachments/files/27730686/tests-comparison.txt>)

