### PR TITLE
[LTS 8.6] nfsd: CVE-2026-31402

### DIFF
--- a/fs/nfsd/nfs4xdr.c
+++ b/fs/nfsd/nfs4xdr.c
@@ -4942,9 +4942,14 @@ nfsd4_encode_operation(struct nfsd4_compoundres *resp, struct nfsd4_op *op)
 		int len = xdr->buf->len - post_err_offset;
 
 		so->so_replay.rp_status = op->status;
-		so->so_replay.rp_buflen = len;
-		read_bytes_from_xdr_buf(xdr->buf, post_err_offset,
+		if (len <= NFSD4_REPLAY_ISIZE) {
+			so->so_replay.rp_buflen = len;
+			read_bytes_from_xdr_buf(xdr->buf,
+						post_err_offset,
 						so->so_replay.rp_buf, len);
+		} else {
+			so->so_replay.rp_buflen = 0;
+		}
 	}
 status:
 	/* Note that op->status is already in network byte order: */

--- a/fs/nfsd/state.h
+++ b/fs/nfsd/state.h
@@ -379,11 +379,18 @@ struct nfs4_client_reclaim {
 	struct xdr_netobj	cr_princhash;
 };
 
-/* A reasonable value for REPLAY_ISIZE was estimated as follows:  
- * The OPEN response, typically the largest, requires 
- *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +  8(verifier) + 
- *   4(deleg. type) + 8(deleg. stateid) + 4(deleg. recall flag) + 
- *   20(deleg. space limit) + ~32(deleg. ace) = 112 bytes 
+/*
+ * REPLAY_ISIZE is sized for an OPEN response with delegation:
+ *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +
+ *   8(verifier) + 4(deleg. type) + 8(deleg. stateid) +
+ *   4(deleg. recall flag) + 20(deleg. space limit) +
+ *   ~32(deleg. ace) = 112 bytes
+ *
+ * Some responses can exceed this. A LOCK denial includes the conflicting
+ * lock owner, which can be up to 1024 bytes (NFS4_OPAQUE_LIMIT). Responses
+ * larger than REPLAY_ISIZE are not cached in rp_ibuf; only rp_status is
+ * saved. Enlarging this constant increases the size of every
+ * nfs4_stateowner.
  */
 
 #define NFSD4_REPLAY_ISIZE       112 


### PR DESCRIPTION
[LTS 8.6]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2026-31402</td>
<td class="org-left">VULN-180161</td>
</tr>
</tbody>
</table>


# Commits

    nfsd: fix heap overflow in NFSv4.0 LOCK replay cache
    
    jira VULN-180161
    cve CVE-2026-31402
    commit-author Jeff Layton <jlayton@kernel.org>
    commit 5133b61aaf437e5f25b1b396b14242a6bb0508e2
    upstream-diff Used `post_err_offset' instead of `op_status_offset +
      XDR_UNIT' in the `read_bytes_from_xdr_buf()' call, as the LTS 8.6
      version is missing ef3675b45bcb6c17cabbbde620c6cea52ffb21ac ("NFSD:
      Encode COMPOUND operation status on page boundaries")

The changes are the same as in `rocky8_10` for the buildable kernel 9b906d0e7b3e34897f09fe4dcb3f4a439510cabe, compare with

    git log --pretty=oneline --patch-with-stat -n 1 9b906d0e7b3e34897f09fe4dcb3f4a439510cabe -- fs/nfsd/nfs4xdr.c fs/nfsd/state.h

They are the same, in turn, as the solutions for LTS 9.2 and and LTS 9.4. Unlike in the [LTS 9.2 solution](https://github.com/ctrliq/kernel-src-tree/pull/1222) the fixes for CVE-2025-40324 and CVE-2023-53241 were not included because they don't apply cleanly - too high hanging fruits to get for their worth.


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts8_6-CVE-2026-31402]	_kabi_check_kernel__x86_64--test--ciqlts8_6-CVE-2026-31402
    ninja explain: output state/kernels/ciqlts8_6-CVE-2026-31402/x86_64/kabi_checked doesn't exist
    ninja explain: state/kernels/ciqlts8_6-CVE-2026-31402/x86_64/kabi_checked is dirty
    + dist_git_version=el-8.6
    + local_version=ciqlts8_6-CVE-2026-31402
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts8_6
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-8.6
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-2026-31402
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-8.6/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts8_6 ''\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-2026-31402/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-2026-31402/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/27729051/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/27729054/kselftests--ciqlts8_6--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/27729062/kselftests--ciqlts8_6--run2.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-2026-31402&#x2013;run1.log](<https://github.com/user-attachments/files/27729063/kselftests--ciqlts8_6-CVE-2026-31402--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-2026-31402&#x2013;run2.log](<https://github.com/user-attachments/files/27729065/kselftests--ciqlts8_6-CVE-2026-31402--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2--run2.log
    Status2   kselftests--ciqlts9_2-CVE-2026-31402--run1.log
    Status3   kselftests--ciqlts9_2-CVE-2026-31402--run2.log

[tests-comparison.txt](<https://github.com/user-attachments/files/27729066/tests-comparison.txt>)

