### PR TITLE
github-actions: Upload built kernel binaries as a downloadable artifact

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -284,7 +284,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-kernel-tarball
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -413,7 +413,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-kernel-tarball
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -495,7 +495,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-kernel-tarball
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -565,7 +565,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-kernel-tarball
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -663,7 +663,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-kernel-tarball
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 

--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -284,7 +284,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-kernel-tarball
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -413,7 +413,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-kernel-tarball
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -495,7 +495,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-kernel-tarball
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -565,7 +565,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-kernel-tarball
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -663,7 +663,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-kernel-tarball
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 

--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -345,6 +345,18 @@ jobs:
         path: output/kernel-build.log
         retention-days: 7
 
+    # Upload kernel binaries tarball (vmlinuz, modules, config) for downstream testing.
+    # Produced by build_kernel.sh in kernel-container-build; the tarball inside is
+    # named kernel-<kernelrelease>-<arch>.tar.xz.
+    - name: Upload kernel binaries tarball
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      if: always()
+      with:
+        name: kernel-binaries-${{ matrix.arch }}
+        path: output/kernel-*.tar.xz
+        retention-days: 7
+        if-no-files-found: warn
+
     # Upload kselftests qcow2 image
     - name: Upload kselftests qcow2 image
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
## Summary
- Add an `upload-artifact` step to the multi-arch CI workflow that publishes the kernel binaries tarball produced by ctrliq/kernel-container-build#32.
- Tarball inside the artifact: `kernel-<kernelrelease>-<arch>.tar.xz` (contains `vmlinuz`, `System.map`, modules tree, and optionally `config`/`initramfs`).
- Artifact name in the run: `kernel-binaries-<arch>` (one per matrix arch).

## Order of operations
Land ctrliq/kernel-container-build#32 **first**. Until that's merged, this PR's upload step will find no file in `output/` and will log a warning (`if-no-files-found: warn`) — non-fatal so production CI isn't broken if this lands out of order. Once kernel-container-build has merged and is producing the tarball reliably, consider flipping to `if-no-files-found: error`.

## How to use the tarball
Once both PRs are merged, every CI run on a `{user}_<base>` push will produce two new artifacts on the run summary page:

- `kernel-binaries-x86_64`
- `kernel-binaries-aarch64`

### Download

Via the GitHub UI: Actions tab → run → scroll to the Artifacts section at the bottom → click `kernel-binaries-<arch>` to download a ZIP containing the `.tar.xz`.

Via CLI:
```bash
gh run download <RUN_ID> -R ctrliq/kernel-src-tree -n kernel-binaries-x86_64 -D ./
# yields: kernel-<KREL>-x86_64.tar.xz
```

### Install on a target host (RHEL/Rocky 8/9/10)

```bash
TARBALL=kernel-<KREL>-x86_64.tar.xz
KREL=<KREL>   # e.g. 5.14.0-_jmaple__ciqlts9_2-01e4dfc2e+

# 1. Extract vmlinuz, System.map, optional initramfs, and the modules tree to /
sudo tar -xJf "$TARBALL" -C /

# 2. Refresh module dependency database
sudo depmod -a "$KREL"

# 3. Regenerate the initramfs against this host's storage drivers
#    (the bundled initramfs was built inside the CI container and is not
#    guaranteed to match your rootfs/devices)
sudo dracut --force /boot/initramfs-"$KREL".img "$KREL"

# 4. Add a GRUB entry and make it the default
sudo grubby --add-kernel=/boot/vmlinuz-"$KREL" \
            --initrd=/boot/initramfs-"$KREL".img \
            --title="CIQ test: $KREL" \
            --copy-default
sudo grubby --set-default=/boot/vmlinuz-"$KREL"

# 5. Reboot — pick the new kernel from GRUB if not default
sudo reboot

# 6. Confirm
uname -r       # should print <KREL>
```

To roll back after testing:
```bash
sudo grubby --set-default=/boot/vmlinuz-<stock-kernel>
sudo grubby --remove-kernel=/boot/vmlinuz-"$KREL"
sudo reboot
```

### Caveat: UEFI Secure Boot

The kernel in the tarball is **not signed by any trusted UEFI key**. On hosts with Secure Boot enabled, shim/GRUB will refuse to load it (`error: prohibited by secure boot policy`). Either:

- Disable Secure Boot on the target host (firmware setup, or `mokutil --disable-validation` followed by an interactive MOK Manager confirmation at next boot), or
- Sign the vmlinuz with a key already enrolled in shim's MOK db before installing.

## Validation
- [x] End-to-end build on a real Rocky 9 VM (`pulp.prod.ciq.dev/ciq/cicd/lts-images/builder` + `lts-9.2-kernel-builder`) against a `ciqlts9_2` checkout: tarball appears at `output/kernel-*.tar.xz` and is a valid xz archive
- [x] Naming format: `kernel-5.14.0-_jmaple__ciqlts9_2-01e4dfc2e+-x86_64.tar.xz` (version + arch, no redundancy)
- [x] Compressed size ~80 MB (x86_64) / ~56 MB (aarch64); 2235 `.ko` files on x86_64
- [x] Real CI integration via `workflow_dispatch`: https://github.com/ctrliq/kernel-src-tree/actions/runs/25837047151 — both `kernel-binaries-x86_64` and `kernel-binaries-aarch64` artifacts published
- [x] Tarball installed and booted on a real RHEL/Rocky 9.6 host with Secure Boot disabled — kernel runs, modules load, no errors in dmesg

🤖 Generated with [Claude Code](https://claude.com/claude-code)