### PR TITLE
[LTS 9.6] CVE-2026-31402, CVE-2026-23066, CVE-2026-23097, CVE-2026-23171

### DIFF
--- a/drivers/net/bonding/bond_main.c
+++ b/drivers/net/bonding/bond_main.c
@@ -2361,10 +2361,6 @@ int bond_enslave(struct net_device *bond_dev, struct net_device *slave_dev,
 		unblock_netpoll_tx();
 	}
 
-	if (bond_mode_can_use_xmit_hash(bond))
-		bond_update_slave_arr(bond, NULL);
-
-
 	if (!slave_dev->netdev_ops->ndo_bpf ||
 	    !slave_dev->netdev_ops->ndo_xdp_xmit) {
 		if (bond->xdp_prog) {
@@ -2397,6 +2393,9 @@ int bond_enslave(struct net_device *bond_dev, struct net_device *slave_dev,
 		if (bond->xdp_prog)
 			bpf_prog_inc(bond->xdp_prog);
 	}
+
+	if (bond_mode_can_use_xmit_hash(bond))
+		bond_update_slave_arr(bond, NULL);
 
 	bond_xdp_set_features(bond_dev);
 

--- a/fs/nfsd/nfs4xdr.c
+++ b/fs/nfsd/nfs4xdr.c
@@ -5785,9 +5785,14 @@ nfsd4_encode_operation(struct nfsd4_compoundres *resp, struct nfsd4_op *op)
 		int len = xdr->buf->len - post_err_offset;
 
 		so->so_replay.rp_status = op->status;
-		so->so_replay.rp_buflen = len;
-		read_bytes_from_xdr_buf(xdr->buf, post_err_offset,
+		if (len <= NFSD4_REPLAY_ISIZE) {
+			so->so_replay.rp_buflen = len;
+			read_bytes_from_xdr_buf(xdr->buf,
+						post_err_offset,
 						so->so_replay.rp_buf, len);
+		} else {
+			so->so_replay.rp_buflen = 0;
+		}
 	}
 status:
 	*p = op->status;

--- a/fs/nfsd/state.h
+++ b/fs/nfsd/state.h
@@ -472,11 +472,18 @@ struct nfs4_client_reclaim {
 	struct xdr_netobj	cr_princhash;
 };
 
-/* A reasonable value for REPLAY_ISIZE was estimated as follows:  
- * The OPEN response, typically the largest, requires 
- *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +  8(verifier) + 
- *   4(deleg. type) + 8(deleg. stateid) + 4(deleg. recall flag) + 
- *   20(deleg. space limit) + ~32(deleg. ace) = 112 bytes 
+/*
+ * REPLAY_ISIZE is sized for an OPEN response with delegation:
+ *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +
+ *   8(verifier) + 4(deleg. type) + 8(deleg. stateid) +
+ *   4(deleg. recall flag) + 20(deleg. space limit) +
+ *   ~32(deleg. ace) = 112 bytes
+ *
+ * Some responses can exceed this. A LOCK denial includes the conflicting
+ * lock owner, which can be up to 1024 bytes (NFS4_OPAQUE_LIMIT). Responses
+ * larger than REPLAY_ISIZE are not cached in rp_ibuf; only rp_status is
+ * saved. Enlarging this constant increases the size of every
+ * nfs4_stateowner.
  */
 
 #define NFSD4_REPLAY_ISIZE       112 

--- a/include/trace/events/rxrpc.h
+++ b/include/trace/events/rxrpc.h
@@ -273,6 +273,7 @@
 	EM(rxrpc_call_put_kernel,		"PUT kernel  ") \
 	EM(rxrpc_call_put_poke,			"PUT poke    ") \
 	EM(rxrpc_call_put_recvmsg,		"PUT recvmsg ") \
+	EM(rxrpc_call_put_recvmsg_peek_nowait,	"PUT peek-nwt") \
 	EM(rxrpc_call_put_release_sock,		"PUT rls-sock") \
 	EM(rxrpc_call_put_release_sock_tba,	"PUT rls-sk-a") \
 	EM(rxrpc_call_put_sendmsg,		"PUT sendmsg ") \
@@ -287,6 +288,9 @@
 	EM(rxrpc_call_see_disconnected,		"SEE disconn ") \
 	EM(rxrpc_call_see_distribute_error,	"SEE dist-err") \
 	EM(rxrpc_call_see_input,		"SEE input   ") \
+	EM(rxrpc_call_see_recvmsg_requeue,	"SEE recv-rqu") \
+	EM(rxrpc_call_see_recvmsg_requeue_first, "SEE recv-rqF") \
+	EM(rxrpc_call_see_recvmsg_requeue_move,	"SEE recv-rqM") \
 	EM(rxrpc_call_see_release,		"SEE release ") \
 	EM(rxrpc_call_see_userid_exists,	"SEE u-exists") \
 	E_(rxrpc_call_see_zap,			"SEE zap     ")

--- a/mm/migrate.c
+++ b/mm/migrate.c
@@ -1385,6 +1385,7 @@ static int unmap_and_move_huge_page(new_folio_t get_new_folio,
 	int page_was_mapped = 0;
 	struct anon_vma *anon_vma = NULL;
 	struct address_space *mapping = NULL;
+	enum ttu_flags ttu = 0;
 
 	if (folio_ref_count(src) == 1) {
 		/* page was freed from under us. So we are done. */
@@ -1426,8 +1427,6 @@ static int unmap_and_move_huge_page(new_folio_t get_new_folio,
 		goto put_anon;
 
 	if (folio_mapped(src)) {
-		enum ttu_flags ttu = 0;
-
 		if (!folio_test_anon(src)) {
 			/*
 			 * In shared mappings, try_to_unmap could potentially
@@ -1444,9 +1443,6 @@ static int unmap_and_move_huge_page(new_folio_t get_new_folio,
 
 		try_to_migrate(src, ttu);
 		page_was_mapped = 1;
-
-		if (ttu & TTU_RMAP_LOCKED)
-			i_mmap_unlock_write(mapping);
 	}
 
 	if (!folio_mapped(src))
@@ -1454,7 +1450,11 @@ static int unmap_and_move_huge_page(new_folio_t get_new_folio,
 
 	if (page_was_mapped)
 		remove_migration_ptes(src,
-			rc == MIGRATEPAGE_SUCCESS ? dst : src, false);
+			rc == MIGRATEPAGE_SUCCESS ? dst : src,
+			ttu ? true : false);
+
+	if (ttu & TTU_RMAP_LOCKED)
+		i_mmap_unlock_write(mapping);
 
 unlock_put_anon:
 	folio_unlock(dst);

--- a/net/rxrpc/recvmsg.c
+++ b/net/rxrpc/recvmsg.c
@@ -415,7 +415,8 @@ try_again:
 	if (rxrpc_call_has_failed(call))
 		goto call_failed;
 
-	if (!skb_queue_empty(&call->recvmsg_queue))
+	if (!(flags & MSG_PEEK) &&
+	    !skb_queue_empty(&call->recvmsg_queue))
 		rxrpc_notify_socket(call);
 	goto not_yet_complete;
 
@@ -446,11 +447,21 @@ error_unlock_call:
 error_requeue_call:
 	if (!(flags & MSG_PEEK)) {
 		spin_lock(&rx->recvmsg_lock);
-		list_add(&call->recvmsg_link, &rx->recvmsg_q);
-		spin_unlock(&rx->recvmsg_lock);
+		if (list_empty(&call->recvmsg_link)) {
+			list_add(&call->recvmsg_link, &rx->recvmsg_q);
+			rxrpc_see_call(call, rxrpc_call_see_recvmsg_requeue);
+			spin_unlock(&rx->recvmsg_lock);
+		} else if (list_is_first(&call->recvmsg_link, &rx->recvmsg_q)) {
+			spin_unlock(&rx->recvmsg_lock);
+			rxrpc_put_call(call, rxrpc_call_see_recvmsg_requeue_first);
+		} else {
+			list_move(&call->recvmsg_link, &rx->recvmsg_q);
+			spin_unlock(&rx->recvmsg_lock);
+			rxrpc_put_call(call, rxrpc_call_see_recvmsg_requeue_move);
+		}
 		trace_rxrpc_recvmsg(call_debug_id, rxrpc_recvmsg_requeue, 0);
 	} else {
-		rxrpc_put_call(call, rxrpc_call_put_recvmsg);
+		rxrpc_put_call(call, rxrpc_call_put_recvmsg_peek_nowait);
 	}
 error_no_call:
 	release_sock(&rx->sk);


### PR DESCRIPTION
[LTS 9.6]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2026-31402</td>
<td class="org-left">VULN-180165</td>
</tr>


<tr>
<td class="org-left">CVE-2026-23066</td>
<td class="org-left">VULN-175573</td>
</tr>


<tr>
<td class="org-left">CVE-2026-23097</td>
<td class="org-left">VULN-175621</td>
</tr>


<tr>
<td class="org-left">CVE-2026-23171</td>
<td class="org-left">VULN-176288</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2026-31402

    nfsd: fix heap overflow in NFSv4.0 LOCK replay cache
    
    jira VULN-180165
    cve CVE-2026-31402
    commit-author Jeff Layton <jlayton@kernel.org>
    commit 5133b61aaf437e5f25b1b396b14242a6bb0508e2
    upstream-diff Used `post_err_offset' instead of `op_status_offset +
      XDR_UNIT' in the `read_bytes_from_xdr_buf()' call, as the LTS 9.6
      version is missing ef3675b45bcb6c17cabbbde620c6cea52ffb21ac ("NFSD:
      Encode COMPOUND operation status on page boundaries")


## CVE-2026-23066

    rxrpc: Fix recvmsg() unconditional requeue
    
    jira VULN-175573
    cve CVE-2026-23066
    commit-author David Howells <dhowells@redhat.com>
    commit 2c28769a51deb6022d7fbd499987e237a01dd63a
    upstream-diff Used linux-6.12.y backport
      cf969bddd6e69c5777fa89dc88402204e72f312a as the basis, which, unlike
      the upstream, produces no conflicts in net/rxrpc/recvmsg.c and only
      trivial conflicts in include/trace/events/rxrpc.h. The contentious
      commit is the non-backported a2ea9a9072607c2fd6442bd1ffb4dbdbf882aed7
      ("Use irq-disabling spinlocks between app and I/O thread"), which
      changes spin_lock()/spin_unlock() pairs to
      spin_lock_irq()/spin_unlock_irq(). Spin locks are used in the CVE fix
      which makes the upstream version incompatible. Linux 6.12 doesn't have
      this commit backported either which makes it better suited for LTS
      9.6. Conflicts left in include/trace/events/rxrpc.h are just a matter
      of putting the newly defined trace points in a correct place on the
      alphabetically-ordered list.

Commit a2ea9a9072607c2fd6442bd1ffb4dbdbf882aed7 was considered for the backport as prerequisite, but it's quite exetensive (14 files modified), requires considerable additional work (conflicts in 4 files) and introduces CVE-2025-38525 which would have to be bugfixed too.


## CVE-2026-23097

    migrate: correct lock ordering for hugetlb file folios
    
    jira VULN-175621
    cve CVE-2026-23097
    commit-author Matthew Wilcox (Oracle) <willy@infradead.org>
    commit b7880cb166ab62c2409046b2347261abf701530e
    upstream-diff Changes in the `remove_migration_ptes()' function call:
      1. Compared `rc' with `MIGRATEPAGE_SUCCESS' as it was originally,
         instead of checking if it's zero - the success code simplification
         was done in the non-backported commit
         fb49a4425cfa163faccd91f913773d3401d3a7d4 ("treewide: remove
         MIGRATEPAGE_SUCCESS").
      2. Used `false' instead of `0' in the third argument in case `ttu' is
         zero. The LTS 9.6 version of `remove_migration_ptes()' accepts
         booleans as the last argument - this was changed in the
         non-backported commit b1f202060afeb7fcb98473929d26fd3d2093b067 ("mm:
         remap unused subpages to shared zeropage when splitting isolated
         thp"). For the same reason used `true' instead of `RMP_LOCKED' in
         case it's non-zero. Inside the LTS 9.6 version of
         `remove_migration_ptes()' it narrows down to the
         `rmap_walk_locked(dst, &rwc)' call, just like in the upstream.

The solution is basically the same as `centos9` 7db3700f507750e2c8e742a505250995b8c4a606, except for formatting.


## CVE-2026-23171

    bonding: fix use-after-free due to enslave fail after slave array update
    
    jira VULN-176288
    cve CVE-2026-23171
    commit-author Nikolay Aleksandrov <razor@blackwall.org>
    commit e9acda52fd2ee0cdca332f996da7a95c5fd25294
    upstream-diff Accounted for the missing commit
      e0caeb24f538c3c9c94f471882ceeb43d9dc2739 ("net: bonding: update the
      slave array for broadcast mode"): moved the conditional
      `bond_update_slave_arr()' call to the same place regardless of the
      condition differing from the upstream.

The LTS 9.6 version is missing e0caeb24f538c3c9c94f471882ceeb43d9dc2739 which changes the condition for the moved code fragment, causing conflicts in applying the upstream fix. That commit is a fix for ce7a381697cb3958ffe0b45e5028ac69444e9288 `net: bonding: add broadcast_neighbor option for 802.3ad`, which was not backported to LTS 9.6 and should not be backported as part of CVE-2026-23171 fixing effort as it introduces new feature. The fix was therefore adapted manually.

Since the mechanism of the bug, as well as its fix, was not entirely clear, and no other backports of this fix to a Linux version with the e0caeb24f538c3c9c94f471882ceeb43d9dc2739 commit missing were found, the reproduction of the bug was attempted to make sure the proposed fix actually solves the problem.


### Bug reproduction

From the fixing commit e9acda52fd2ee0cdca332f996da7a95c5fd25294 message:

> It is very easy to reproduce the problem with a simple xdp\_pass prog:
>  ip l add bond1 type bond mode balance-xor
>  ip l set bond1 up
>  ip l set dev bond1 xdp object xdp\_pass.o sec xdp\_pass
>  ip l add dumdum type dummy
> 
> Then run in parallel:
>  while :; do ip l set dumdum master bond1 1>/dev/null 2>&1; done;
>  mausezahn bond1 -a own -b rand -A rand -B 1.1.1.1 -c 0 -t tcp "dp=1-1023, flags=syn"


### Config

To reproduce the issue tha KASAN option was enabled in `ciqlts9_6`. However, merely setting

    CONFIG_KASAN=y

in the default config `kernel-x86_64-rhel.config` resulted in a kernel which was crashing on boot. Instead the `kernel-x86_64-debug-rhel.config` configuration was used which happened to have KASAN enabled and was nevertheless booting fine for some reason.

[kasan-crashing.log](<https://github.com/user-attachments/files/27974731/kasan-crashing.log>)


### The "xdp\_pass prog"

The `xdp_pass` prog mentioned in the commit message was assumed to be a minimal XDP eBPF program whose behavior is just to return `XDP_PASS`:

    #include <linux/bpf.h>
    #include <bpf/bpf_helpers.h>
    
    SEC("xdp_pass")
    int xdp_prog(struct xdp_md *ctx)
    {
        return XDP_PASS;
    }
    
    char _license[] SEC("license") = "GPL";

Compilation:

    clang -I/usr/src/kernels/5.14.0-611.55.1.el9_7.x86_64+debug/tools/bpf/resolve_btfids/libbpf/include -O2 -g -target bpf -c xdp_pass.c -o xdp_pass.o

The `bpf/bpf_helpers.h` header was only available after installing `kernel-debug-devel` package

    sudo dnf --color=never install kernel-debug-devel.x86_64 -y


### Bug reproduction on `ciqlts9_6`

Commands from the commit message were used to reproduce the bug, namely

    ip l add bond1 type bond mode balance-xor
    ip l set bond1 up
    ip l set dev bond1 xdp object xdp_pass.o sec xdp_pass
    ip l add dumdum type dummy
    while :; do ip l set dumdum master bond1 1>/dev/null 2>&1; done;

in one console and

    mausezahn bond1 -a own -b rand -A rand -B 1.1.1.1 -c 0 -t tcp "dp=1-1023, flags=syn"

in another.

The reported KASAN message was not obtained on any run. Insted the kernel was spontaneously rebooting right after the `mausezahn` command invocation.

[ciqlts9\_6&#x2013;reproduction-console-1.log](<https://github.com/user-attachments/files/27974727/ciqlts9_6--reproduction-console-1.log>)
[ciqlts9\_6&#x2013;reproduction-console-2.log](<https://github.com/user-attachments/files/27974728/ciqlts9_6--reproduction-console-2.log>)


### Patch test

Similarly to the bug reproduction on `ciqlts9_6` the patched version was compiled under the `kernel-x86_64-debug-rhel.config` configuration file. Repeating the same steps resulted in no reboots, crashes or hangs.

[ciqlts9\_6-patched&#x2013;reproduction-console-1.log](<https://github.com/user-attachments/files/27974729/ciqlts9_6-patched--reproduction-console-1.log>)
[ciqlts9\_6-patched&#x2013;reproduction-console-2.log](<https://github.com/user-attachments/files/27974730/ciqlts9_6-patched--reproduction-console-2.log>)


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts9_6-CVE-batch-32]	_kabi_check_kernel__x86_64--test--ciqlts9_6-CVE-batch-32
    + dist_git_version=el-9.6
    + local_version=ciqlts9_6-CVE-batch-32
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts9_6
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-9.6
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts9_6-CVE-batch-32
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-9.6/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts9_6 ''\''/mnt/code/kernel-dist-git-el-9.6/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-9.6/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts9_6-CVE-batch-32/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts9_6-CVE-batch-32/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/27974724/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_6&#x2013;run1.log](<https://github.com/user-attachments/files/27974732/kselftests--ciqlts9_6--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_6-CVE-batch-32&#x2013;run1.log](<https://github.com/user-attachments/files/27978223/kselftests--ciqlts9_6-CVE-batch-32--run1.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  --------------------------------------------
    Status0   kselftests--ciqlts9_6--run1.log
    Status1   kselftests--ciqlts9_6-CVE-batch-32--run1.log

[tests-comparison.txt](<https://github.com/user-attachments/files/27978252/tests-comparison.txt>)

