### PR TITLE
[CIQ] ciq_kernel-6.12.89-2 - updated spec

### DIFF
--- a/ciq/SOURCES/bundle_bindgen.sh
+++ b/ciq/SOURCES/bundle_bindgen.sh
@@ -16,7 +16,7 @@ BINDGEN_CLI_CRATE=bindgen-cli.crate
 BINDGEN_CLI_SHA256="fded10ca0956afd0cbe5cf89cc71ae1a679e65b8216c651fca17ba7de8ac54dc"
 CRATESIO_API_ENDPOINT=https://crates.io/api/v1/crates/bindgen-cli/${BINDGEN_CLI_VERSION}/download
 
-curl -sfL $CRATESIO_API_ENDPOINT -o $SOURCES/$BINDGEN_CLI_CRATE
+curl -sfL -A "bundle_bindgen/1.0" $CRATESIO_API_ENDPOINT -o $SOURCES/$BINDGEN_CLI_CRATE
 
 echo "$BINDGEN_CLI_SHA256  $SOURCES/$BINDGEN_CLI_CRATE" | sha256sum -c - || {
     echo "Error: SHA256 checksum mismatch for $BINDGEN_CLI_CRATE"

--- a/ciq/SPECS/kernel-clk6.12.spec
+++ b/ciq/SPECS/kernel-clk6.12.spec
@@ -166,7 +166,7 @@ Summary: The Linux kernel
 %define kernel_patch 89
 %define buildid .1
 %define specversion %{kernel_major_minor}.%{kernel_patch}
-%define pkgrelease 1%{?buildid}
+%define pkgrelease 2%{?buildid}
 %define kversion %{lua:print((rpm.expand("%{kernel_major_minor}"):match("^(%d+)")))}
 
 %define tarfile_release %{specversion}-%{pkgrelease}.el%{el_version}
@@ -4202,6 +4202,11 @@ fi\
 #
 #
 %changelog
+* Wed May 27 2026 Brett Mastbergen <bmastbergen@ciq.com> - 6.12.89-2.1.el9
+-- bundle_bindgen: add User-Agent header to crates.io request (Brett Mastbergen)
+-- smb: client: reject userspace cifs.spnego descriptions (Shreeya Patel)
+-- net: gro: don't merge zcopy skbs (Sabrina Dubroca)
+
 * Fri May 15 2026 Brett Mastbergen <bmastbergen@ciq.com> - 6.12.89-1.1.el9
 -- Rebased changes for Linux 6.12.89 (https://github.com/ctrliq/kernel-src-tree/releases/tag/ciq_kernel-6.12.89-1)
 -- [CIQ] v6.12.89 - rebased configs (Brett Mastbergen)


### PR DESCRIPTION
Update the spec to reference the latest changes

Also, fix an issue with bundle_bindgen.  Apparently crates.io started requiring a user-agent when interacting with their api.