### PR TITLE
CLK 6.18: bundle_bindgen fix

### DIFF
--- a/ciq/SOURCES/bundle_bindgen.sh
+++ b/ciq/SOURCES/bundle_bindgen.sh
@@ -16,7 +16,7 @@ BINDGEN_CLI_CRATE=bindgen-cli.crate
 BINDGEN_CLI_SHA256="fded10ca0956afd0cbe5cf89cc71ae1a679e65b8216c651fca17ba7de8ac54dc"
 CRATESIO_API_ENDPOINT=https://crates.io/api/v1/crates/bindgen-cli/${BINDGEN_CLI_VERSION}/download
 
-curl -sfL $CRATESIO_API_ENDPOINT -o $SOURCES/$BINDGEN_CLI_CRATE
+curl -sfL -A "bundle_bindgen/1.0" $CRATESIO_API_ENDPOINT -o $SOURCES/$BINDGEN_CLI_CRATE
 
 echo "$BINDGEN_CLI_SHA256  $SOURCES/$BINDGEN_CLI_CRATE" | sha256sum -c - || {
     echo "Error: SHA256 checksum mismatch for $BINDGEN_CLI_CRATE"

--- a/ciq/SPECS/kernel-clk6.18.spec
+++ b/ciq/SPECS/kernel-clk6.18.spec
@@ -171,7 +171,7 @@ Summary: The Linux kernel
 %define kernel_patch 33
 %define buildid .1
 %define specversion %{kernel_major_minor}.%{kernel_patch}
-%define pkgrelease 1%{?buildid}
+%define pkgrelease 2%{?buildid}
 %define kversion %{lua:print((rpm.expand("%{kernel_major_minor}"):match("^(%d+)")))}
 
 %define tarfile_release %{specversion}-%{pkgrelease}.el%{el_version}
@@ -4495,6 +4495,9 @@ fi\
 #
 #
 %changelog
+* Wed May 27 2026 Brett Mastbergen <bmastbergen@ciq.com> - 6.18.33-2.1.el9
+-- bundle_bindgen: add User-Agent header to crates.io request (Brett Mastbergen)
+
 * Tue May 26 2026 github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com> - 6.18.33-1.1.el9
 -- Rebased changes for Linux 6.18.33 (https://github.com/ctrliq/kernel-src-tree/releases/tag/ciq_kernel-6.18.33-1)
 -- smb: client: reject userspace cifs.spnego descriptions (Shreeya Patel)


### PR DESCRIPTION
Fix an issue with bundle_bindgen. Apparently crates.io started requiring a user-agent when interacting with their api.