### PR TITLE
github-actions: Upload kselftests/LTP tarballs; add no_pr dispatch input

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -11,6 +11,11 @@ on:
         description: "Workflow run ID to fetch artifacts from"
         required: true
         type: string
+      no_pr:
+        description: "Skip PR creation/update at the end of the run (for testing only)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -368,6 +373,17 @@ jobs:
           output/last_build_image.txt
         retention-days: 7
 
+    # Upload kselftests binaries tarball (the /var/kselftests install tree) for
+    # downstream testing on hosts that match the kernel release + arch.
+    - name: Upload kselftests binaries tarball
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      if: ${{ always() && needs.pre-setup.outputs.skip_kselftests == 'false' }}
+      with:
+        name: kselftests-binaries-${{ matrix.arch }}
+        path: output/kselftests-*.tar.xz
+        retention-days: 7
+        if-no-files-found: warn
+
     # Upload LTP qcow2 image
     - name: Upload LTP qcow2 image
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -379,6 +395,17 @@ jobs:
           output/last_ltp_image.txt
           output/last_build_image.txt
         retention-days: 7
+
+    # Upload LTP binaries tarball (the /opt/ltp install tree) for downstream
+    # testing on any arch-matching host.
+    - name: Upload LTP binaries tarball
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      if: ${{ always() && needs.pre-setup.outputs.skip_ltp == 'false' }}
+      with:
+        name: ltp-binaries-${{ matrix.arch }}
+        path: output/ltp-*.tar.xz
+        retention-days: 7
+        if-no-files-found: warn
 
     # Upload plain boot qcow2 image (only when both kselftests and LTP are skipped)
     - name: Upload plain boot qcow2 image
@@ -1175,10 +1202,14 @@ jobs:
     name: Create Pull Request
     runs-on: kernel-build
     needs: [pre-setup, setup, build, boot, test-kselftest, compare-kselftest, test-ltp, compare-ltp]
+    # The (workflow_dispatch || !no_pr) clause lets manual reruns opt out of
+    # PR creation by passing -f no_pr=true. workflow_run events (normal CI)
+    # are unaffected since inputs.no_pr is not set there.
     if: |
       always() &&
       needs.build.result == 'success' &&
-      needs.boot.result == 'success'
+      needs.boot.result == 'success' &&
+      (github.event_name != 'workflow_dispatch' || !inputs.no_pr)
 
     steps:
     - name: Check if branch name matches a supported pattern

--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -289,7 +289,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-test-suite-tarballs
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -440,7 +440,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-test-suite-tarballs
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -522,7 +522,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-test-suite-tarballs
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -592,7 +592,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-test-suite-tarballs
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -690,7 +690,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: main
+        ref: extract-test-suite-tarballs
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 

--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -289,7 +289,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-test-suite-tarballs
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -440,7 +440,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-test-suite-tarballs
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -522,7 +522,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-test-suite-tarballs
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -592,7 +592,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-test-suite-tarballs
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 
@@ -690,7 +690,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: ctrliq/kernel-container-build
-        ref: extract-test-suite-tarballs
+        ref: main
         path: kernel-container-build
         token: ${{ steps.generate_token.outputs.token }}
 

--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -1202,14 +1202,16 @@ jobs:
     name: Create Pull Request
     runs-on: kernel-build
     needs: [pre-setup, setup, build, boot, test-kselftest, compare-kselftest, test-ltp, compare-ltp]
-    # The (workflow_dispatch || !no_pr) clause lets manual reruns opt out of
-    # PR creation by passing -f no_pr=true. workflow_run events (normal CI)
-    # are unaffected since inputs.no_pr is not set there.
+    # The (workflow_dispatch || no_pr != true) clause lets manual reruns opt
+    # out of PR creation by passing -f no_pr=true. workflow_run events (normal
+    # CI) are unaffected since inputs.no_pr is not set there. The explicit
+    # `!= true` form avoids the boolean/string coercion ambiguity that affects
+    # `!inputs.no_pr` in some GHA expression contexts.
     if: |
       always() &&
       needs.build.result == 'success' &&
       needs.boot.result == 'success' &&
-      (github.event_name != 'workflow_dispatch' || !inputs.no_pr)
+      (github.event_name != 'workflow_dispatch' || inputs.no_pr != true)
 
     steps:
     - name: Check if branch name matches a supported pattern


### PR DESCRIPTION
## Summary
Follow-on to #1225 (kernel binaries tarball). Three changes to the multi-arch workflow:

1. **New `upload-artifact` steps** publish the kselftests and LTP install-tree tarballs produced by [ctrliq/kernel-container-build#33](https://github.com/ctrliq/kernel-container-build/pull/33):
   - `kselftests-binaries-<arch>` — `output/kselftests-*.tar.xz`
   - `ltp-binaries-<arch>` — `output/ltp-*.tar.xz`
   Both honor existing `skip_kselftests` / `skip_ltp` metadata; both use `if-no-files-found: warn` so a missing tarball is non-fatal.
2. **New `workflow_dispatch` input `no_pr`** (bool, default `false`) lets manual reruns suppress the `create-pr` job — useful for integration testing without producing a spurious `created-by-kernelci` PR. `workflow_run` events (normal CI) are unaffected.
3. **Tightened `create-pr` `if`-condition** to honor `no_pr` when set on a `workflow_dispatch` event.

## Order of operations
Land [ctrliq/kernel-container-build#33](https://github.com/ctrliq/kernel-container-build/pull/33) **first**. Until that's merged, the upload step will find no file in `output/` and log a warning (non-fatal). Once kernel-container-build is producing the tarballs, this PR can land.

## Cleanup before merge
The `TEST ONLY` commit on this branch (`832854d7`) pins the workflow's `kernel-container-build` checkout to the `extract-test-suite-tarballs` branch so we can exercise the change via `workflow_dispatch` before either side merges. **Revert that commit before flipping out of draft** — or use "Squash and merge" and hand-edit the diff to drop it.

## Wiki note
The [Kernel CI Workflow Confluence page](https://ciqinc.atlassian.net/wiki/spaces/ENG/pages/1892384771/Kernel+CI+Workflow+for+Builds+and+Testing) should be updated post-merge to reflect:
- New artifacts (`kernel-binaries-<arch>`, `kselftests-binaries-<arch>`, `ltp-binaries-<arch>`)
- LTP stage (test-ltp + compare-ltp jobs aren't currently documented)
- `workflow_dispatch` usage incl. `run_id` and the new `no_pr` input
- Helper script links should reference `main` instead of `automated-testing-v1`

## Test plan
- [ ] `workflow_dispatch` against this branch with `no_pr=true` and a real PR's `run_id`: verify `kselftests-binaries-<arch>` and `ltp-binaries-<arch>` appear in the Artifacts section, and that **no PR** is created/edited
- [ ] Confirm the primary qcow2 artifacts still upload alongside

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Test results

Validated end-to-end via `workflow_dispatch` on https://github.com/ctrliq/kernel-src-tree/actions/runs/26651444112 (3h36m, full pipeline).

| Job | Result |
|---|---|
| Build (x86_64 + aarch64) | ✓ success |
| Boot verification (both arches) | ✓ success |
| Kselftests (both arches) | ✓ success |
| LTP (both arches) | ✓ success |
| Compare kselftests / LTP (both) | ✓ success |
| Create Pull Request | **skipped** (`no_pr=true` honored) |

**Artifacts produced (all expected, plus existing qcow2 / logs / boot-logs):**
- `kernel-binaries-x86_64` 86 MB / `kernel-binaries-aarch64` 62 MB
- `kselftests-binaries-x86_64` 46 MB / `kselftests-binaries-aarch64` 45 MB
- `ltp-binaries-x86_64` 137 MB / `ltp-binaries-aarch64` 135 MB

**PR-creation suppression confirmed**: no new `created-by-kernelci` PR was created during the test run.
