### PR TITLE
github actions: fix notify-slack script fetch failing on checked-out main

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch.yml
@@ -1706,7 +1706,7 @@ jobs:
       - name: Fetch notification script from main
         if: steps.decide.outputs.should_notify == 'true'
         run: |
-          git fetch origin main:main
+          git fetch --depth=1 --no-tags origin main
           git checkout origin/main -- .github/scripts/notify-slack-kernelci.sh
           chmod +x .github/scripts/notify-slack-kernelci.sh
 


### PR DESCRIPTION
The notify-slack job checks out the repo without specifying a ref, so it lands on the local main branch. The subsequent `git fetch origin main:main` then tries to write into refs/heads/main while it's the checked-out branch, which Git refuses:

  fatal: refusing to fetch into branch 'refs/heads/main' checked out at ...

Drop the explicit destination refspec so the fetch updates the remote-tracking ref refs/remotes/origin/main instead of the local branch. The following
`git checkout origin/main -- .github/scripts/notify-slack-kernelci.sh` should be unaffected.

Pipeline that failed https://github.com/ctrliq/kernel-src-tree/actions/runs/27123775148/job/80050683847

Retriggered pipeline with the fix https://github.com/ctrliq/kernel-src-tree/actions/runs/27132149619
and we received the notification on slack. 