### PR TITLE
[rocky8_10] History Rebuild through kernel-4.18.0-553.129.1.el8_10

### DIFF
--- a/Makefile.rhelver
+++ b/Makefile.rhelver
@@ -12,7 +12,7 @@ RHEL_MINOR = 10
 #
 # Use this spot to avoid future merge conflicts.
 # Do not trim this comment.
-RHEL_RELEASE = 553.126.1
+RHEL_RELEASE = 553.129.1
 
 #
 # ZSTREAM

--- a/ciq/ciq_backports/kernel-4.18.0-553.129.1.el8_10/3df690bb.failed
+++ b/ciq/ciq_backports/kernel-4.18.0-553.129.1.el8_10/3df690bb.failed
@@ -1,0 +1,203 @@
+smb: client: fix OOB reads parsing symlink error response
+
+jira KERNEL-1129
+cve CVE-2026-31613
+Rebuild_History Non-Buildable kernel-4.18.0-553.129.1.el8_10
+commit-author Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+commit 3df690bba28edec865cf7190be10708ad0ddd67e
+Empty-Commit: Cherry-Pick Conflicts during history rebuild.
+Will be included in final tarball splat. Ref for failed cherry-pick at:
+ciq/ciq_backports/kernel-4.18.0-553.129.1.el8_10/3df690bb.failed
+
+When a CREATE returns STATUS_STOPPED_ON_SYMLINK, smb2_check_message()
+returns success without any length validation, leaving the symlink
+parsers as the only defense against an untrusted server.
+
+symlink_data() walks SMB 3.1.1 error contexts with the loop test "p <
+end", but reads p->ErrorId at offset 4 and p->ErrorDataLength at offset
+0.  When the server-controlled ErrorDataLength advances p to within 1-7
+bytes of end, the next iteration will read past it.  When the matching
+context is found, sym->SymLinkErrorTag is read at offset 4 from
+p->ErrorContextData with no check that the symlink header itself fits.
+
+smb2_parse_symlink_response() then bounds-checks the substitute name
+using SMB2_SYMLINK_STRUCT_SIZE as the offset of PathBuffer from
+iov_base.  That value is computed as sizeof(smb2_err_rsp) +
+sizeof(smb2_symlink_err_rsp), which is correct only when
+ErrorContextCount == 0.
+
+With at least one error context the symlink data sits 8 bytes deeper,
+and each skipped non-matching context shifts it further by 8 +
+ALIGN(ErrorDataLength, 8).  The check is too short, allowing the
+substitute name read to run past iov_len.  The out-of-bound heap bytes
+are UTF-16-decoded into the symlink target and returned to userspace via
+readlink(2).
+
+Fix this all up by making the loops test require the full context header
+to fit, rejecting sym if its header runs past end, and bound the
+substitute name against the actual position of sym->PathBuffer rather
+than a fixed offset.
+
+Because sub_offs and sub_len are 16bits, the pointer math will not
+overflow here with the new greater-than.
+
+	Cc: Ronnie Sahlberg <ronniesahlberg@gmail.com>
+	Cc: Shyam Prasad N <sprasad@microsoft.com>
+	Cc: Tom Talpey <tom@talpey.com>
+	Cc: Bharath SM <bharathsm@microsoft.com>
+	Cc: linux-cifs@vger.kernel.org
+	Cc: samba-technical@lists.samba.org
+	Cc: stable <stable@kernel.org>
+	Reviewed-by: Paulo Alcantara (Red Hat) <pc@manguebit.org>
+Assisted-by: gregkh_clanker_t1000
+	Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+	Signed-off-by: Steve French <stfrench@microsoft.com>
+(cherry picked from commit 3df690bba28edec865cf7190be10708ad0ddd67e)
+	Signed-off-by: Jonathan Maple <jmaple@ciq.com>
+
+# Conflicts:
+#	fs/cifs/smb2file.c
+diff --cc fs/cifs/smb2file.c
+index 9dfd2dd612c2,b292aa94a593..000000000000
+--- a/fs/cifs/smb2file.c
++++ b/fs/cifs/smb2file.c
+@@@ -20,10 -20,132 +20,136 @@@
+  #include "cifs_unicode.h"
+  #include "fscache.h"
+  #include "smb2proto.h"
+ -#include "../common/smb2status.h"
+ -#include "../common/smbfsctl.h"
+  
+++<<<<<<< HEAD:fs/cifs/smb2file.c
+ +int
+ +smb2_open_file(const unsigned int xid, struct cifs_open_parms *oparms,
+ +	       __u32 *oplock, FILE_ALL_INFO *buf)
+++=======
++ static struct smb2_symlink_err_rsp *symlink_data(const struct kvec *iov)
++ {
++ 	struct smb2_err_rsp *err = iov->iov_base;
++ 	struct smb2_symlink_err_rsp *sym = ERR_PTR(-EINVAL);
++ 	u8 *end = (u8 *)err + iov->iov_len;
++ 	u32 len;
++ 
++ 	if (err->ErrorContextCount) {
++ 		struct smb2_error_context_rsp *p;
++ 
++ 		len = (u32)err->ErrorContextCount * (offsetof(struct smb2_error_context_rsp,
++ 							      ErrorContextData) +
++ 						     sizeof(struct smb2_symlink_err_rsp));
++ 		if (le32_to_cpu(err->ByteCount) < len || iov->iov_len < len + sizeof(*err) + 1)
++ 			return ERR_PTR(-EINVAL);
++ 
++ 		p = (struct smb2_error_context_rsp *)err->ErrorData;
++ 		while ((u8 *)p + sizeof(*p) <= end) {
++ 			if (le32_to_cpu(p->ErrorId) == SMB2_ERROR_ID_DEFAULT) {
++ 				sym = (struct smb2_symlink_err_rsp *)p->ErrorContextData;
++ 				break;
++ 			}
++ 			cifs_dbg(FYI, "%s: skipping unhandled error context: 0x%x\n",
++ 				 __func__, le32_to_cpu(p->ErrorId));
++ 
++ 			len = ALIGN(le32_to_cpu(p->ErrorDataLength), 8);
++ 			p = (struct smb2_error_context_rsp *)(p->ErrorContextData + len);
++ 		}
++ 	} else if (le32_to_cpu(err->ByteCount) >= sizeof(*sym) &&
++ 		   iov->iov_len >= SMB2_SYMLINK_STRUCT_SIZE) {
++ 		sym = (struct smb2_symlink_err_rsp *)err->ErrorData;
++ 	}
++ 
++ 	if (!IS_ERR(sym) &&
++ 	    ((u8 *)sym + sizeof(*sym) > end ||
++ 	     le32_to_cpu(sym->SymLinkErrorTag) != SYMLINK_ERROR_TAG ||
++ 	     le32_to_cpu(sym->ReparseTag) != IO_REPARSE_TAG_SYMLINK))
++ 		sym = ERR_PTR(-EINVAL);
++ 
++ 	return sym;
++ }
++ 
++ int smb2_fix_symlink_target_type(char **target, bool directory, struct cifs_sb_info *cifs_sb)
++ {
++ 	char *buf;
++ 	int len;
++ 
++ 	/*
++ 	 * POSIX server does not distinguish between symlinks to file and
++ 	 * symlink directory. So nothing is needed to fix on the client side.
++ 	 */
++ 	if (cifs_sb_flags(cifs_sb) & CIFS_MOUNT_POSIX_PATHS)
++ 		return 0;
++ 
++ 	if (!*target)
++ 		return smb_EIO(smb_eio_trace_null_pointers);
++ 
++ 	len = strlen(*target);
++ 	if (!len)
++ 		return smb_EIO1(smb_eio_trace_sym_target_len, len);
++ 
++ 	/*
++ 	 * If this is directory symlink and it does not have trailing slash then
++ 	 * append it. Trailing slash simulates Windows/SMB behavior which do not
++ 	 * allow resolving directory symlink to file.
++ 	 */
++ 	if (directory && (*target)[len-1] != '/') {
++ 		buf = krealloc(*target, len+2, GFP_KERNEL);
++ 		if (!buf)
++ 			return -ENOMEM;
++ 		buf[len] = '/';
++ 		buf[len+1] = '\0';
++ 		*target = buf;
++ 		len++;
++ 	}
++ 
++ 	/*
++ 	 * If this is a file (non-directory) symlink and it points to path name
++ 	 * with trailing slash then this is an invalid symlink because file name
++ 	 * cannot contain slash character. File name with slash is invalid on
++ 	 * both Windows and Linux systems. So return an error for such symlink.
++ 	 */
++ 	if (!directory && (*target)[len-1] == '/')
++ 		return smb_EIO(smb_eio_trace_sym_slash);
++ 
++ 	return 0;
++ }
++ 
++ int smb2_parse_symlink_response(struct cifs_sb_info *cifs_sb, const struct kvec *iov,
++ 				const char *full_path, char **path)
++ {
++ 	struct smb2_symlink_err_rsp *sym;
++ 	unsigned int sub_offs, sub_len;
++ 	unsigned int print_offs, print_len;
++ 
++ 	if (!cifs_sb || !iov || !iov->iov_base || !iov->iov_len || !path)
++ 		return -EINVAL;
++ 
++ 	sym = symlink_data(iov);
++ 	if (IS_ERR(sym))
++ 		return PTR_ERR(sym);
++ 
++ 	sub_len = le16_to_cpu(sym->SubstituteNameLength);
++ 	sub_offs = le16_to_cpu(sym->SubstituteNameOffset);
++ 	print_len = le16_to_cpu(sym->PrintNameLength);
++ 	print_offs = le16_to_cpu(sym->PrintNameOffset);
++ 
++ 	if ((char *)sym->PathBuffer + sub_offs + sub_len >
++ 		(char *)iov->iov_base + iov->iov_len ||
++ 	    (char *)sym->PathBuffer + print_offs + print_len >
++ 		(char *)iov->iov_base + iov->iov_len)
++ 		return -EINVAL;
++ 
++ 	return smb2_parse_native_symlink(path,
++ 					 (char *)sym->PathBuffer + sub_offs,
++ 					 sub_len,
++ 					 le32_to_cpu(sym->Flags) & SYMLINK_FLAG_RELATIVE,
++ 					 full_path,
++ 					 cifs_sb);
++ }
++ 
++ int smb2_open_file(const unsigned int xid, struct cifs_open_parms *oparms,
++ 		   __u32 *oplock, void *buf)
+++>>>>>>> 3df690bba28e (smb: client: fix OOB reads parsing symlink error response):fs/smb/client/smb2file.c
+  {
+  	int rc;
+  	__le16 *smb2_path;
+* Unmerged path fs/cifs/smb2file.c

--- a/ciq/ciq_backports/kernel-4.18.0-553.129.1.el8_10/d73f4b53.failed
+++ b/ciq/ciq_backports/kernel-4.18.0-553.129.1.el8_10/d73f4b53.failed
@@ -1,0 +1,66 @@
+netfilter: nf_tables: release flowtable after rcu grace period on error
+
+jira KERNEL-1129
+cve CVE-2026-23392
+Rebuild_History Non-Buildable kernel-4.18.0-553.129.1.el8_10
+commit-author Pablo Neira Ayuso <pablo@netfilter.org>
+commit d73f4b53aaaea4c95f245e491aa5eeb8a21874ce
+Empty-Commit: Cherry-Pick Conflicts during history rebuild.
+Will be included in final tarball splat. Ref for failed cherry-pick at:
+ciq/ciq_backports/kernel-4.18.0-553.129.1.el8_10/d73f4b53.failed
+
+Call synchronize_rcu() after unregistering the hooks from error path,
+since a hook that already refers to this flowtable can be already
+registered, exposing this flowtable to packet path and nfnetlink_hook
+control plane.
+
+This error path is rare, it should only happen by reaching the maximum
+number hooks or by failing to set up to hardware offload, just call
+synchronize_rcu().
+
+There is a check for already used device hooks by different flowtable
+that could result in EEXIST at this late stage. The hook parser can be
+updated to perform this check earlier to this error path really becomes
+rarely exercised.
+
+Uncovered by KASAN reported as use-after-free from nfnetlink_hook path
+when dumping hooks.
+
+Fixes: 3b49e2e94e6e ("netfilter: nf_tables: add flow table netlink frontend")
+	Reported-by: Yiming Qian <yimingqian591@gmail.com>
+	Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+	Signed-off-by: Florian Westphal <fw@strlen.de>
+(cherry picked from commit d73f4b53aaaea4c95f245e491aa5eeb8a21874ce)
+	Signed-off-by: Jonathan Maple <jmaple@ciq.com>
+
+# Conflicts:
+#	net/netfilter/nf_tables_api.c
+diff --cc net/netfilter/nf_tables_api.c
+index f6ea6960927c,3922cff1bb3d..000000000000
+--- a/net/netfilter/nf_tables_api.c
++++ b/net/netfilter/nf_tables_api.c
+@@@ -7064,13 -9201,13 +7064,23 @@@ static int nf_tables_newflowtable(struc
+  	list_add_tail_rcu(&flowtable->list, &table->flowtables);
+  
+  	return 0;
+++<<<<<<< HEAD
+ +err5:
+ +	list_for_each_entry_safe(hook, next, &flowtable->hook_list, list) {
+ +		nft_unregister_flowtable_hook(net, flowtable, hook);
+ +		list_del_rcu(&hook->list);
+ +		kfree_rcu(hook, rcu);
+ +	}
+ +err4:
+++=======
++ 
++ err_flowtable_hooks:
++ 	synchronize_rcu();
++ 	nft_trans_destroy(trans);
++ err_flowtable_trans:
++ 	nft_hooks_destroy(&flowtable->hook_list);
++ err_flowtable_parse_hooks:
+++>>>>>>> d73f4b53aaae (netfilter: nf_tables: release flowtable after rcu grace period on error)
+  	flowtable->data.type->free(&flowtable->data);
+  err3:
+  	module_put(type->owner);
+* Unmerged path net/netfilter/nf_tables_api.c

--- a/ciq/ciq_backports/kernel-4.18.0-553.129.1.el8_10/rebuild.details.txt
+++ b/ciq/ciq_backports/kernel-4.18.0-553.129.1.el8_10/rebuild.details.txt
@@ -1,0 +1,24 @@
+Rebuild_History BUILDABLE
+Rebuilding Kernel from rpm changelog with Fuzz Limit: 87.50%
+Number of commits in upstream range v4.18~1..kernel-mainline: 625874
+Number of commits in rpm: 15
+Number of commits matched with upstream: 9 (60.00%)
+Number of commits in upstream but not in rpm: 625865
+Number of commits NOT found in upstream: 6 (40.00%)
+
+Rebuilding Kernel on Branch rocky8_10_rebuild_kernel-4.18.0-553.129.1.el8_10 for kernel-4.18.0-553.129.1.el8_10
+Clean Cherry Picks: 7 (77.78%)
+Empty Cherry Picks: 2 (22.22%)
+_______________________________
+
+__EMPTY COMMITS__________________________
+d73f4b53aaaea4c95f245e491aa5eeb8a21874ce netfilter: nf_tables: release flowtable after rcu grace period on error
+3df690bba28edec865cf7190be10708ad0ddd67e smb: client: fix OOB reads parsing symlink error response
+
+__CHANGES NOT IN UPSTREAM________________
+Adding prod certs and changed cert date to 20210620
+Adding Rocky secure boot certs
+Fixing vmlinuz removal
+Fixing UEFI CA path
+Porting to 8.10, debranding and Rocky branding
+Fixing pesign_key_name values

--- a/configs/kernel-4.18.0-aarch64-debug.config
+++ b/configs/kernel-4.18.0-aarch64-debug.config
@@ -5,7 +5,7 @@
 #
 
 #
-# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/configs/kernel-4.18.0-aarch64.config
+++ b/configs/kernel-4.18.0-aarch64.config
@@ -5,7 +5,7 @@
 #
 
 #
-# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y

--- a/configs/kernel-4.18.0-ppc64le-debug.config
+++ b/configs/kernel-4.18.0-ppc64le-debug.config
@@ -5,7 +5,7 @@
 #
 
 #
-# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
 #
 CONFIG_PPC64=y
 

--- a/configs/kernel-4.18.0-ppc64le.config
+++ b/configs/kernel-4.18.0-ppc64le.config
@@ -5,7 +5,7 @@
 #
 
 #
-# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
 #
 CONFIG_PPC64=y
 

--- a/configs/kernel-4.18.0-s390x-debug.config
+++ b/configs/kernel-4.18.0-s390x-debug.config
@@ -5,7 +5,7 @@
 #
 
 #
-# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/configs/kernel-4.18.0-s390x-zfcpdump.config
+++ b/configs/kernel-4.18.0-s390x-zfcpdump.config
@@ -5,7 +5,7 @@
 #
 
 #
-# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/configs/kernel-4.18.0-s390x.config
+++ b/configs/kernel-4.18.0-s390x.config
@@ -5,7 +5,7 @@
 #
 
 #
-# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
 #
 CONFIG_MMU=y
 CONFIG_ZONE_DMA=y

--- a/configs/kernel-4.18.0-x86_64-debug.config
+++ b/configs/kernel-4.18.0-x86_64-debug.config
@@ -5,7 +5,7 @@
 #
 
 #
-# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/configs/kernel-4.18.0-x86_64.config
+++ b/configs/kernel-4.18.0-x86_64.config
@@ -5,7 +5,7 @@
 #
 
 #
-# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+# Compiler: gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/drivers/block/nbd.c
+++ b/drivers/block/nbd.c
@@ -2059,12 +2059,13 @@ again:
 	}
 	set_bit(NBD_RT_HAS_BACKEND_FILE, &config->runtime_flags);
 out:
-	mutex_unlock(&nbd->config_lock);
 	if (!ret) {
 		set_bit(NBD_RT_HAS_CONFIG_REF, &config->runtime_flags);
 		refcount_inc(&nbd->config_refs);
 		nbd_connect_reply(info, nbd->index);
 	}
+	mutex_unlock(&nbd->config_lock);
+
 	nbd_config_put(nbd);
 	if (put_dev)
 		nbd_put(nbd);

--- a/drivers/net/geneve.c
+++ b/drivers/net/geneve.c
@@ -1943,16 +1943,11 @@ static void geneve_destroy_tunnels(struct net *net, struct list_head *head)
 	/* gather any geneve devices that were moved into this ns */
 	for_each_netdev_safe(net, dev, aux)
 		if (dev->rtnl_link_ops == &geneve_link_ops)
-			unregister_netdevice_queue(dev, head);
+			geneve_dellink(dev, head);
 
 	/* now gather any other geneve devices that were created in this ns */
-	list_for_each_entry_safe(geneve, next, &gn->geneve_list, next) {
-		/* If geneve->dev is in the same netns, it was already added
-		 * to the list by the previous loop.
-		 */
-		if (!net_eq(dev_net(geneve->dev), net))
-			unregister_netdevice_queue(geneve->dev, head);
-	}
+	list_for_each_entry_safe(geneve, next, &gn->geneve_list, next)
+		geneve_dellink(geneve->dev, head);
 }
 
 static void __net_exit geneve_exit_batch_net(struct list_head *net_list)

--- a/drivers/net/geneve.c
+++ b/drivers/net/geneve.c
@@ -1938,14 +1938,7 @@ static void geneve_destroy_tunnels(struct net *net, struct list_head *head)
 {
 	struct geneve_net *gn = net_generic(net, geneve_net_id);
 	struct geneve_dev *geneve, *next;
-	struct net_device *dev, *aux;
 
-	/* gather any geneve devices that were moved into this ns */
-	for_each_netdev_safe(net, dev, aux)
-		if (dev->rtnl_link_ops == &geneve_link_ops)
-			geneve_dellink(dev, head);
-
-	/* now gather any other geneve devices that were created in this ns */
 	list_for_each_entry_safe(geneve, next, &gn->geneve_list, next)
 		geneve_dellink(geneve->dev, head);
 }

--- a/fs/cifs/cifs_spnego.c
+++ b/fs/cifs/cifs_spnego.c
@@ -8,6 +8,7 @@
  */
 
 #include <linux/list.h>
+#include <linux/cred.h>
 #include <linux/slab.h>
 #include <linux/string.h>
 #include <keys/user-type.h>
@@ -46,12 +47,27 @@ cifs_spnego_key_destroy(struct key *key)
 	kfree(key->payload.data[0]);
 }
 
+static int
+cifs_spnego_key_vet_description(const char *description)
+{
+	/*
+	 * cifs.spnego descriptions are authority-bearing inputs to cifs.upcall.
+	 * They are only valid when produced by CIFS while using the private
+	 * spnego_cred installed below.  Do not let userspace create this type
+	 * of key through request_key(2)/add_key(2), since the helper treats
+	 * pid/uid/creduid/upcall_target as kernel-originating fields.
+	 */
+	if (current_cred() != spnego_cred)
+		return -EPERM;
+	return 0;
+}
 
 /*
  * keytype for CIFS spnego keys
  */
 struct key_type cifs_spnego_key_type = {
 	.name		= "cifs.spnego",
+	.vet_description = cifs_spnego_key_vet_description,
 	.instantiate	= cifs_spnego_key_instantiate,
 	.destroy	= cifs_spnego_key_destroy,
 	.describe	= user_describe,

--- a/fs/cifs/smb2ops.c
+++ b/fs/cifs/smb2ops.c
@@ -3134,7 +3134,49 @@ parse_reparse_point(struct reparse_data_buffer *buf,
 }
 
 #define SMB2_SYMLINK_STRUCT_SIZE \
-	(sizeof(struct smb2_err_rsp) - 1 + sizeof(struct smb2_symlink_err_rsp))
+	(sizeof(struct smb2_err_rsp) + sizeof(struct smb2_symlink_err_rsp))
+
+static struct smb2_symlink_err_rsp *symlink_data(const struct kvec *iov)
+{
+	struct smb2_err_rsp *err = iov->iov_base;
+	struct smb2_symlink_err_rsp *sym = ERR_PTR(-EINVAL);
+	u8 *end = (u8 *)err + iov->iov_len;
+	u32 len;
+
+	if (err->ErrorContextCount) {
+		struct smb2_error_context_rsp *p;
+
+		len = (u32)err->ErrorContextCount * (offsetof(struct smb2_error_context_rsp,
+							      ErrorContextData) +
+						     sizeof(struct smb2_symlink_err_rsp));
+		if (le32_to_cpu(err->ByteCount) < len || iov->iov_len < len + sizeof(*err) + 1)
+			return ERR_PTR(-EINVAL);
+
+		p = (struct smb2_error_context_rsp *)err->ErrorData;
+		while ((u8 *)p + sizeof(*p) <= end) {
+			if (le32_to_cpu(p->ErrorId) == SMB2_ERROR_ID_DEFAULT) {
+				sym = (struct smb2_symlink_err_rsp *)p->ErrorContextData;
+				break;
+			}
+			cifs_dbg(FYI, "%s: skipping unhandled error context: 0x%x\n",
+				 __func__, le32_to_cpu(p->ErrorId));
+
+			len = ALIGN(le32_to_cpu(p->ErrorDataLength), 8);
+			p = (struct smb2_error_context_rsp *)(p->ErrorContextData + len);
+		}
+	} else if (le32_to_cpu(err->ByteCount) >= sizeof(*sym) &&
+		   iov->iov_len >= SMB2_SYMLINK_STRUCT_SIZE) {
+		sym = (struct smb2_symlink_err_rsp *)err->ErrorData;
+	}
+
+	if (!IS_ERR(sym) &&
+	    ((u8 *)sym + sizeof(*sym) > end ||
+	     le32_to_cpu(sym->SymLinkErrorTag) != SYMLINK_ERROR_TAG ||
+	     le32_to_cpu(sym->ReparseTag) != IO_REPARSE_TAG_SYMLINK))
+		sym = ERR_PTR(-EINVAL);
+
+	return sym;
+}
 
 static int
 smb2_query_symlink(const unsigned int xid, struct cifs_tcon *tcon,
@@ -3147,7 +3189,6 @@ smb2_query_symlink(const unsigned int xid, struct cifs_tcon *tcon,
 	struct cifs_open_parms oparms;
 	struct cifs_fid fid;
 	struct kvec err_iov = {NULL, 0};
-	struct smb2_err_rsp *err_buf = NULL;
 	struct smb2_symlink_err_rsp *symlink;
 	struct TCP_Server_Info *server = cifs_pick_channel(tcon->ses);
 	unsigned int sub_len;
@@ -3165,6 +3206,7 @@ smb2_query_symlink(const unsigned int xid, struct cifs_tcon *tcon,
 	struct smb2_ioctl_rsp *ioctl_rsp;
 	struct reparse_data_buffer *reparse_buf;
 	int create_options = is_reparse_point ? OPEN_REPARSE_POINT : 0;
+	size_t len;
 	u32 plen;
 
 	cifs_dbg(FYI, "%s: path: %s\n", __func__, full_path);
@@ -3270,35 +3312,38 @@ smb2_query_symlink(const unsigned int xid, struct cifs_tcon *tcon,
 		goto querty_exit;
 	}
 
-	err_buf = err_iov.iov_base;
-	if (le32_to_cpu(err_buf->ByteCount) < sizeof(struct smb2_symlink_err_rsp) ||
-	    err_iov.iov_len < SMB2_SYMLINK_STRUCT_SIZE) {
-		rc = -EINVAL;
-		goto querty_exit;
-	}
-
-	symlink = (struct smb2_symlink_err_rsp *)err_buf->ErrorData;
-	if (le32_to_cpu(symlink->SymLinkErrorTag) != SYMLINK_ERROR_TAG ||
-	    le32_to_cpu(symlink->ReparseTag) != IO_REPARSE_TAG_SYMLINK) {
-		rc = -EINVAL;
-		goto querty_exit;
-	}
-
 	/* open must fail on symlink - reset rc */
 	rc = 0;
+	symlink = symlink_data(&err_iov);
+	if (IS_ERR(symlink)) {
+		rc = PTR_ERR(symlink);
+		goto querty_exit;
+	}
+
 	sub_len = le16_to_cpu(symlink->SubstituteNameLength);
 	sub_offset = le16_to_cpu(symlink->SubstituteNameOffset);
 	print_len = le16_to_cpu(symlink->PrintNameLength);
 	print_offset = le16_to_cpu(symlink->PrintNameOffset);
 
-	if (err_iov.iov_len < SMB2_SYMLINK_STRUCT_SIZE + sub_offset + sub_len) {
+	if ((char *)symlink->PathBuffer + sub_offset + sub_len >
+	    (char *)err_iov.iov_base + err_iov.iov_len ||
+	    (char *)symlink->PathBuffer + print_offset + print_len >
+	    (char *)err_iov.iov_base + err_iov.iov_len) {
+		cifs_dbg(VFS, "srv returned malformed symlink buffer\n");
 		rc = -EINVAL;
 		goto querty_exit;
 	}
 
-	if (err_iov.iov_len <
-	    SMB2_SYMLINK_STRUCT_SIZE + print_offset + print_len) {
-		rc = -EINVAL;
+	if (!sub_len || (sub_len % 2)) {
+		cifs_dbg(VFS, "srv returned malformed symlink buffer\n");
+		rc = -EIO;
+		goto querty_exit;
+	}
+	len = UniStrnlen((wchar_t *)((char *)symlink->PathBuffer + sub_offset),
+			 sub_len / 2);
+	if (len != sub_len / 2) {
+		cifs_dbg(VFS, "srv returned null byte in native symlink target location\n");
+		rc = -EIO;
 		goto querty_exit;
 	}
 

--- a/fs/cifs/smb2pdu.h
+++ b/fs/cifs/smb2pdu.h
@@ -57,7 +57,8 @@ struct smb2_rdma_encryption_transform {
 struct smb2_err_rsp {
 	struct smb2_hdr hdr;
 	__le16 StructureSize;
-	__le16 Reserved; /* MBZ */
+	__u8   ErrorContextCount;
+	__u8   Reserved;
 	__le32 ByteCount;  /* even if zero, at least one byte follows */
 	__u8   ErrorData[];  /* variable length */
 } __packed;
@@ -82,7 +83,7 @@ struct smb2_symlink_err_rsp {
 struct smb2_error_context_rsp {
 	__le32 ErrorDataLength;
 	__le32 ErrorId;
-	__u8  ErrorContextData; /* ErrorDataLength long array */
+	__u8  ErrorContextData[]; /* ErrorDataLength long array */
 } __packed;
 
 /* ErrorId values */

--- a/net/ceph/messenger_v2.c
+++ b/net/ceph/messenger_v2.c
@@ -2191,7 +2191,9 @@ static int process_auth_done(struct ceph_connection *con, void *p, void *end)
 
 	ceph_decode_64_safe(&p, end, global_id, bad);
 	ceph_decode_32_safe(&p, end, con->v2.con_mode, bad);
+
 	ceph_decode_32_safe(&p, end, payload_len, bad);
+	ceph_decode_need(&p, end, payload_len, bad);
 
 	dout("%s con %p global_id %llu con_mode %d payload_len %d\n",
 	     __func__, con, global_id, con->v2.con_mode, payload_len);

--- a/net/ceph/osdmap.c
+++ b/net/ceph/osdmap.c
@@ -1959,10 +1959,12 @@ struct ceph_osdmap *osdmap_apply_incremental(void **p, void *end, bool msgr2,
 			 sizeof(u64) + sizeof(u32), e_inval);
 	ceph_decode_copy(p, &fsid, sizeof(fsid));
 	epoch = ceph_decode_32(p);
-	BUG_ON(epoch != map->epoch+1);
 	ceph_decode_copy(p, &modified, sizeof(modified));
 	new_pool_max = ceph_decode_64(p);
 	new_flags = ceph_decode_32(p);
+
+	if (epoch != map->epoch + 1)
+		goto e_inval;
 
 	/* full map? */
 	ceph_decode_32_safe(p, end, len, e_inval);

--- a/net/netfilter/nf_tables_api.c
+++ b/net/netfilter/nf_tables_api.c
@@ -7071,6 +7071,7 @@ err5:
 		kfree_rcu(hook, rcu);
 	}
 err4:
+	synchronize_rcu();
 	flowtable->data.type->free(&flowtable->data);
 err3:
 	module_put(type->owner);

--- a/net/smc/af_smc.c
+++ b/net/smc/af_smc.c
@@ -3270,6 +3270,17 @@ static int __smc_create(struct net *net, struct socket *sock, int protocol,
 			sk_common_release(sk);
 			goto out;
 		}
+
+		/* smc_clcsock_release() does not wait smc->clcsock->sk's
+		 * destruction;  its sk_state might not be TCP_CLOSE after
+		 * smc->sk is close()d, and TCP timers can be fired later,
+		 * which need net ref.
+		 */
+		sk = smc->clcsock->sk;
+		__netns_tracker_free(net, &sk->ns_tracker, false);
+		sk->sk_net_refcnt = 1;
+		get_net_track(net, &sk->ns_tracker, GFP_KERNEL);
+		sock_inuse_add(net, 1);
 	} else {
 		smc->clcsock = clcsock;
 	}

--- a/net/smc/af_smc.c
+++ b/net/smc/af_smc.c
@@ -3277,10 +3277,10 @@ static int __smc_create(struct net *net, struct socket *sock, int protocol,
 		 * which need net ref.
 		 */
 		sk = smc->clcsock->sk;
-		__netns_tracker_free(net, &sk->ns_tracker, false);
 		sk->sk_net_refcnt = 1;
-		get_net_track(net, &sk->ns_tracker, GFP_KERNEL);
-		sock_inuse_add(net, 1);
+		get_net(net);
+		sock_prot_inuse_add(net, sk->sk_prot, 1);
+
 	} else {
 		smc->clcsock = clcsock;
 	}


### PR DESCRIPTION
This is an automated kernel history rebuild using cron and internal tooling. It follows the same process used for previous history rebuilds:

* Download all unprocessed `src.rpm` packages
* For each `src.rpm`:
  * Identify all commits in the changelog up to the last known tag (`4.18.0-553`)
  * Replay commits in chronological order (oldest to newest in the changelog) using `git cherry-pick`
  * Replace the code in the branch with the output of `rpmbuild -bp` for the corresponding `src.rpm`
  * Tag the rebuild branch

## JIRA Tickets
* Parent: [KERNEL-1128](https://ciqinc.atlassian.net/browse/KERNEL-1128)
* History Rebuild: [KERNEL-1129](https://ciqinc.atlassian.net/browse/KERNEL-1129)

## Rebuild Splat Inspection
###  kernel-4.18.0-553.129.1.el8_10
```
$ cat ciq/ciq_backports/kernel-4.18.0-553.129.1.el8_10/rebuild.details.txt
Rebuild_History BUILDABLE
Rebuilding Kernel from rpm changelog with Fuzz Limit: 87.50%
Number of commits in upstream range v4.18~1..kernel-mainline: 625874
Number of commits in rpm: 15
Number of commits matched with upstream: 9 (60.00%)
Number of commits in upstream but not in rpm: 625865
Number of commits NOT found in upstream: 6 (40.00%)

Rebuilding Kernel on Branch rocky8_10_rebuild_kernel-4.18.0-553.129.1.el8_10 for kernel-4.18.0-553.129.1.el8_10
Clean Cherry Picks: 7 (77.78%)
Empty Cherry Picks: 2 (22.22%)
_______________________________

__EMPTY COMMITS__________________________
d73f4b53aaaea4c95f245e491aa5eeb8a21874ce netfilter: nf_tables: release flowtable after rcu grace period on error
3df690bba28edec865cf7190be10708ad0ddd67e smb: client: fix OOB reads parsing symlink error response

__CHANGES NOT IN UPSTREAM________________
Adding prod certs and changed cert date to 20210620
Adding Rocky secure boot certs
Fixing vmlinuz removal
Fixing UEFI CA path
Porting to 8.10, debranding and Rocky branding
Fixing pesign_key_name values
```

## BUILD
```
$ grep -E -B 5 -A 5 "\[TIMER\]|^Starting Build" $(ls -t kbuild* | head -n1)
/mnt/code/kernel-src-tree-build
Running make mrproper...
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
[TIMER]{MRPROPER}: 5s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-rocky8_10_rebuild-cbfcdd653216"
Making olddefconfig
--
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --olddefconfig Kconfig
#
# configuration written to .config
#
Starting Build
scripts/kconfig/conf  --syncconfig Kconfig
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_64_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_64.h
--
  LD [M]  sound/usb/usx2y/snd-usb-usx2y.ko
  LD [M]  sound/virtio/virtio_snd.ko
  LD [M]  sound/x86/snd-hdmi-lpe-audio.ko
  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1598s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx2.ko
  INSTALL arch/x86/crypto/camellia-x86_64.ko
--
  INSTALL sound/virtio/virtio_snd.ko
  INSTALL sound/x86/snd-hdmi-lpe-audio.ko
  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-rocky8_10_rebuild-cbfcdd653216+
[TIMER]{MODULES}: 13s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-rocky8_10_rebuild-cbfcdd653216+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 25s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-rocky8_10_rebuild-cbfcdd653216+ and Index to 2
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 5s
[TIMER]{BUILD}: 1598s
[TIMER]{MODULES}: 13s
[TIMER]{INSTALL}: 25s
[TIMER]{TOTAL} 1647s
Rebooting in 10 seconds
```

## KSelfTests
```
$ get_kselftest_diff.sh
ls: cannot access 'selftest-*': No such file or directory
kselftest.4.18.0-rocky8_10_rebuild-a542f27904df+.log
207
kselftest.4.18.0-rocky8_10_rebuild-3029e67fd566+.log
207
kselftest.4.18.0-rocky8_10_rebuild-7b8ffde4a267+.log
207
kselftest.4.18.0-rocky8_10_rebuild-cbfcdd653216+.log
206
Before: kselftest.4.18.0-rocky8_10_rebuild-7b8ffde4a267+.log
After: kselftest.4.18.0-rocky8_10_rebuild-cbfcdd653216+.log
Diff:
-ok 1 selftests: exec: execveat
```

[KERNEL-1128]: https://ciqinc.atlassian.net/browse/KERNEL-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KERNEL-1129]: https://ciqinc.atlassian.net/browse/KERNEL-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ