### PR TITLE
[CBR 7.9] CVE-2025-40240, CVE-2026-31402, CVE-2018-16885

### DIFF
--- a/fs/nfsd/nfs4xdr.c
+++ b/fs/nfsd/nfs4xdr.c
@@ -4469,9 +4469,14 @@ nfsd4_encode_operation(struct nfsd4_compoundres *resp, struct nfsd4_op *op)
 		int len = xdr->buf->len - post_err_offset;
 
 		so->so_replay.rp_status = op->status;
-		so->so_replay.rp_buflen = len;
-		read_bytes_from_xdr_buf(xdr->buf, post_err_offset,
+		if (len <= NFSD4_REPLAY_ISIZE) {
+			so->so_replay.rp_buflen = len;
+			read_bytes_from_xdr_buf(xdr->buf,
+						post_err_offset,
 						so->so_replay.rp_buf, len);
+		} else {
+			so->so_replay.rp_buflen = 0;
+		}
 	}
 status:
 	/* Note that op->status is already in network byte order: */

--- a/fs/nfsd/state.h
+++ b/fs/nfsd/state.h
@@ -364,11 +364,18 @@ struct nfs4_client_reclaim {
 	char			cr_recdir[HEXDIR_LEN]; /* recover dir */
 };
 
-/* A reasonable value for REPLAY_ISIZE was estimated as follows:  
- * The OPEN response, typically the largest, requires 
- *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +  8(verifier) + 
- *   4(deleg. type) + 8(deleg. stateid) + 4(deleg. recall flag) + 
- *   20(deleg. space limit) + ~32(deleg. ace) = 112 bytes 
+/*
+ * REPLAY_ISIZE is sized for an OPEN response with delegation:
+ *   4(status) + 8(stateid) + 20(changeinfo) + 4(rflags) +
+ *   8(verifier) + 4(deleg. type) + 8(deleg. stateid) +
+ *   4(deleg. recall flag) + 20(deleg. space limit) +
+ *   ~32(deleg. ace) = 112 bytes
+ *
+ * Some responses can exceed this. A LOCK denial includes the conflicting
+ * lock owner, which can be up to 1024 bytes (NFS4_OPAQUE_LIMIT). Responses
+ * larger than REPLAY_ISIZE are not cached in rp_ibuf; only rp_status is
+ * saved. Enlarging this constant increases the size of every
+ * nfs4_stateowner.
  */
 
 #define NFSD4_REPLAY_ISIZE       112 

--- a/net/sctp/inqueue.c
+++ b/net/sctp/inqueue.c
@@ -185,13 +185,14 @@ next_chunk:
 				chunk->head_skb = chunk->skb;
 
 			/* skbs with "cover letter" */
-			if (chunk->head_skb && chunk->skb->data_len == chunk->skb->len)
+			if (chunk->head_skb && chunk->skb->data_len == chunk->skb->len) {
+				if (WARN_ON(!skb_shinfo(chunk->skb)->frag_list)) {
+					SCTP_INC_STATS_BH(dev_net(chunk->skb->dev),
+							  SCTP_MIB_IN_PKT_DISCARDS);
+					sctp_chunk_free(chunk);
+					goto next_chunk;
+				}
 				chunk->skb = skb_shinfo(chunk->skb)->frag_list;
-
-			if (WARN_ON(!chunk->skb)) {
-				SCTP_INC_STATS_BH(dev_net(chunk->skb->dev), SCTP_MIB_IN_PKT_DISCARDS);
-				sctp_chunk_free(chunk);
-				goto next_chunk;
 			}
 		}
 


### PR DESCRIPTION
[CBR 7.9]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2025-40240</td>
<td class="org-left">VULN-176137</td>
</tr>


<tr>
<td class="org-left">CVE-2026-31402</td>
<td class="org-left">VULN-180160</td>
</tr>


<tr>
<td class="org-left">CVE-2018-16885</td>
<td class="org-left">VULN-184749</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2025-40240

    sctp: avoid NULL dereference when chunk data buffer is missing
    
    jira VULN-176137
    cve CVE-2025-40240
    commit-author Alexey Simakov <bigalex934@gmail.com>
    commit 441f0647f7673e0e64d4910ef61a5fb8f16bfb82
    upstream-diff Same change as in upstream, except for ciqcbr7_9's
      SCTP_INC_STATS_BH macro instead of upstream's __SCTP_INC_STATS. It's
      the same macro, renamed on upstream in
      13415e46c5915e2dac089de516369005fbc045f9 ("net: snmp: kill STATS_BH
      macros")


## CVE-2026-31402

    nfsd: fix heap overflow in NFSv4.0 LOCK replay cache
    
    jira VULN-180160
    cve CVE-2026-31402
    commit-author Jeff Layton <jlayton@kernel.org>
    commit 5133b61aaf437e5f25b1b396b14242a6bb0508e2
    upstream-diff Used `post_err_offset' instead of `op_status_offset +
      XDR_UNIT' in the `read_bytes_from_xdr_buf()' call, as the CBR 7.9
      version is missing ef3675b45bcb6c17cabbbde620c6cea52ffb21ac ("NFSD:
      Encode COMPOUND operation status on page boundaries")


## CVE-2018-16885

CBR 7.9 is not affected by this bug since c3ad1c3e7302742989d83875b14d77fd232661ef.


### Situation

On December 21, 2018 RH [published a bug](https://bugzilla.redhat.com/show_bug.cgi?id=1661503), described as 

> A flaw was found in the Linux kernel that allows the userspace to call memcpy\_fromiovecend() and similar functions with a zero offset and buffer length. This can cause a read beyond the buffer boundaries flaw and, in certain cases, cause a memory access fault and a system halt by accessing invalid memory address

From the same page:

> Note: this is a RHEL-only bug.

There is no upstream commit (or any other for that matter) identified as the fix, neither on [RH CVE-2018-16885 page](https://access.redhat.com/security/cve/cve-2018-16885) nor others ([NIST](https://nvd.nist.gov/vuln/detail/CVE-2018-16885), [CVE.org](https://www.cve.org/CVERecord?id=CVE-2018-16885)). No more detailed explanation of the problem was found anywhere.

On August 6, 2019 an errata page [RHSA-2019:2029](https://access.redhat.com/errata/RHSA-2019:2029) was published containing the fix for RHEL 7, version `kernel-0:3.10.0-1062.el7` (<https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2018-16885.json>), with the fix identified as 

> kernel: out-of-bound read in memcpy\_fromiovecend() (CVE-2018-16885)

This specific kernel version can be found in CBR 7.9 history at c3ad1c3e7302742989d83875b14d77fd232661ef. It contains only four line changes in the `net/core/iovec.c` file (the one containing `memcpy_fromiovecend()` function mentioned), aligning perfectly with the short problem description given in the bug page:

    $ git log --date=iso --pretty=oneline --patch-with-stat -n 1 c3ad1c3e7302742989d83875b14d77fd232661ef -- net/core/iovec.c

>

    c3ad1c3e7302742989d83875b14d77fd232661ef (tag: centos_kernel-3.10.0-1062.el7) Rebuild centos7 with kernel-3.10.0-1062.el7
     net/core/iovec.c | 8 ++++----
     1 file changed, 4 insertions(+), 4 deletions(-)
    
    diff --git a/net/core/iovec.c b/net/core/iovec.c
    index 3e23152424a66ef568ec3599bfec1ff24cb8a0e8..0a0feb0e4e20507de6322dcfa9f06bad10e06cdd 100644
    --- a/net/core/iovec.c
    +++ b/net/core/iovec.c
    @@ -164,7 +164,7 @@ int memcpy_fromiovecend(unsigned char *kdata, const struct iovec *iov,
     			int offset, int len)
     {
     	/* Skip over the finished iovecs */
    -	while (offset >= iov->iov_len) {
    +	while (offset && offset >= iov->iov_len) {
     		offset -= iov->iov_len;
     		iov++;
     	}
    @@ -192,7 +192,7 @@ int memcpy_fromiovecend_partial_flushcache(unsigned char *kdata,
     	int orig_len = len;
     
     	/* Skip over the finished iovecs */
    -	while (offset >= iov->iov_len) {
    +	while (offset && offset >= iov->iov_len) {
     		offset -= iov->iov_len;
     		iov++;
     	}
    @@ -226,7 +226,7 @@ int memcpy_fromiovecend_partial_nocache(unsigned char *kdata,
     	int orig_len = len;
     
     	/* Skip over the finished iovecs */
    -	while (offset >= iov->iov_len) {
    +	while (offset && offset >= iov->iov_len) {
     		offset -= iov->iov_len;
     		iov++;
     	}
    @@ -262,7 +262,7 @@ int csum_partial_copy_fromiovecend(unsigned char *kdata, struct iovec *iov,
     	int partial_cnt = 0, err = 0;
     
     	/* Skip over the finished iovecs */
    -	while (offset >= iov->iov_len) {
    +	while (offset && offset >= iov->iov_len) {
     		offset -= iov->iov_len;
     		iov++;
     	}

The "similar functions" mentioned in the bug description apparently are `csum_partial_copy_fromiovecend()`, `memcpy_fromiovecend_partial_nocache()` and `memcpy_fromiovecend_partial_flushcache()`.

On May 26, 2026 RH published an errata page [RHSA-2026:14925](https://access.redhat.com/errata/RHSA-2026:14925) for RHEL 7 ELS containing the same fix

> kernel: out-of-bound read in memcpy\_fromiovecend() (CVE-2018-16885)

and linking to the same [bug page](https://bugzilla.redhat.com/show_bug.cgi?id=1661503). The patched kernel version was `kernel-0:3.10.0-1160.149.1.el7`, strongly suggesting that the CVE-2018-16885 fix was already in place from the `kernel-0:3.10.0-1062.el7` patched revision. The reason for RH patching this kernel again is not clear.


### The bug

Consider the `memcpy_fromiovecend()` function from before c3ad1c3e7302742989d83875b14d77fd232661ef (`centos_kernel-3.10.0-1062.el7` tag):

<https://github.com/ctrliq/kernel-src-tree/blob/460ce23b2e6247ef1341209a37d94ffbbf572185/net/core/iovec.c#L163-L185>

It implements the vectorized I/O [scatter/gather pattern](https://en.wikipedia.org/wiki/Vectored_I/O). It copies `len` bytes of data scattered across the user-space `iov` array to the contiguous kernel buffer `kdata`. The `offset` argument allows to skip initial `offset` bytes of copying, so the sum `offset + len` must not be greater than the total number of bytes in the `iov` chunks. The `struct iovec` specifies a single chunk of data and has a simple "pointer + size" definition:

<https://github.com/ctrliq/kernel-src-tree/blob/460ce23b2e6247ef1341209a37d94ffbbf572185/include/uapi/linux/uio.h#L16-L20>

The size of `iov` array is not given explicitly (let alone bound-checked) anywhere; instead it's assumed the user knows how many bytes collectively the `iov` chunks contain and doesn't request with `offset + len` any more than that (failure to ensure that was the exact reason for the bug described in <https://lists.openvz.org/pipermail/devel/2018-December/072970.html> - more on that [later](#orgffdcae8)).

Different elements of the `memcpy_fromiovecend()` mechanism can be graphed as follows (all labels denote variables, unless quoted):

               offset                       len
       |----------------------|-----------------------------|
                                  copy
                              |---------|
    
                     iov[i]->base
                     |
                     ' iov[i]->iov_len
       |--------|----|------------------|--------|--------|----------------|  "iov chunks"
    i= 0        1    2        .         3        4        5
                              |
                              base
    
       \_____________/        \_____________________________/
      "finished iovecs"               "copied data"
       \___________________________________________________________________/
                        "total data size contained by iov"

Note that, despite forming a line above, the `iov` chunks are not necessarily contiguous in memory - they were put in line just to better illustrate the sizes arithmetics.

The CVE-2018-16885 bug occurs in the first stage of skipping the "finished iovecs":

<https://github.com/ctrliq/kernel-src-tree/blob/460ce23b2e6247ef1341209a37d94ffbbf572185/net/core/iovec.c#L167-L170>

If the initial `offset` equals the total number of bytes contained in the `iov` chunks, then the loop above, upon ultimately reaching the end of `iov` and reducing `offset` to `0` (perhaps without any iterations if `iov` was empty and `offset` was `0` from the start), will attempt to execute an additional iteration for the `iov` pointer laying outside the boundary of the original `iov` array.

This problem is actually more general than what CVE-2018-16885 description states, namely `memcpy_fromiovecend()` not being able to cope with `offset = N`, where `N` is the total size of data contained in `iov`. The bug page describes the special case of `N = 0`.

The issue may be fixed by checking whether `offset` became `0` and breaking the loop right then. This is exactly what the change in c3ad1c3e7302742989d83875b14d77fd232661ef does:

<https://github.com/ctrliq/kernel-src-tree/blob/c3ad1c3e7302742989d83875b14d77fd232661ef/net/core/iovec.c#L167-L170>


### Similar code

It was evaluated whether the additional fixing of CVE-2018-16885 in RHEL 7 ELS was associated with other instances of `offset >= iov->iov_len` pattern in the `net/core/iovec.c` file, for example in `memcpy_toiovecend()`:

<https://github.com/ctrliq/kernel-src-tree/blob/460ce23b2e6247ef1341209a37d94ffbbf572185/net/core/iovec.c#L81-L100>

(Similar situation in `memcpy_toiovecend_partial()` and `memcpy_toiovecend_partial_mcsafe()`.) However, unlike `memcpy_fromiovecend()` and similar, the `memcpy_toiovecend()` family guards `offset >= iov->iov_len` checks with `len > 0` condition. Assuming that these functions are called properly, that is with `offset + len <= N` condition fulfilled, the problematic `offset = N` situation implies `len = 0`, which would prevent the "finished iovecs skipping" loop from falling out of `iov` bounds, as it happens in `memcpy_fromiovecend()`.


### Discussion of other solutions

Three other solutions (to not necessarily the same problem) surfaced on the RH's [bug page](https://bugzilla.redhat.com/show_bug.cgi?id=1661503). They are discussed below to shed more light on the issue.

1.  UFO removal

    > This specific bug is indirectly fixed upstream by UFO removal
    
    UFO stands for "UDP Fragmentation Offload" feature. It was removed in a branch merged in 5c3c6081b246b05ee5bb2fc1759a7c0c6a0b7c3b:
    
        $ git log -n 15 --oneline --graph 5c3c6081b246b05ee5bb2fc1759a7c0c6a0b7c3b
    
        *   5c3c6081b246b05ee5bb2fc1759a7c0c6a0b7c3b Merge branch 'net-ufo-remove'
        |\  
        | * d9d30adf56777c402c0027c0e6ae21f17cc0a365 net: Kill NETIF_F_UFO and SKB_GSO_UDP.
        | * 6800b2e040edda01f593aba28203c2ebf1679f4c inet: Remove software UFO fragmenting code.
        | * 880388aa3c07fdea4f9b85e35641753017b1852f net: Remove all references to SKB_GSO_UDP.
        | * 988cf74deb45bd6ee27433b7b5d1be6004d842b8 inet: Stop generating UFO packets.
        | * 08a00fea6de277df12ccfadc21bf779df2e83705 net: Remove references to NETIF_F_UFO from ethtool.
        | * d4c023f4f3dd96734ef53d4b588136a872300046 net: Remove references to NETIF_F_UFO in netdev_fix_features().
        | * e078de03788353b220f3d501fc3607cc92db28c1 virtio_net: Remove references to NETIF_F_UFO.
        | * 2082499a95ad31b88466e50f4c61513e3873ba9e dummy: Remove references to NETIF_F_UFO.
        | * d591a1f3aad92ade4642e4173f4c368006c27f0f tun/tap: Remove references to NETIF_F_UFO.
        | * fb652fdfe83710da0ca13448a41b7ed027d0a984 macvlan/macvtap: Remove NETIF_F_UFO advertisement.
        | * 182e0b6b58463b85f9a34dd038847e4ab3604a4f ipvlan: Stop advertising NETIF_F_UFO support.
        | * f9c45ae020bab86a820d8ef9097d021d5496b855 macb: Remove bogus reference to NETIF_F_UFO.
        | * ed22e2f6b72de9dc2a2fe43cd553cf4d36f70785 s2io: Remove UFO support.
        |/  
        *   6093ec2dc313b57e6442c0d92acf137e60b42043 Merge branch 'xdp-redirect'
    
    This solution is not mutually exclusive with checking if `offset` is `0`, as was done in `0:3.10.0-1062.el7` - removing UFO may get rid of problematic `memcpy_fromiovecend()` calls, but leave `memcpy_fromiovecend()` itself bugged.
    
    In any case UFO removal cannot be backported, as that would be a feature change.

2.  Commit 21226abb4e9f14d88238964d89b279e461ddc30c

    > the buggy memcpy\_fromiovecend() (and related functions) are fixed by:
    > 
    > commit 21226abb4e9f14d88238964d89b279e461ddc30c
    > Author: Al Viro <viro.org.uk>
    > Date: Fri Nov 28 15:48:29 2014 -0500
    > net: switch memcpy\_fromiovec()/memcpy\_fromiovecend() users to copy\_from\_iter()
    
    The commit mentioned doesn't really "fix" `memcpy_fromiovecend()`, but simply drops its usage, replacing it with a newer `iov_iter` interface (see <https://lwn.net/Articles/625077/>). In fact it's a part of a three-commits patch resulting in the eventual removal of `memcpy_fromiovecend()` function altogether:
    
        $ git log --date=iso -n 3 31a25fae85956e3a9c778141d29e5e803fb0b124
    
    >
    
        commit 31a25fae85956e3a9c778141d29e5e803fb0b124
        Author: Al Viro <viro@zeniv.linux.org.uk>
        Date:   2014-11-28 15:53:57 -0500
        
            net: bury net/core/iovec.c - nothing in there is used anymore
            
            Signed-off-by: Al Viro <viro@zeniv.linux.org.uk>
        
        commit f25dcc7687d42a72de18aa41b04990a24c9e77c7
        Author: Al Viro <viro@zeniv.linux.org.uk>
        Date:   2014-11-28 15:52:29 -0500
        
            tipc: tipc ->sendmsg() conversion
            
            This one needs to copy the same data from user potentially more than
            once.  Sadly, MTU changes can trigger that ;-/
            
            Cc: Jon Maloy <jon.maloy@ericsson.com>
            Signed-off-by: Al Viro <viro@zeniv.linux.org.uk>
        
        commit 21226abb4e9f14d88238964d89b279e461ddc30c
        Author: Al Viro <viro@zeniv.linux.org.uk>
        Date:   2014-11-28 15:48:29 -0500
        
            net: switch memcpy_fromiovec()/memcpy_fromiovecend() users to copy_from_iter()
            
            That takes care of the majority of ->sendmsg() instances - most of them
            via memcpy_to_msg() or assorted getfrag() callbacks.  One place where we
            still keep memcpy_fromiovecend() is tipc - there we potentially read the
            same data over and over; separate patch, that...
            
            Signed-off-by: Al Viro <viro@zeniv.linux.org.uk>
    
    It's possible that the re-application of the CVE-2018-16885 patch in RH's `kernel-0:3.10.0-1160.149.1.el7` kernel was the shift to `iov_iter` interface as well. Backporting this commit generates conflicts in nearly all modified files though, and solving them would require accounting for (at least) one prerequisite c0371da6047abd261bc483c744dbc7d81a116172, which probably can't be backported in full. In short - it's not trivial and was left as an option to evaluate by the reviewers before putting effort into it.

3.  Guarding the `vhost_chr_write_iter()` call

    > Sorry for inconvenience, I meant <https://bugzilla.redhat.com/show_bug.cgi?id=1659451>, but accidentally missed, we have similar issue where. And <https://lists.openvz.org/pipermail/devel/2018-December/072970.html> is a possible fix for it.
    
    The issue described in that mail is similar to what CVE-2018-16885 identifies only in the outcome of accessing `iov` array outside of bounds. The mechanism is entirely different and boils down to requesting `memcpy_fromiovecend()` to copy more bytes than the data chunks in `iov` contain. It may therefore be understood as improper use of `memcpy_fromiovecend()` and not necessarily a bug in the function itself. For the record, the patch given there is present in CBR 7.9 as well, in the same commit as the CVE-2018-16885 fix - c3ad1c3e7302742989d83875b14d77fd232661ef. See
    
    <https://github.com/ctrliq/kernel-src-tree/blob/c3ad1c3e7302742989d83875b14d77fd232661ef/drivers/vhost/net.c#L1437-L1453>


# kABI check: passed

    $ LOGS=ERROR CVE=CVE-batch-35 ./ninja.sh -d explain _kabi_check_kernel__x86_64--test--ciqcbr7_9-CVE-batch-35
    [0/1] kabi_check_kernel	Check ABI of kernel [ciqcbr7_9-CVE-batch-35]	_kabi_check_kernel__x86_64--test--ciqcbr7_9-CVE-batch-35
    ninja explain: output state/kernels/ciqcbr7_9-CVE-batch-35/x86_64/kabi_checked doesn't exist
    ninja explain: state/kernels/ciqcbr7_9-CVE-batch-35/x86_64/kabi_checked is dirty
    + dist_git_version=el-7.9
    + local_version=ciqcbr7_9-CVE-batch-35
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqcbr7_9
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-7.9
    + build_dir=/mnt/build_files/kernel-src-tree-ciqcbr7_9-CVE-batch-35
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-7.9/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqcbr7_9 ''\''/mnt/code/kernel-dist-git-el-7.9/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-7.9/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqcbr7_9-CVE-batch-35/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqcbr7_9-CVE-batch-35/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/29025236/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqcbr7\_9&#x2013;run1.log](<https://github.com/user-attachments/files/29025238/kselftests--ciqcbr7_9--run1.log>)


## Patch

[kselftests&#x2013;ciqcbr7\_9-CVE-batch-35&#x2013;run1.log](<https://github.com/user-attachments/files/29025239/kselftests--ciqcbr7_9-CVE-batch-35--run1.log>)
[kselftests&#x2013;ciqcbr7\_9-CVE-batch-35&#x2013;run2.log](<https://github.com/user-attachments/files/29025240/kselftests--ciqcbr7_9-CVE-batch-35--run2.log>)


## Comparison

The tests results were compared manually with `meld`. No results differences were found.

