### PR TITLE
[LTS 8.6] imon: CVE-2025-39993, kvm: CVE-2026-23401, CVE-2023-30456, CVE-2022-45869, CVE-2022-1852

### DIFF
--- a/arch/x86/kvm/mmu/mmu.c
+++ b/arch/x86/kvm/mmu/mmu.c
@@ -2699,11 +2699,6 @@ static int mmu_set_spte(struct kvm_vcpu *vcpu, u64 *sptep,
 	pgprintk("%s: spte %llx write_fault %d gfn %llx\n", __func__,
 		 *sptep, write_fault, gfn);
 
-	if (unlikely(is_noslot_pfn(pfn))) {
-		mark_mmio_spte(vcpu, sptep, gfn, pte_access);
-		return RET_PF_EMULATE;
-	}
-
 	if (is_shadow_present_pte(*sptep)) {
 		/*
 		 * If we overwrite a PTE page pointer with a 2MB PMD, unlink
@@ -2723,6 +2718,14 @@ static int mmu_set_spte(struct kvm_vcpu *vcpu, u64 *sptep,
 			flush = true;
 		} else
 			was_rmapped = 1;
+	}
+
+	if (unlikely(is_noslot_pfn(pfn))) {
+		mark_mmio_spte(vcpu, sptep, gfn, pte_access);
+		if (flush)
+			kvm_flush_remote_tlbs_with_address(vcpu->kvm, gfn,
+					KVM_PAGES_PER_HPAGE(level));
+		return RET_PF_EMULATE;
 	}
 
 	set_spte_ret = set_spte(vcpu, sptep, pte_access, level, gfn, pfn,

--- a/arch/x86/kvm/mmu/mmu.c
+++ b/arch/x86/kvm/mmu/mmu.c
@@ -2365,6 +2365,7 @@ static bool __kvm_mmu_prepare_zap_page(struct kvm *kvm,
 {
 	bool list_unstable;
 
+	lockdep_assert_held_write(&kvm->mmu_lock);
 	trace_kvm_mmu_prepare_zap_page(sp);
 	++kvm->stat.mmu_shadow_zapped;
 	*nr_zapped = mmu_zap_unsync_children(kvm, sp, invalid_list);
@@ -3992,16 +3993,17 @@ static int direct_page_fault(struct kvm_vcpu *vcpu, gpa_t gpa, u32 error_code,
 
 	if (!is_noslot_pfn(pfn) && mmu_notifier_retry_hva(vcpu->kvm, mmu_seq, hva))
 		goto out_unlock;
-	r = make_mmu_pages_available(vcpu);
-	if (r)
-		goto out_unlock;
 
-	if (is_tdp_mmu_fault)
+	if (is_tdp_mmu_fault) {
 		r = kvm_tdp_mmu_map(vcpu, gpa, error_code, map_writable, max_level,
 				    pfn, prefault);
-	else
+	} else {
+		r = make_mmu_pages_available(vcpu);
+		if (r)
+			goto out_unlock;
 		r = __direct_map(vcpu, gpa, error_code, map_writable, max_level, pfn,
 				 prefault, is_tdp);
+	}
 
 out_unlock:
 	if (is_tdp_mmu_fault)

--- a/arch/x86/kvm/vmx/nested.c
+++ b/arch/x86/kvm/vmx/nested.c
@@ -2986,7 +2986,7 @@ static int nested_vmx_check_guest_state(struct kvm_vcpu *vcpu,
 					struct vmcs12 *vmcs12,
 					enum vm_entry_failure_code *entry_failure_code)
 {
-	bool ia32e;
+	bool ia32e = !!(vmcs12->vm_entry_controls & VM_ENTRY_IA32E_MODE);
 
 	*entry_failure_code = ENTRY_FAIL_DEFAULT;
 
@@ -3012,6 +3012,13 @@ static int nested_vmx_check_guest_state(struct kvm_vcpu *vcpu,
 					   vmcs12->guest_ia32_perf_global_ctrl)))
 		return -EINVAL;
 
+	if (CC((vmcs12->guest_cr0 & (X86_CR0_PG | X86_CR0_PE)) == X86_CR0_PG))
+		return -EINVAL;
+
+	if (CC(ia32e && !(vmcs12->guest_cr4 & X86_CR4_PAE)) ||
+	    CC(ia32e && !(vmcs12->guest_cr0 & X86_CR0_PG)))
+		return -EINVAL;
+
 	/*
 	 * If the load IA32_EFER VM-entry control is 1, the following checks
 	 * are performed on the field for the IA32_EFER MSR:
@@ -3023,7 +3030,6 @@ static int nested_vmx_check_guest_state(struct kvm_vcpu *vcpu,
 	 */
 	if (to_vmx(vcpu)->nested.nested_run_pending &&
 	    (vmcs12->vm_entry_controls & VM_ENTRY_LOAD_IA32_EFER)) {
-		ia32e = (vmcs12->vm_entry_controls & VM_ENTRY_IA32E_MODE) != 0;
 		if (CC(!kvm_valid_efer(vcpu, vmcs12->guest_ia32_efer)) ||
 		    CC(ia32e != !!(vmcs12->guest_ia32_efer & EFER_LMA)) ||
 		    CC(((vmcs12->guest_cr0 & X86_CR0_PG) &&

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -7973,7 +7973,7 @@ int kvm_skip_emulated_instruction(struct kvm_vcpu *vcpu)
 }
 EXPORT_SYMBOL_GPL(kvm_skip_emulated_instruction);
 
-static bool kvm_vcpu_check_breakpoint(struct kvm_vcpu *vcpu, int *r)
+static bool kvm_vcpu_check_code_breakpoint(struct kvm_vcpu *vcpu, int *r)
 {
 	if (unlikely(vcpu->guest_debug & KVM_GUESTDBG_USE_HW_BP) &&
 	    (vcpu->arch.guest_debug_dr7 & DR7_BP_EN_MASK)) {
@@ -8042,24 +8042,22 @@ static bool is_vmware_backdoor_opcode(struct x86_emulate_ctxt *ctxt)
 }
 
 /*
- * Decode to be emulated instruction. Return EMULATION_OK if success.
+ * Decode an instruction for emulation.  The caller is responsible for handling
+ * code breakpoints.  Note, manually detecting code breakpoints is unnecessary
+ * (and wrong) when emulating on an intercepted fault-like exception[*], as
+ * code breakpoints have higher priority and thus have already been done by
+ * hardware.
+ *
+ * [*] Except #MC, which is higher priority, but KVM should never emulate in
+ *     response to a machine check.
  */
 int x86_decode_emulated_instruction(struct kvm_vcpu *vcpu, int emulation_type,
 				    void *insn, int insn_len)
 {
-	int r = EMULATION_OK;
 	struct x86_emulate_ctxt *ctxt = vcpu->arch.emulate_ctxt;
+	int r;
 
 	init_emulate_ctxt(vcpu);
-
-	/*
-	 * We will reenter on the same instruction since we do not set
-	 * complete_userspace_io. This does not handle watchpoints yet,
-	 * those would be handled in the emulate_ops.
-	 */
-	if (!(emulation_type & EMULTYPE_SKIP) &&
-	    kvm_vcpu_check_breakpoint(vcpu, &r))
-		return r;
 
 	r = x86_decode_insn(ctxt, insn, insn_len, emulation_type);
 
@@ -8092,6 +8090,15 @@ int x86_emulate_instruction(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
 
 	if (!(emulation_type & EMULTYPE_NO_DECODE)) {
 		kvm_clear_exception_queue(vcpu);
+
+		/*
+		 * Return immediately if RIP hits a code breakpoint, such #DBs
+		 * are fault-like and are higher priority than any faults on
+		 * the code fetch itself.
+		 */
+		if (!(emulation_type & EMULTYPE_SKIP) &&
+		    kvm_vcpu_check_code_breakpoint(vcpu, &r))
+			return r;
 
 		r = x86_decode_emulated_instruction(vcpu, emulation_type,
 						    insn, insn_len);

--- a/drivers/media/rc/imon.c
+++ b/drivers/media/rc/imon.c
@@ -627,15 +627,14 @@ static int send_packet(struct imon_context *ictx)
 		pr_err_ratelimited("error submitting urb(%d)\n", retval);
 	} else {
 		/* Wait for transmission to complete (or abort) */
-		mutex_unlock(&ictx->lock);
 		retval = wait_for_completion_interruptible(
 				&ictx->tx.finished);
 		if (retval) {
 			usb_kill_urb(ictx->tx_urb);
 			pr_err_ratelimited("task interrupted\n");
 		}
-		mutex_lock(&ictx->lock);
 
+		ictx->tx.busy = false;
 		retval = ictx->tx.status;
 		if (retval)
 			pr_err_ratelimited("packet tx failed (%d)\n", retval);
@@ -939,7 +938,8 @@ static ssize_t vfd_write(struct file *file, const char __user *buf,
 	if (ictx->disconnected)
 		return -ENODEV;
 
-	mutex_lock(&ictx->lock);
+	if (mutex_lock_interruptible(&ictx->lock))
+		return -ERESTARTSYS;
 
 	if (!ictx->dev_present_intf0) {
 		pr_err_ratelimited("no iMON device present\n");

--- a/drivers/media/rc/imon.c
+++ b/drivers/media/rc/imon.c
@@ -1134,10 +1134,7 @@ static int imon_ir_change_protocol(struct rc_dev *rc, u64 *rc_proto)
 
 	memcpy(ictx->usb_tx_buf, &ir_proto_packet, sizeof(ir_proto_packet));
 
-	if (!mutex_is_locked(&ictx->lock)) {
-		unlock = true;
-		mutex_lock(&ictx->lock);
-	}
+	unlock = mutex_trylock(&ictx->lock);
 
 	retval = send_packet(ictx);
 	if (retval)

--- a/drivers/media/rc/imon.c
+++ b/drivers/media/rc/imon.c
@@ -517,7 +517,9 @@ static int display_open(struct inode *inode, struct file *file)
 
 	mutex_lock(&ictx->lock);
 
-	if (!ictx->display_supported) {
+	if (ictx->disconnected) {
+		retval = -ENODEV;
+	} else if (!ictx->display_supported) {
 		pr_err("display not supported by device\n");
 		retval = -ENODEV;
 	} else if (ictx->display_isopen) {
@@ -580,6 +582,9 @@ static int send_packet(struct imon_context *ictx)
 	struct usb_ctrlrequest *control_req = NULL;
 
 	lockdep_assert_held(&ictx->lock);
+
+	if (ictx->disconnected)
+		return -ENODEV;
 
 	/* Check if we need to use control or interrupt urb */
 	if (!ictx->tx_control) {
@@ -937,11 +942,13 @@ static ssize_t vfd_write(struct file *file, const char __user *buf,
 	static const unsigned char vfd_packet6[] = {
 		0x01, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF };
 
-	if (ictx->disconnected)
-		return -ENODEV;
-
 	if (mutex_lock_interruptible(&ictx->lock))
 		return -ERESTARTSYS;
+
+	if (ictx->disconnected) {
+		retval = -ENODEV;
+		goto exit;
+	}
 
 	if (!ictx->dev_present_intf0) {
 		pr_err_ratelimited("no iMON device present\n");
@@ -1017,10 +1024,12 @@ static ssize_t lcd_write(struct file *file, const char __user *buf,
 	int retval = 0;
 	struct imon_context *ictx = file->private_data;
 
-	if (ictx->disconnected)
-		return -ENODEV;
-
 	mutex_lock(&ictx->lock);
+
+	if (ictx->disconnected) {
+		retval = -ENODEV;
+		goto exit;
+	}
 
 	if (!ictx->display_supported) {
 		pr_err_ratelimited("no iMON display present\n");
@@ -2460,7 +2469,11 @@ static void imon_disconnect(struct usb_interface *interface)
 	int ifnum;
 
 	ictx = usb_get_intfdata(interface);
+
+	mutex_lock(&ictx->lock);
 	ictx->disconnected = true;
+	mutex_unlock(&ictx->lock);
+
 	dev = ictx->dev;
 	ifnum = interface->cur_altsetting->desc.bInterfaceNumber;
 

--- a/drivers/media/rc/imon.c
+++ b/drivers/media/rc/imon.c
@@ -579,6 +579,8 @@ static int send_packet(struct imon_context *ictx)
 	int retval = 0;
 	struct usb_ctrlrequest *control_req = NULL;
 
+	lockdep_assert_held(&ictx->lock);
+
 	/* Check if we need to use control or interrupt urb */
 	if (!ictx->tx_control) {
 		pipe = usb_sndintpipe(ictx->usbdev_intf0,
@@ -1107,7 +1109,7 @@ static int imon_ir_change_protocol(struct rc_dev *rc, u64 *rc_proto)
 	int retval;
 	struct imon_context *ictx = rc->priv;
 	struct device *dev = ictx->dev;
-	bool unlock = false;
+	const bool unlock = mutex_trylock(&ictx->lock);
 	unsigned char ir_proto_packet[] = {
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x86 };
 
@@ -1133,8 +1135,6 @@ static int imon_ir_change_protocol(struct rc_dev *rc, u64 *rc_proto)
 	}
 
 	memcpy(ictx->usb_tx_buf, &ir_proto_packet, sizeof(ir_proto_packet));
-
-	unlock = mutex_trylock(&ictx->lock);
 
 	retval = send_packet(ictx);
 	if (retval)

--- a/drivers/media/rc/imon.c
+++ b/drivers/media/rc/imon.c
@@ -160,6 +160,24 @@ struct imon_context {
 	int touch_y;			/* y coordinate on touchscreen */
 	struct imon_usb_dev_descr *dev_descr; /* device description with key
 						 table for front panels */
+	/*
+	 * Fields for deferring free_imon_context().
+	 *
+	 * Since reference to "struct imon_context" is stored into
+	 * "struct file"->private_data, we need to remember
+	 * how many file descriptors might access this "struct imon_context".
+	 */
+	refcount_t users;
+	/*
+	 * Use a flag for telling display_open()/vfd_write()/lcd_write() that
+	 * imon_disconnect() was already called.
+	 */
+	bool disconnected;
+	/*
+	 * We need to wait for RCU grace period in order to allow
+	 * display_open() to safely check ->disconnected and increment ->users.
+	 */
+	struct rcu_head rcu;
 };
 
 #define TOUCH_TIMEOUT	(HZ/30)
@@ -167,18 +185,18 @@ struct imon_context {
 /* vfd character device file operations */
 static const struct file_operations vfd_fops = {
 	.owner		= THIS_MODULE,
-	.open		= &display_open,
-	.write		= &vfd_write,
-	.release	= &display_close,
+	.open		= display_open,
+	.write		= vfd_write,
+	.release	= display_close,
 	.llseek		= noop_llseek,
 };
 
 /* lcd character device file operations */
 static const struct file_operations lcd_fops = {
 	.owner		= THIS_MODULE,
-	.open		= &display_open,
-	.write		= &lcd_write,
-	.release	= &display_close,
+	.open		= display_open,
+	.write		= lcd_write,
+	.release	= display_close,
 	.llseek		= noop_llseek,
 };
 
@@ -420,9 +438,6 @@ static struct usb_driver imon_driver = {
 	.id_table	= imon_usb_id_table,
 };
 
-/* to prevent races between open() and disconnect(), probing, etc */
-static DEFINE_MUTEX(driver_lock);
-
 /* Module bookkeeping bits */
 MODULE_AUTHOR(MOD_AUTHOR);
 MODULE_DESCRIPTION(MOD_DESC);
@@ -462,9 +477,11 @@ static void free_imon_context(struct imon_context *ictx)
 	struct device *dev = ictx->dev;
 
 	usb_free_urb(ictx->tx_urb);
+	WARN_ON(ictx->dev_present_intf0);
 	usb_free_urb(ictx->rx_urb_intf0);
+	WARN_ON(ictx->dev_present_intf1);
 	usb_free_urb(ictx->rx_urb_intf1);
-	kfree(ictx);
+	kfree_rcu(ictx, rcu);
 
 	dev_dbg(dev, "%s: iMON context freed\n", __func__);
 }
@@ -480,9 +497,6 @@ static int display_open(struct inode *inode, struct file *file)
 	int subminor;
 	int retval = 0;
 
-	/* prevent races with disconnect */
-	mutex_lock(&driver_lock);
-
 	subminor = iminor(inode);
 	interface = usb_find_interface(&imon_driver, subminor);
 	if (!interface) {
@@ -490,13 +504,16 @@ static int display_open(struct inode *inode, struct file *file)
 		retval = -ENODEV;
 		goto exit;
 	}
-	ictx = usb_get_intfdata(interface);
 
-	if (!ictx) {
+	rcu_read_lock();
+	ictx = usb_get_intfdata(interface);
+	if (!ictx || ictx->disconnected || !refcount_inc_not_zero(&ictx->users)) {
+		rcu_read_unlock();
 		pr_err("no context found for minor %d\n", subminor);
 		retval = -ENODEV;
 		goto exit;
 	}
+	rcu_read_unlock();
 
 	mutex_lock(&ictx->lock);
 
@@ -514,8 +531,10 @@ static int display_open(struct inode *inode, struct file *file)
 
 	mutex_unlock(&ictx->lock);
 
+	if (retval && refcount_dec_and_test(&ictx->users))
+		free_imon_context(ictx);
+
 exit:
-	mutex_unlock(&driver_lock);
 	return retval;
 }
 
@@ -525,15 +544,8 @@ exit:
  */
 static int display_close(struct inode *inode, struct file *file)
 {
-	struct imon_context *ictx = NULL;
+	struct imon_context *ictx = file->private_data;
 	int retval = 0;
-
-	ictx = file->private_data;
-
-	if (!ictx) {
-		pr_err("no context for device\n");
-		return -ENODEV;
-	}
 
 	mutex_lock(&ictx->lock);
 
@@ -549,6 +561,8 @@ static int display_close(struct inode *inode, struct file *file)
 	}
 
 	mutex_unlock(&ictx->lock);
+	if (refcount_dec_and_test(&ictx->users))
+		free_imon_context(ictx);
 	return retval;
 }
 
@@ -918,15 +932,12 @@ static ssize_t vfd_write(struct file *file, const char __user *buf,
 	int offset;
 	int seq;
 	int retval = 0;
-	struct imon_context *ictx;
+	struct imon_context *ictx = file->private_data;
 	static const unsigned char vfd_packet6[] = {
 		0x01, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF };
 
-	ictx = file->private_data;
-	if (!ictx) {
-		pr_err_ratelimited("no context for device\n");
+	if (ictx->disconnected)
 		return -ENODEV;
-	}
 
 	mutex_lock(&ictx->lock);
 
@@ -1002,13 +1013,10 @@ static ssize_t lcd_write(struct file *file, const char __user *buf,
 			 size_t n_bytes, loff_t *pos)
 {
 	int retval = 0;
-	struct imon_context *ictx;
+	struct imon_context *ictx = file->private_data;
 
-	ictx = file->private_data;
-	if (!ictx) {
-		pr_err_ratelimited("no context for device\n");
+	if (ictx->disconnected)
 		return -ENODEV;
-	}
 
 	mutex_lock(&ictx->lock);
 
@@ -2369,7 +2377,6 @@ static int imon_probe(struct usb_interface *interface,
 	int ifnum, sysfs_err;
 	int ret = 0;
 	struct imon_context *ictx = NULL;
-	struct imon_context *first_if_ctx = NULL;
 	u16 vendor, product;
 
 	usbdev     = usb_get_dev(interface_to_usbdev(interface));
@@ -2381,16 +2388,11 @@ static int imon_probe(struct usb_interface *interface,
 	dev_dbg(dev, "%s: found iMON device (%04x:%04x, intf%d)\n",
 		__func__, vendor, product, ifnum);
 
-	/* prevent races probing devices w/multiple interfaces */
-	mutex_lock(&driver_lock);
-
 	first_if = usb_ifnum_to_if(usbdev, 0);
 	if (!first_if) {
 		ret = -ENODEV;
 		goto fail;
 	}
-
-	first_if_ctx = usb_get_intfdata(first_if);
 
 	if (ifnum == 0) {
 		ictx = imon_init_intf0(interface, id);
@@ -2399,9 +2401,11 @@ static int imon_probe(struct usb_interface *interface,
 			ret = -ENODEV;
 			goto fail;
 		}
+		refcount_set(&ictx->users, 1);
 
 	} else {
 		/* this is the secondary interface on the device */
+		struct imon_context *first_if_ctx = usb_get_intfdata(first_if);
 
 		/* fail early if first intf failed to register */
 		if (!first_if_ctx) {
@@ -2415,14 +2419,13 @@ static int imon_probe(struct usb_interface *interface,
 			ret = -ENODEV;
 			goto fail;
 		}
+		refcount_inc(&ictx->users);
 
 	}
 
 	usb_set_intfdata(interface, ictx);
 
 	if (ifnum == 0) {
-		mutex_lock(&ictx->lock);
-
 		if (product == 0xffdc && ictx->rf_device) {
 			sysfs_err = sysfs_create_group(&interface->dev.kobj,
 						       &imon_rf_attr_group);
@@ -2433,21 +2436,17 @@ static int imon_probe(struct usb_interface *interface,
 
 		if (ictx->display_supported)
 			imon_init_display(ictx, interface);
-
-		mutex_unlock(&ictx->lock);
 	}
 
 	dev_info(dev, "iMON device (%04x:%04x, intf%d) on usb<%d:%d> initialized\n",
 		 vendor, product, ifnum,
 		 usbdev->bus->busnum, usbdev->devnum);
 
-	mutex_unlock(&driver_lock);
 	usb_put_dev(usbdev);
 
 	return 0;
 
 fail:
-	mutex_unlock(&driver_lock);
 	usb_put_dev(usbdev);
 	dev_err(dev, "unable to register, err %d\n", ret);
 
@@ -2463,10 +2462,8 @@ static void imon_disconnect(struct usb_interface *interface)
 	struct device *dev;
 	int ifnum;
 
-	/* prevent races with multi-interface device probing and display_open */
-	mutex_lock(&driver_lock);
-
 	ictx = usb_get_intfdata(interface);
+	ictx->disconnected = true;
 	dev = ictx->dev;
 	ifnum = interface->cur_altsetting->desc.bInterfaceNumber;
 
@@ -2507,10 +2504,8 @@ static void imon_disconnect(struct usb_interface *interface)
 		}
 	}
 
-	if (!ictx->dev_present_intf0 && !ictx->dev_present_intf1)
+	if (refcount_dec_and_test(&ictx->users))
 		free_imon_context(ictx);
-
-	mutex_unlock(&driver_lock);
 
 	dev_dbg(dev, "%s: iMON device (intf%d) disconnected\n",
 		__func__, ifnum);


### PR DESCRIPTION
[LTS 8.6]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2022-1852</td>
<td class="org-left">VULN-3154</td>
</tr>


<tr>
<td class="org-left">CVE-2022-45869</td>
<td class="org-left">VULN-3954</td>
</tr>


<tr>
<td class="org-left">CVE-2023-30456</td>
<td class="org-left">VULN-3974</td>
</tr>


<tr>
<td class="org-left">CVE-2025-39993</td>
<td class="org-left">VULN-158816</td>
</tr>


<tr>
<td class="org-left">CVE-2026-23401</td>
<td class="org-left">VULN-180393</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2022-1852

    KVM: x86: avoid calling x86 emulator without a decoded instruction
    
    jira VULN-3154
    cve CVE-2022-1852
    commit-author Sean Christopherson <seanjc@google.com>
    commit fee060cd52d69c114b62d1a2948ea9648b5131f9


## CVE-2022-45869

    KVM: x86/mmu: Fix race condition in direct_page_fault
    
    jira VULN-3954
    cve CVE-2022-45869
    commit-author Kazuki Takiguchi <takiguchi.kazuki171@gmail.com>
    commit 47b0c2e4c220f2251fd8dcfbb44479819c715e15
    upstream-diff Used linux-5.15.y backport
      f88a6977f8b981bfb5fddd18fbaa75e57e8af293 for the clean pick. The
      modified function `direct_page_fault' is the same in both versions


## CVE-2023-30456

    KVM: nVMX: add missing consistency checks for CR0 and CR4
    
    jira VULN-3974
    cve CVE-2023-30456
    commit-author Paolo Bonzini <pbonzini@redhat.com>
    commit 112e66017bff7f2837030f34c2bc19501e9212d5


## CVE-2025-39993

0:

    media: rc: fix races with imon_disconnect()
    
    jira VULN-158816
    cve CVE-2025-39993
    commit-author Larshin Sergey <Sergey.Larshin@kaspersky.com>
    commit fa0f61cc1d828178aa921475a9b786e7fbb65ccb

1:

    media: imon: grab lock earlier in imon_ir_change_protocol()
    
    jira VULN-158816
    cve-pre CVE-2025-39993
    commit-author Tetsuo Handa <penguin-kernel@I-love.SAKURA.ne.jp>
    commit 7019553ab850ce1d3f0e512e16d14ab153f91c04

2:

    media: imon: Fix race getting ictx->lock
    
    jira VULN-158816
    cve-pre CVE-2025-39993
    commit-author Ricardo Ribalda <ribalda@chromium.org>
    commit 24147897507cd3a7d63745d1518a638bf4132238

3:

    media: imon: fix a race condition in send_packet()
    
    jira VULN-158816
    cve-pre CVE-2025-39993
    commit-author Gautam Menghani <gautammenghani201@gmail.com>
    commit 813ceef062b53d68f296aa3cb944b21a091fabdb

4:

    media: imon: reorganize serialization
    
    jira VULN-158816
    cve-pre CVE-2025-39993
    commit-author Tetsuo Handa <penguin-kernel@I-love.SAKURA.ne.jp>
    commit db264d4c66c0fe007b5d19fd007707cd0697603d
    upstream-diff Context conflict solved due to missing
      cf330691668a3bee37b8ac8212709b3ccdd87997 ("media: rc: Add support for
      another iMON 0xffdc device")

The `imon` module had a bunch of synchronization fixes building one upon the other. This batch of prerequisites follows the general pattern found in other versions having CVE-2025-39993 fix backported:

       File
       -----------------------
       drivers/media/rc/imon.c
       
       kernel-mainline                                                                        ciqlts8_6               linux-5.4.y             linux-5.10.y            linux-6.1.y             linux-6.6.y             linux-6.12.y            linux-5.15.y            linux-6.16.y
       -------------------------------------------------------------------------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------  ----------------------
       88796a18f20f0a9 media: imon: drop redundant device references
       dccc0c3ddf8f160 media: rc: fix race between unregister and urb/irq callbacks
       bf4afc53b77aeaa Convert 'alloc_obj' family to use the new default GFP_KERNEL argument
       69050f8d6d075dc treewide: Replace kmalloc with kmalloc_obj for non-scalar types
    0: fa0f61cc1d82817 media: rc: fix races with imon_disconnect()                                                    ~ 934897600 2025-10-29  ~ b03fac6e2 2025-10-29  ~ 71096a616 2025-10-15  ~ 71da40648 2025-10-06  ~ fd5d3e6b1 2025-10-06  ~ 71c52b073 2025-10-19  ~ d9f6ce996 2025-10-06
       a75b8d198c55e9e media: imon: Remove unused defines
    1: 7019553ab850ce1 media: imon: grab lock earlier in imon_ir_change_protocol()                                    ~ e1b1ba186 2025-10-29
       eecd203ada43a46 media: imon: make send_packet() more robust                                                    ~ 519737af1 2025-12-03  ~ f58ab83b7 2025-12-07  ~ 667afd468 2025-12-07  ~ 8231e8011 2025-11-24  ~ 0213e4175 2025-11-13  ~ 26f6a1dd5 2025-12-07
       41cb08555c41649 treewide, timers: Rename from_timer() to timer_container_of()                                                                                                                                                                                  = 41cb08555 2025-06-08
       8fa7292fee5c524 treewide: Switch/rename to timer_delete[_sync]()                                                                                                                                                                                               = 8fa7292fe 2025-04-05
    2: 24147897507cd3a media: imon: Fix race getting ictx->lock                                                       ~ 031eda178 2024-08-19  ~ f3968b3d3 2024-08-19  ~ 2e13203b8 2024-08-03  ~ ff64b8197 2024-08-03  = 241478975 2024-05-31  ~ 477799870 2024-08-19  = 241478975 2024-05-31
       cc4cce95a95be82 media: imon: Convert sprintf/snprintf to sysfs_emit                                                                                                                                            = cc4cce95a 2024-03-25                          = cc4cce95a 2024-03-25
       a1766a4fd83befa media: imon: fix access to invalid resource for the second interface                                                   ~ 0f5068519 2023-11-28  ~ b083aaf5d 2023-11-28  ~ 2a493a34b 2023-11-28  = a1766a4fd 2023-10-07  ~ 5e0b788fb 2023-11-28  = a1766a4fd 2023-10-07
    3: 813ceef062b53d6 media: imon: fix a race condition in send_packet()                                             ~ 1d8521e11 2023-01-18  ~ dabf7b675 2023-01-14  ~ 3f8b24ab0 2022-12-31  = 813ceef06 2022-11-25  = 813ceef06 2022-11-25  ~ bffc80bac 2022-12-31  = 813ceef06 2022-11-25
       2dfe2c4f1720b6b media: imon: Remove the unneeded result variable                                                                                               = 2dfe2c4f1 2022-09-24  = 2dfe2c4f1 2022-09-24  = 2dfe2c4f1 2022-09-24                          = 2dfe2c4f1 2022-09-24
    4: db264d4c66c0fe0 media: imon: reorganize serialization                                                          ~ ab5d16511 2025-10-29  ~ 4cf6ba936 2022-06-09  = db264d4c6 2022-05-13  = db264d4c6 2022-05-13  = db264d4c6 2022-05-13  ~ 32c7b04d5 2022-06-09  = db264d4c6 2022-05-13
       af2aa3c4e52bc63 media: imon: drop references only after device is no longer used                                                                               = af2aa3c4e 2022-05-13  = af2aa3c4e 2022-05-13  = af2aa3c4e 2022-05-13                          = af2aa3c4e 2022-05-13
       07af64dddfb87d1 media: imon: fix timer racing disconnect                                                                                                       = 07af64ddd 2022-05-13  = 07af64ddd 2022-05-13  = 07af64ddd 2022-05-13                          = 07af64ddd 2022-05-13
       a43617a5bf1b678 media: imon: avoid needless atomic allocations in resume                                                                                       = a43617a5b 2022-05-13  = a43617a5b 2022-05-13  = a43617a5b 2022-05-13                          = a43617a5b 2022-05-13
       c9458c6f8a8f9c8 media: rc: clean the freed urb pointer to avoid double free                                                                                    = c9458c6f8 2021-09-30  = c9458c6f8 2021-09-30  = c9458c6f8 2021-09-30                          = c9458c6f8 2021-09-30
       f1d9f315924f02e media: imon: use DEVICE_ATTR_RW() helper macro                                                                                                 = f1d9f3159 2021-06-08  = f1d9f3159 2021-06-08  = f1d9f3159 2021-06-08  = f1d9f3159 2021-06-08  = f1d9f3159 2021-06-08
       276e2ee0765941e media: imon: Replace http links with https ones                                                                        = 276e2ee07 2020-07-19  = 276e2ee07 2020-07-19  = 276e2ee07 2020-07-19  = 276e2ee07 2020-07-19  = 276e2ee07 2020-07-19  = 276e2ee07 2020-07-19
       f3f5ba42c58d56d media: imon: invalid dereference in imon_touch_event                                           ~ eff2ccdfd 2019-11-29  = f3f5ba42c 2019-10-24  = f3f5ba42c 2019-10-24  = f3f5ba42c 2019-10-24  = f3f5ba42c 2019-10-24  = f3f5ba42c 2019-10-24  = f3f5ba42c 2019-10-24
       cf330691668a3be media: rc: Add support for another iMON 0xffdc device                                          ~ f61cad824 2025-10-29  = cf3306916 2019-10-07  = cf3306916 2019-10-07  = cf3306916 2019-10-07  = cf3306916 2019-10-07  = cf3306916 2019-10-07  = cf3306916 2019-10-07
       b20a6e298bcb8cb media: rc: imon: Allow iMON RC protocol for ffdc 7e device                                     = b20a6e298 2019-08-14  = b20a6e298 2019-08-14  = b20a6e298 2019-08-14  = b20a6e298 2019-08-14  = b20a6e298 2019-08-14  = b20a6e298 2019-08-14  = b20a6e298 2019-08-14
       3cfa958b08a4f81 treewide: Replace GPLv2 boilerplate/reference with SPDX - rule 158                             = 3cfa958b0 2019-05-30  = 3cfa958b0 2019-05-30  = 3cfa958b0 2019-05-30  = 3cfa958b0 2019-05-30  = 3cfa958b0 2019-05-30  = 3cfa958b0 2019-05-30  = 3cfa958b0 2019-05-30
       2396e2821b0f42a media: rc: imon: replace strcpy() by strscpy()                                                 = 2396e2821 2018-11-22  = 2396e2821 2018-11-22  = 2396e2821 2018-11-22  = 2396e2821 2018-11-22  = 2396e2821 2018-11-22  = 2396e2821 2018-11-22  = 2396e2821 2018-11-22
       2525fdcb6e8211e media: imon: rename protocol from other to imon                        = 2525fdcb6 2018-03-21  = 2525fdcb6 2018-03-21  = 2525fdcb6 2018-03-21  = 2525fdcb6 2018-03-21  = 2525fdcb6 2018-03-21  = 2525fdcb6 2018-03-21  = 2525fdcb6 2018-03-21  = 2525fdcb6 2018-03-21
       1b450f211e009d2 media: Revert "[media] staging: lirc_imon: port remaining usb ids to   = 1b450f211 2018-03-21  = 1b450f211 2018-03-21  = 1b450f211 2018-03-21  = 1b450f211 2018-03-21  = 1b450f211 2018-03-21  = 1b450f211 2018-03-21  = 1b450f211 2018-03-21  = 1b450f211 2018-03-21
       e607486c4cfcddb media: imon: remove unused function tv2int                             = e607486c4 2017-12-18  = e607486c4 2017-12-18  = e607486c4 2017-12-18  = e607486c4 2017-12-18  = e607486c4 2017-12-18  = e607486c4 2017-12-18  = e607486c4 2017-12-18  = e607486c4 2017-12-18
       6a489f760ea1b78 media: imon: auto-config ffdc 26 device                                = 6a489f760 2017-12-18  = 6a489f760 2017-12-18  = 6a489f760 2017-12-18  = 6a489f760 2017-12-18  = 6a489f760 2017-12-18  = 6a489f760 2017-12-18  = 6a489f760 2017-12-18  = 6a489f760 2017-12-18
       [...]


## CVE-2026-23401

    KVM: x86/mmu: Drop/zap existing present SPTE even when creating an MMIO SPTE
    
    jira VULN-180393
    cve CVE-2026-23401
    commit-author Sean Christopherson <seanjc@google.com>
    commit aad885e774966e97b675dfe928da164214a71605
    upstream-diff Used linux-5.15.y's backport
      20656cd1f243d3a154aac5dd1b823110b6906fe1 for the clean cherry-pick.
      Just like that version the LTS 8.6 misses
      1075d41efd598d3fd4d52a1e1116b20979975135 ("KVM: x86/mmu: Expand and
      clean up page fault stats"). Strictly speaking, the upstream's
      `kvm_flush_remote_tlbs_gfn(vcpu->kvm, gfn, level)' call corresponds to
      LTS 8.6-native `kvm_flush_remote_tlbs_with_address(vcpu->kvm, gfn &
      -KVM_PAGES_PER_HPAGE(level), KVM_PAGES_PER_HPAGE(level))'. See the
      non-backported commits:
      - 9ffe9265375cbaf6c01647e31ae9fee8595b698c ("KVM: x86/mmu: Fix wrong gfn
        range of tlb flushing in kvm_set_pte_rmapp()"),
      - 8c63e8c2176552d5c003d7459609383d32bf47f3 ("KVM: x86/mmu: Rename
        kvm_flush_remote_tlbs_with_address()"),
      - c667a3baeddcc982bf512c126aec8d0f04adecfe ("KVM: x86/mmu: Move
        round_gfn_for_level() helper into mmu_internal.h").
      Nevertheless preserved linux-5.15.y's
      `kvm_flush_remote_tlbs_with_address()' call without `gfn' rounding, as
      that's exactly how it's used in the same function a few lines later,
      strongly suggesting that the issues raised in commit 9ffe92653 don't
      apply here.

For details see the [PR for the LTS 9.2 solution](https://github.com/ctrliq/kernel-src-tree/pull/1357) with the same situation.


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts8_6-CVE-batch-36]	_kabi_check_kernel__x86_64--test--ciqlts8_6-CVE-batch-36
    ninja explain: output state/kernels/ciqlts8_6-CVE-batch-36/x86_64/kabi_checked older than most recent input state/kernels/ciqlts8_6-CVE-batch-36/x86_64/compiled (1781819728816874964 vs 1781827317595394731)
    ninja explain: state/kernels/ciqlts8_6-CVE-batch-36/x86_64/kabi_checked is dirty
    + dist_git_version=el-8.6
    + local_version=ciqlts8_6-CVE-batch-36
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts8_6
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-8.6
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-batch-36
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-8.6/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts8_6 ''\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-8.6/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts8_6-CVE-batch-36/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts8_6-CVE-batch-36/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/29150173/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts8\_6&#x2013;run1.log](<https://github.com/user-attachments/files/29150174/kselftests--ciqlts8_6--run1.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run2.log](<https://github.com/user-attachments/files/29150176/kselftests--ciqlts8_6--run2.log>)
[kselftests&#x2013;ciqlts8\_6&#x2013;run3.log](<https://github.com/user-attachments/files/29150177/kselftests--ciqlts8_6--run3.log>)


## Patch

[kselftests&#x2013;ciqlts8\_6-CVE-batch-36&#x2013;run1.log](<https://github.com/user-attachments/files/29150178/kselftests--ciqlts8_6-CVE-batch-36--run1.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-batch-36&#x2013;run2.log](<https://github.com/user-attachments/files/29150179/kselftests--ciqlts8_6-CVE-batch-36--run2.log>)
[kselftests&#x2013;ciqlts8\_6-CVE-batch-36&#x2013;run3.log](<https://github.com/user-attachments/files/29150180/kselftests--ciqlts8_6-CVE-batch-36--run3.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff -d kselftests*.log

>

    Column    File
    --------  --------------------------------------------
    Status0   kselftests--ciqlts8_6--run1.log
    Status1   kselftests--ciqlts8_6--run2.log
    Status2   kselftests--ciqlts8_6--run3.log
    Status3   kselftests--ciqlts8_6-CVE-batch-36--run1.log
    Status4   kselftests--ciqlts8_6-CVE-batch-36--run2.log
    Status5   kselftests--ciqlts8_6-CVE-batch-36--run3.log

[full-tests-results-comparison.log](<https://github.com/user-attachments/files/29150652/full-tests-results-comparison.log>)

