### PR TITLE
[LTS 9.2] CVE-2026-23401

### DIFF
--- a/arch/x86/kvm/mmu/mmu.c
+++ b/arch/x86/kvm/mmu/mmu.c
@@ -2792,12 +2792,6 @@ static int mmu_set_spte(struct kvm_vcpu *vcpu, struct kvm_memory_slot *slot,
 	pgprintk("%s: spte %llx write_fault %d gfn %llx\n", __func__,
 		 *sptep, write_fault, gfn);
 
-	if (unlikely(is_noslot_pfn(pfn))) {
-		vcpu->stat.pf_mmio_spte_created++;
-		mark_mmio_spte(vcpu, sptep, gfn, pte_access);
-		return RET_PF_EMULATE;
-	}
-
 	if (is_shadow_present_pte(*sptep)) {
 		/*
 		 * If we overwrite a PTE page pointer with a 2MB PMD, unlink
@@ -2817,6 +2811,15 @@ static int mmu_set_spte(struct kvm_vcpu *vcpu, struct kvm_memory_slot *slot,
 			flush = true;
 		} else
 			was_rmapped = 1;
+	}
+
+	if (unlikely(is_noslot_pfn(pfn))) {
+		vcpu->stat.pf_mmio_spte_created++;
+		mark_mmio_spte(vcpu, sptep, gfn, pte_access);
+		if (flush)
+			kvm_flush_remote_tlbs_with_address(vcpu->kvm, gfn,
+					KVM_PAGES_PER_HPAGE(level));
+		return RET_PF_EMULATE;
 	}
 
 	wrprot = make_spte(vcpu, sp, slot, pte_access, gfn, pfn, *sptep, prefetch,


### PR DESCRIPTION
[LTS 9.2]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2026-23401</td>
<td class="org-left">VULN-180395</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2026-23401

    KVM: x86/mmu: Drop/zap existing present SPTE even when creating an MMIO SPTE
    
    jira VULN-180395
    cve CVE-2026-23401
    commit-author Sean Christopherson <seanjc@google.com>
    commit aad885e774966e97b675dfe928da164214a71605
    upstream-diff Used linux-6.1.y backport
      ed5909992f344a7d3f4024261e9f751d9618a27d for the clean pick. Strictly
      speaking, the upstream's `kvm_flush_remote_tlbs_gfn(vcpu->kvm, gfn,
      level)' call corresponds to LTS 9.2-native
      `kvm_flush_remote_tlbs_with_address(vcpu->kvm, gfn &
      -KVM_PAGES_PER_HPAGE(level), KVM_PAGES_PER_HPAGE(level))'. See the
      non-backported commits:
      - 9ffe9265375cbaf6c01647e31ae9fee8595b698c ("KVM: x86/mmu: Fix wrong gfn
        range of tlb flushing in kvm_set_pte_rmapp()"),
      - 8c63e8c2176552d5c003d7459609383d32bf47f3 ("KVM: x86/mmu: Rename
        kvm_flush_remote_tlbs_with_address()"),
      - c667a3baeddcc982bf512c126aec8d0f04adecfe ("KVM: x86/mmu: Move
        round_gfn_for_level() helper into mmu_internal.h").
      Nevertheless preserved linux-6.1.y's
      `kvm_flush_remote_tlbs_with_address()' call without `gfn' rounding, as
      that's exactly how it's used in the same function a few lines later,
      strongly suggesting that the issues raised in commit 9ffe92653 don't
      apply here.

The KVM module uses different table flushing procedures across time and code space, those relevant to the CVE-2026-23401 fix being:

-   `kvm_flush_remote_tlbs_with_range`,
-   `kvm_flush_remote_tlbs_with_address`,
-   `kvm_flush_remote_tlbs_range`,
-   `kvm_flush_remote_tlbs_gfn`.

Their evolution can best be presented in the following table, with commits starting from the oldest, up to what can be found in the upstream at the moment of the aad885e774966e97b675dfe928da164214a71605 fix:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">`kernel-mainline`</th>
<th scope="col" class="org-left">`ciqlts8_6`</th>
<th scope="col" class="org-left">`ciqlts9_2`</th>
<th scope="col" class="org-left">`linux-6.1.y`</th>
<th scope="col" class="org-left">`linux-5.15.y`</th>
<th scope="col" class="org-left">`kvm_flush_remote_tlbs_with_range`</th>
<th scope="col" class="org-left">`kvm_flush_remote_tlbs_with_address`</th>
<th scope="col" class="org-left">`kvm_flush_remote_tlbs_range`</th>
<th scope="col" class="org-left">`kvm_flush_remote_tlbs_gfn`</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">40ef75a758b291dc2cc88ecef36ffbb0eb095e00</td>
<td class="org-left">c4b11c69f8ecbe83964b4c5187dc084c4c7280a3</td>
<td class="org-left">40ef75a758b291dc2cc88ecef36ffbb0eb095e00</td>
<td class="org-left">40ef75a758b291dc2cc88ecef36ffbb0eb095e00</td>
<td class="org-left">40ef75a758b291dc2cc88ecef36ffbb0eb095e00</td>
<td class="org-left">Defined in `arch/x86/kvm/mmu.c`</td>
<td class="org-left">Defined in `arch/x86/kvm/mmu.c` (calls `kvm_flush_remote_tlbs_with_range`)</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">c50d8ae3a1274f32c9033bbb0e1c5b3115da2112</td>
<td class="org-left">94adbae9f30242d37082daea59608858559fa2c0</td>
<td class="org-left">c50d8ae3a1274f32c9033bbb0e1c5b3115da2112</td>
<td class="org-left">c50d8ae3a1274f32c9033bbb0e1c5b3115da2112</td>
<td class="org-left">c50d8ae3a1274f32c9033bbb0e1c5b3115da2112</td>
<td class="org-left">Moved to `arch/x86/kvm/mmu/mmu.c`</td>
<td class="org-left">Moved to `arch/x86/kvm/mmu/mmu.c`</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">2f2fad0897cbfda4e384a7b9eab73654974015ac</td>
<td class="org-left">b10939c95c9c75e3de02cefd1a0d046565124cfc</td>
<td class="org-left">2f2fad0897cbfda4e384a7b9eab73654974015ac</td>
<td class="org-left">2f2fad0897cbfda4e384a7b9eab73654974015ac</td>
<td class="org-left">2f2fad0897cbfda4e384a7b9eab73654974015ac</td>
<td class="org-left">0</td>
<td class="org-left">Made public (non-static)</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">9ffe9265375cbaf6c01647e31ae9fee8595b698c</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">0</td>
<td class="org-left">0</td>
<td class="org-left">-</td>
<td class="org-left">Definition</td>
</tr>


<tr>
<td class="org-left">28e4b4597d65927f8147c493d66aa0fe006e364c</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">Inlined into `kvm_flush_remote_tlbs_with_address`</td>
<td class="org-left">Inlined the `kvm_flush_remote_tlbs_with_range` call</td>
<td class="org-left">-</td>
<td class="org-left">0</td>
</tr>


<tr>
<td class="org-left">8c63e8c2176552d5c003d7459609383d32bf47f3</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">Renamed to `kvm_flush_remote_tlbs_range`</td>
<td class="org-left">Created from `kvm_flush_remote_tlbs_with_address`</td>
<td class="org-left">Change inner call from `kvm_flush_remote_tlbs_with_address` to `kvm_flush_remote_tlbs_range`</td>
</tr>


<tr>
<td class="org-left">9d4655da1a4c17f6691a6434303d9973017bf1ca</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">Changed arg `u64 pages` → `gfn_t nr_pages`</td>
<td class="org-left">0</td>
</tr>


<tr>
<td class="org-left">d4788996051e3c07fadc6d9b214073fcf78810a8</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">Moved to `virt/kvm/kvm_main.c` and changed body</td>
<td class="org-left">0</td>
</tr>
</tbody>
</table>

Upstream fix uses:

<https://github.com/ctrliq/kernel-src-tree/blob/aad885e774966e97b675dfe928da164214a71605/arch/x86/kvm/mmu/mmu.c#L3074>

The `kvm_flush_remote_tlbs_gfn()` function is defined as:

<https://github.com/ctrliq/kernel-src-tree/blob/aad885e774966e97b675dfe928da164214a71605/arch/x86/kvm/mmu/mmu_internal.h#L211-L216>

The `kvm_flush_remote_tlbs_range()` call corresponds to `kvm_flush_remote_tlbs_with_address()` call - the function was renamed in 8c63e8c2176552d5c003d7459609383d32bf47f3. The `gfn_round_for_level()` function is

<https://github.com/ctrliq/kernel-src-tree/blob/aad885e774966e97b675dfe928da164214a71605/arch/x86/kvm/mmu/mmu_internal.h#L197-L200>

It also exists in LTS 9.2, under a similar name `round_gfn_for_level()` (moved and renamed in c667a3baeddcc982bf512c126aec8d0f04adecfe).

<https://github.com/ctrliq/kernel-src-tree/blob/cf9f720a1efd39df2d0a6c7a0288f039bc998da3/arch/x86/kvm/mmu/tdp_iter.c#L18-L21>

(It's private, however, so using it in `arch/x86/kvm/mmu/mmu.c` would require publicizing it (basically what c667a3baeddcc982bf512c126aec8d0f04adecfe does)).

Taking all of the above into account would result in a LTS 9.2-corresponding call:

    kvm_flush_remote_tlbs_with_address(vcpu->kvm,
    				   gfn & -KVM_PAGES_PER_HPAGE(level),
    				   KVM_PAGES_PER_HPAGE(level));

The `gfn & -KVM_PAGES_PER_HPAGE(level)` part is a rounding of `gfn` to a value appropriate for `kvm_flush_remote_tlbs_with_address()` call. Failure to do so in the `kvm_set_pte_rmap()` function motivated the introduction of `kvm_flush_remote_tlbs_gfn()` in 9ffe9265375cbaf6c01647e31ae9fee8595b698c:

> Also introduce a helper function to flush the given
> page (huge or not) of guest memory, which would help prevent future
> buggy use of kvm\_flush\_remote\_tlbs\_with\_address() in such case.

The transition from using `kvm_flush_remote_tlbs_with_address()` to `kvm_flush_remote_tlbs_gfn()` was done in a few commits: 9ffe9265375cbaf6c01647e31ae9fee8595b698c, 1e203847aa9245bd782d6dc904ece124ca1b89cb, 1b2dc7360463932d2e7cac9461de16ce6fa11cb7, 4ad980aea7f58632638d036ac5697fccf8234dde.

However, the CVE-2026-23401-fix-modified function `mmu_set_spte()` uses `kvm_flush_remote_tlbs_with_address()` call without `gfn` rounding just a few lines later

<https://github.com/ctrliq/kernel-src-tree/blob/cf9f720a1efd39df2d0a6c7a0288f039bc998da3/arch/x86/kvm/mmu/mmu.c#L2838-L2839>

and the transition of this call to `kvm_flush_remote_tlbs_gfn()` on upstream was done in a non-bugfixing commit 4ad980aea7f58632638d036ac5697fccf8234dde. This strongly suggests that `gfn` is already rounded to the proper value.

Retained the `linux-6.1.y` solution (aligning also with `rocky8_10` fix in 9b906d0e7b3e34897f09fe4dcb3f4a439510cabe) for the sake of simplicity.


# kABI check: passed

    [0/1] kabi_check_kernel	Check ABI of kernel [ciqlts9_2-CVE-2026-23401]	_kabi_check_kernel__x86_64--test--ciqlts9_2-CVE-2026-23401
    + dist_git_version=el-9.2
    + local_version=ciqlts9_2-CVE-2026-23401
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts9_2
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-9.2
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts9_2-CVE-2026-23401
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-9.2/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts9_2 ''\''/mnt/code/kernel-dist-git-el-9.2/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts9_2-CVE-2026-23401/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-2026-23401/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/29167910/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/29167912/kselftests--ciqlts9_2--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-2026-23401&#x2013;run1.log](<https://github.com/user-attachments/files/29167913/kselftests--ciqlts9_2-CVE-2026-23401--run1.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  ----------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2-CVE-2026-23401--run1.log

[full-tests-results-comparison.log](<https://github.com/user-attachments/files/29167911/full-tests-results-comparison.log>)

