### PR TITLE
github-actions: extend trigger glob to match suffix branches

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '*_ciqcbr7_9'
+      - '*_ciqcbr7_9-*'
   pull_request:
     types: [opened, synchronize, reopened]
     branches:


### PR DESCRIPTION
Catches *_ciqcbr7_9-no-ltp, *_ciqcbr7_9-pr-only, and other branch-name suffix variants used by the kernelCI skip-stages feature.