### PR TITLE
github-actions: extend trigger glob to match suffix branches

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '*_ciq-6.12.y'
+      - '*_ciq-6.12.y-*'
       - '*_ciq-6.12.y-next'
 
 jobs:


### PR DESCRIPTION
Catches *_ciq-6.12.y-no-ltp, *_ciq-6.12.y-pr-only, and other branch-name suffix variants used by the kernelCI skip-stages feature.