### PR TITLE
github-actions: extend trigger glob to match suffix branches

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '*_ciqlts8_6'
+      - '*_ciqlts8_6-*'
   pull_request:
     types: [opened, synchronize, reopened]
     branches:


### PR DESCRIPTION
Catches *_ciqlts8_6-no-ltp, *_ciqlts8_6-pr-only, and other branch-name suffix variants used by the kernelCI skip-stages feature.