### PR TITLE
github-actions: extend trigger glob to match suffix branches

### DIFF
--- a/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
+++ b/.github/workflows/kernel-build-and-test-multiarch-trigger.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '*_ciqlts9_2'
+      - '*_ciqlts9_2-*'
   pull_request:
     types: [opened, synchronize, reopened]
     branches:


### PR DESCRIPTION
Catches *_ciqlts9_2-no-ltp, *_ciqlts9_2-pr-only, and other branch-name suffix variants used by the kernelCI skip-stages feature.