### PR TITLE
[LTS 9.2] smb (cifs): CVE-2026-46195, CVE-2026-46139, CVE-2026-43350, CVE-2026-31709; net: CVE-2026-31419

### DIFF
--- a/drivers/net/bonding/bond_main.c
+++ b/drivers/net/bonding/bond_main.c
@@ -5155,18 +5155,22 @@ static netdev_tx_t bond_xmit_broadcast(struct sk_buff *skb,
 				       struct net_device *bond_dev)
 {
 	struct bonding *bond = netdev_priv(bond_dev);
-	struct slave *slave = NULL;
-	struct list_head *iter;
+	struct bond_up_slave *slaves;
 	bool xmit_suc = false;
 	bool skb_used = false;
+	int slaves_count, i;
 
-	bond_for_each_slave_rcu(bond, slave, iter) {
+	slaves = rcu_dereference(bond->all_slaves);
+
+	slaves_count = slaves ? READ_ONCE(slaves->count) : 0;
+	for (i = 0; i < slaves_count; i++) {
+		struct slave *slave = slaves->arr[i];
 		struct sk_buff *skb2;
 
 		if (!(bond_slave_is_up(slave) && slave->link == BOND_LINK_UP))
 			continue;
 
-		if (bond_is_last_slave(bond, slave)) {
+		if (i + 1 == slaves_count) {
 			skb2 = skb;
 			skb_used = true;
 		} else {

--- a/fs/cifs/cifsacl.c
+++ b/fs/cifs/cifsacl.c
@@ -1718,7 +1718,7 @@ id_mode_to_cifs_acl(struct inode *inode, const char *path, __u64 *pnmode,
 	 * descriptor parameters, and security descriptor itself
 	 */
 	nsecdesclen = max_t(u32, nsecdesclen, DEFAULT_SEC_DESC_LEN);
-	pnntsd = kmalloc(nsecdesclen, GFP_KERNEL);
+	pnntsd = kzalloc(nsecdesclen, GFP_KERNEL);
 	if (!pnntsd) {
 		kfree(pntsd);
 		cifs_put_tlink(tlink);

--- a/fs/cifs/cifsacl.c
+++ b/fs/cifs/cifsacl.c
@@ -877,6 +877,7 @@ static void parse_dacl(struct cifs_acl *pdacl, char *end_of_acl,
 			dump_ace(ppace[i], end_of_dacl);
 #endif
 			if (mode_from_special_sid &&
+			    ppace[i]->sid.num_subauth >= 3 &&
 			    (compare_sids(&(ppace[i]->sid),
 					  &sid_unix_NFS_mode) == 0)) {
 				/*

--- a/fs/cifs/cifsacl.c
+++ b/fs/cifs/cifsacl.c
@@ -1254,6 +1254,17 @@ static int parse_sid(struct cifs_sid *psid, char *end_of_acl)
 	return 0;
 }
 
+static bool dacl_offset_valid(unsigned int acl_len, __u32 dacloffset)
+{
+	if (acl_len < sizeof(struct cifs_acl))
+		return false;
+
+	if (dacloffset < sizeof(struct cifs_ntsd))
+		return false;
+
+	return dacloffset <= acl_len - sizeof(struct cifs_acl);
+}
+
 
 /* Convert CIFS ACL to POSIX form */
 static int parse_sec_desc(struct cifs_sb_info *cifs_sb,
@@ -1274,7 +1285,6 @@ static int parse_sec_desc(struct cifs_sb_info *cifs_sb,
 	group_sid_ptr = (struct cifs_sid *)((char *)pntsd +
 				le32_to_cpu(pntsd->gsidoffset));
 	dacloffset = le32_to_cpu(pntsd->dacloffset);
-	dacl_ptr = (struct cifs_acl *)((char *)pntsd + dacloffset);
 	cifs_dbg(NOISY, "revision %d type 0x%x ooffset 0x%x goffset 0x%x sacloffset 0x%x dacloffset 0x%x\n",
 		 pntsd->revision, pntsd->type, le32_to_cpu(pntsd->osidoffset),
 		 le32_to_cpu(pntsd->gsidoffset),
@@ -1305,11 +1315,18 @@ static int parse_sec_desc(struct cifs_sb_info *cifs_sb,
 		return rc;
 	}
 
-	if (dacloffset)
+	if (dacloffset) {
+		if (!dacl_offset_valid(acl_len, dacloffset)) {
+			cifs_dbg(VFS, "Server returned illegal DACL offset\n");
+			return -EINVAL;
+		}
+
+		dacl_ptr = (struct cifs_acl *)((char *)pntsd + dacloffset);
 		parse_dacl(dacl_ptr, end_of_acl, owner_sid_ptr,
 			   group_sid_ptr, fattr, get_mode_from_special_sid);
-	else
+	} else {
 		cifs_dbg(FYI, "no ACL\n"); /* BB grant all or default perms? */
+	}
 
 	return rc;
 }
@@ -1332,6 +1349,11 @@ static int build_sec_desc(struct cifs_ntsd *pntsd, struct cifs_ntsd *pnntsd,
 
 	dacloffset = le32_to_cpu(pntsd->dacloffset);
 	if (dacloffset) {
+		if (!dacl_offset_valid(secdesclen, dacloffset)) {
+			cifs_dbg(VFS, "Server returned illegal DACL offset\n");
+			return -EINVAL;
+		}
+
 		dacl_ptr = (struct cifs_acl *)((char *)pntsd + dacloffset);
 		rc = validate_dacl(dacl_ptr, end_of_acl);
 		if (rc)
@@ -1696,6 +1718,12 @@ id_mode_to_cifs_acl(struct inode *inode, const char *path, __u64 *pnmode,
 		nsecdesclen = sizeof(struct cifs_ntsd) + (sizeof(struct cifs_sid) * 2);
 		dacloffset = le32_to_cpu(pntsd->dacloffset);
 		if (dacloffset) {
+			if (!dacl_offset_valid(secdesclen, dacloffset)) {
+				cifs_dbg(VFS, "Server returned illegal DACL offset\n");
+				rc = -EINVAL;
+				goto id_mode_to_cifs_acl_exit;
+			}
+
 			dacl_ptr = (struct cifs_acl *)((char *)pntsd + dacloffset);
 			rc = validate_dacl(dacl_ptr, (char *)pntsd + secdesclen);
 			if (rc) {
@@ -1738,6 +1766,7 @@ id_mode_to_cifs_acl(struct inode *inode, const char *path, __u64 *pnmode,
 		rc = ops->set_acl(pnntsd, nsecdesclen, inode, path, aclflag);
 		cifs_dbg(NOISY, "set_cifs_acl rc: %d\n", rc);
 	}
+id_mode_to_cifs_acl_exit:
 	cifs_put_tlink(tlink);
 
 	kfree(pnntsd);

--- a/fs/cifs/cifsacl.c
+++ b/fs/cifs/cifsacl.c
@@ -753,6 +753,78 @@ static void dump_ace(struct cifs_ace *pace, char *end_of_acl)
 }
 #endif
 
+static int validate_dacl(struct cifs_acl *pdacl, char *end_of_acl)
+{
+	int i, ace_hdr_size, ace_size, min_ace_size;
+	u16 dacl_size;
+	u32 num_aces;
+	char *acl_base, *end_of_dacl;
+	struct cifs_ace *pace;
+
+	if (!pdacl)
+		return 0;
+
+	if (end_of_acl < (char *)pdacl + sizeof(struct cifs_acl)) {
+		cifs_dbg(VFS, "ACL too small to parse DACL\n");
+		return -EINVAL;
+	}
+
+	dacl_size = le16_to_cpu(pdacl->size);
+	if (dacl_size < sizeof(struct cifs_acl) ||
+	    end_of_acl < (char *)pdacl + dacl_size) {
+		cifs_dbg(VFS, "ACL too small to parse DACL\n");
+		return -EINVAL;
+	}
+
+	num_aces = le32_to_cpu(pdacl->num_aces);
+	if (!num_aces)
+		return 0;
+
+	ace_hdr_size = offsetof(struct cifs_ace, sid) +
+		offsetof(struct cifs_sid, sub_auth);
+	min_ace_size = ace_hdr_size + sizeof(__le32);
+	if (num_aces > (dacl_size - sizeof(struct cifs_acl)) / min_ace_size) {
+		cifs_dbg(VFS, "ACL too small to parse DACL\n");
+		return -EINVAL;
+	}
+
+	end_of_dacl = (char *)pdacl + dacl_size;
+	acl_base = (char *)pdacl;
+	ace_size = sizeof(struct cifs_acl);
+
+	for (i = 0; i < num_aces; ++i) {
+		if (end_of_dacl - acl_base < ace_size) {
+			cifs_dbg(VFS, "ACL too small to parse ACE\n");
+			return -EINVAL;
+		}
+
+		pace = (struct cifs_ace *)(acl_base + ace_size);
+		acl_base = (char *)pace;
+
+		if (end_of_dacl - acl_base < ace_hdr_size ||
+		    pace->sid.num_subauth == 0 ||
+		    pace->sid.num_subauth > SID_MAX_SUB_AUTHORITIES) {
+			cifs_dbg(VFS, "ACL too small to parse ACE\n");
+			return -EINVAL;
+		}
+
+		ace_size = ace_hdr_size + sizeof(__le32) * pace->sid.num_subauth;
+		if (end_of_dacl - acl_base < ace_size ||
+		    le16_to_cpu(pace->size) < ace_size) {
+			cifs_dbg(VFS, "ACL too small to parse ACE\n");
+			return -EINVAL;
+		}
+
+		ace_size = le16_to_cpu(pace->size);
+		if (end_of_dacl - acl_base < ace_size) {
+			cifs_dbg(VFS, "ACL too small to parse ACE\n");
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
 static void parse_dacl(struct cifs_acl *pdacl, char *end_of_acl,
 		       struct cifs_sid *pownersid, struct cifs_sid *pgrpsid,
 		       struct cifs_fattr *fattr, bool mode_from_special_sid)
@@ -760,7 +832,7 @@ static void parse_dacl(struct cifs_acl *pdacl, char *end_of_acl,
 	int i;
 	int num_aces = 0;
 	int acl_size;
-	char *acl_base;
+	char *acl_base, *end_of_dacl;
 	struct cifs_ace **ppace;
 
 	/* BB need to add parm so we can store the SID BB */
@@ -772,11 +844,8 @@ static void parse_dacl(struct cifs_acl *pdacl, char *end_of_acl,
 		return;
 	}
 
-	/* validate that we do not go past end of acl */
-	if (end_of_acl < (char *)pdacl + le16_to_cpu(pdacl->size)) {
-		cifs_dbg(VFS, "ACL too small to parse DACL\n");
+	if (validate_dacl(pdacl, end_of_acl))
 		return;
-	}
 
 	cifs_dbg(NOISY, "DACL revision %d size %d num aces %d\n",
 		 le16_to_cpu(pdacl->revision), le16_to_cpu(pdacl->size),
@@ -787,6 +856,7 @@ static void parse_dacl(struct cifs_acl *pdacl, char *end_of_acl,
 	   user/group/other have no permissions */
 	fattr->cf_mode &= ~(0777);
 
+	end_of_dacl = (char *)pdacl + le16_to_cpu(pdacl->size);
 	acl_base = (char *)pdacl;
 	acl_size = sizeof(struct cifs_acl);
 
@@ -804,7 +874,7 @@ static void parse_dacl(struct cifs_acl *pdacl, char *end_of_acl,
 		for (i = 0; i < num_aces; ++i) {
 			ppace[i] = (struct cifs_ace *) (acl_base + acl_size);
 #ifdef CONFIG_CIFS_DEBUG2
-			dump_ace(ppace[i], end_of_acl);
+			dump_ace(ppace[i], end_of_dacl);
 #endif
 			if (mode_from_special_sid &&
 			    (compare_sids(&(ppace[i]->sid),
@@ -1262,10 +1332,9 @@ static int build_sec_desc(struct cifs_ntsd *pntsd, struct cifs_ntsd *pnntsd,
 	dacloffset = le32_to_cpu(pntsd->dacloffset);
 	if (dacloffset) {
 		dacl_ptr = (struct cifs_acl *)((char *)pntsd + dacloffset);
-		if (end_of_acl < (char *)dacl_ptr + le16_to_cpu(dacl_ptr->size)) {
-			cifs_dbg(VFS, "Server returned illegal ACL size\n");
-			return -EINVAL;
-		}
+		rc = validate_dacl(dacl_ptr, end_of_acl);
+		if (rc)
+			return rc;
 	}
 
 	owner_sid_ptr = (struct cifs_sid *)((char *)pntsd +
@@ -1627,6 +1696,12 @@ id_mode_to_cifs_acl(struct inode *inode, const char *path, __u64 *pnmode,
 		dacloffset = le32_to_cpu(pntsd->dacloffset);
 		if (dacloffset) {
 			dacl_ptr = (struct cifs_acl *)((char *)pntsd + dacloffset);
+			rc = validate_dacl(dacl_ptr, (char *)pntsd + secdesclen);
+			if (rc) {
+				kfree(pntsd);
+				cifs_put_tlink(tlink);
+				return rc;
+			}
 			if (mode_from_sid)
 				nsecdesclen +=
 					le32_to_cpu(dacl_ptr->num_aces) * sizeof(struct cifs_ace);


### PR DESCRIPTION
[LTS 9.2]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2026-46195</td>
<td class="org-left">VULN-188328</td>
</tr>


<tr>
<td class="org-left">CVE-2026-46139</td>
<td class="org-left">VULN-188853</td>
</tr>


<tr>
<td class="org-left">CVE-2026-43350</td>
<td class="org-left">VULN-184957</td>
</tr>


<tr>
<td class="org-left">CVE-2026-31709</td>
<td class="org-left">VULN-183468</td>
</tr>


<tr>
<td class="org-left">CVE-2026-31419</td>
<td class="org-left">VULN-181412</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2026-46195

    smb: client: validate dacloffset before building DACL pointers
    
    jira VULN-188328
    cve CVE-2026-46195
    commit-author Michael Bommarito <michael.bommarito@gmail.com>
    commit f98b48151cc502ada59d9778f0112d21f2586ca3
    upstream-diff Used linux-5.15.y backport
      5de2665e913a10ad70aaeecf736b97276e83d995 for the clean pick

See [CVE-2026-31709 section](#org9ef59ad) for the discussion of the differences between `linux-5.15.y` and `kernel-mainline`.


## CVE-2026-46139

    smb: client: use kzalloc to zero-initialize security descriptor buffer
    
    jira VULN-188853
    cve CVE-2026-46139
    commit-author Bjoern Doebel <doebel@amazon.de>
    commit 5e489c6c47a2ac15edbaca153b9348e42c1eacab


## CVE-2026-43350

    smb: client: require a full NFS mode SID before reading mode bits
    
    jira VULN-184957
    cve CVE-2026-43350
    commit-author Michael Bommarito <michael.bommarito@gmail.com>
    commit 2757ad3e4b6f9e0fed4c7739594e702abc5cab21


<a id="org9ef59ad"></a>

## CVE-2026-31709

    smb: client: validate the whole DACL before rewriting it in cifsacl
    
    jira VULN-183468
    cve CVE-2026-31709
    commit-author Michael Bommarito <michael.bommarito@gmail.com>
    commit 0a8cf165566ba55a39fd0f4de172119dd646d39a
    upstream-diff Used linux-5.15.y backport
      b8603d9ae6c9087662b098619996bc4a8064319d for a clean pick. Compared to
      the upstream:
      1. Structs `cifs_{acl,ace,sid}' underwent renaming to
         `smb_{acl,ace,sid}' in 7f599d8fb3e087aff5be4e1392baaae3f8d42419,
         251b93ae73805b216e84ed2190b525f319da4c87,
         09bedafc1e2c5c82aad3cbfe1359e2b0bf752f3a. Additionally the `__le32
         num_aces' field of `smb_acl' was split into `__le16 num_aces' and
         `__le16 reserved' in 62e7dd0a39c2d0d7ff03274c36df971f1b3d2d0d. These
         changes were taken into account in the body of `validate_dacl()'
         function.
      2. No removal of validation code fragments in `parse_dacl()'. In the
         upstream those were put into place by
         aa2a739a75ab6f24ef72fb3fdb9192c081eacf06 and
         eeb827f2922eb07ffbf7d53569cc95b38272646f, not backported to LTS
         9.2. In both versions they ultimately landed in the `validate_dacl()'
         function in this fix.

LTS 9.2 `cifs` module is on roughly the same level feature-and-bugfix-wise as Linux stable 5.15. The differences between the upstream fix and 5.15 backport stem from the evolution of the core data structures - mostly just renaming and moving around the codebase, although there is one change to the `smb_acl` fielfs as well.

Compare `ciqlts9_2`:

<https://github.com/ctrliq/kernel-src-tree/blob/4f58c44b12339e945e352ac5644c1e644abba25f/fs/cifs/cifsacl.h#L77-L81>

<https://github.com/ctrliq/kernel-src-tree/blob/4f58c44b12339e945e352ac5644c1e644abba25f/fs/cifs/cifsacl.h#L114-L120>

<https://github.com/ctrliq/kernel-src-tree/blob/4f58c44b12339e945e352ac5644c1e644abba25f/fs/cifs/cifsacl.h#L67-L72>

with upstream:

<https://github.com/ctrliq/kernel-src-tree/blob/0a8cf165566ba55a39fd0f4de172119dd646d39a/fs/smb/common/smbacl.h#L107-L112>

<https://github.com/ctrliq/kernel-src-tree/blob/0a8cf165566ba55a39fd0f4de172119dd646d39a/fs/smb/common/smbacl.h#L114-L120>

<https://github.com/ctrliq/kernel-src-tree/blob/0a8cf165566ba55a39fd0f4de172119dd646d39a/fs/smb/common/smbacl.h#L97-L102>

The data structures timeline can be summarized in the following table (from oldest):

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">kernel-mainline</th>
<th scope="col" class="org-left">`ciqlts9_2`</th>
<th scope="col" class="org-left">`*_acl`</th>
<th scope="col" class="org-left">`*_ace`</th>
<th scope="col" class="org-left">`*_sid`</th>
<th scope="col" class="org-left">Change</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">bf8206791750854bc6668266b694e8fe2cacb924</td>
<td class="org-left">bf8206791750854bc6668266b694e8fe2cacb924</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">x</td>
<td class="org-left">Definition of `cifs_sid`</td>
</tr>


<tr>
<td class="org-left">442aa310f3bc49cf4e059da790fbae62411d50db</td>
<td class="org-left">442aa310f3bc49cf4e059da790fbae62411d50db</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">Definition of `cifs_acl`, `cifs_ace`, fields changed in `cifs_sid`</td>
</tr>


<tr>
<td class="org-left">af6f4612fdfd782c6d35272836a2b97e7e5b790e</td>
<td class="org-left">af6f4612fdfd782c6d35272836a2b97e7e5b790e</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">Endiannes fixes in `cifs_acl`, `cifs_ace`, `cifs_sid`</td>
</tr>


<tr>
<td class="org-left">38c8a9a52082579090e34c033d439ed2cd1a462d</td>
<td class="org-left">-</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">File containing structs definitions moved `fs/cifs/cifsacl.h` → `fs/smb/client/cifsacl.h`</td>
</tr>


<tr>
<td class="org-left">7f599d8fb3e087aff5be4e1392baaae3f8d42419</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">Renaming: `smb_sid`, `cifs_ace` member type rename: `cifs_sid` → `smb_sid`</td>
</tr>


<tr>
<td class="org-left">251b93ae73805b216e84ed2190b525f319da4c87</td>
<td class="org-left">-</td>
<td class="org-left">x</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">Renaming: `cifs_acl` → `smb_acl`</td>
</tr>


<tr>
<td class="org-left">09bedafc1e2c5c82aad3cbfe1359e2b0bf752f3a</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">x</td>
<td class="org-left">-</td>
<td class="org-left">Renaming: `cifs_ace` → `smb_ace`</td>
</tr>


<tr>
<td class="org-left">b51174da743b6b7cd87c02e882ebe60dcb99f8bf</td>
<td class="org-left">-</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">Move from `fs/smb/client/cifsacl.h` to `fs/smb/common/smbacl.h`</td>
</tr>


<tr>
<td class="org-left">62e7dd0a39c2d0d7ff03274c36df971f1b3d2d0d</td>
<td class="org-left">-</td>
<td class="org-left">x</td>
<td class="org-left">-</td>
<td class="org-left">-</td>
<td class="org-left">`num_aces` split: `__le32 num_aces` → `__le16 num_aces`, `__le16 reserved`</td>
</tr>


<tr>
<td class="org-left">e7e60e8bfcc5bfff0dc40a3b8ab275a4da6990a0</td>
<td class="org-left">-</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">x</td>
<td class="org-left">`__attribute__((packed))` → `__packed`</td>
</tr>
</tbody>
</table>


## CVE-2026-31419

    net: bonding: fix use-after-free in bond_xmit_broadcast()
    
    jira VULN-181412
    cve CVE-2026-31419
    commit-author Xiang Mei <xmei5@asu.edu>
    commit 2884bf72fb8f03409e423397319205de48adca16
    upstream-diff Used linux-6.12.y backport
      3453882f36c40d2339267093676585a89808a73d for a clean pick. That commit
      partially includes changes from ce7a381697cb3958ffe0b45e5028ac69444e9288
      ("net: bonding: add broadcast_neighbor option for 802.3ad"), which was
      not backported to LTS 9.2 either.


# kABI check: passed

    [1/2] kabi_check_kernel	Check ABI of kernel [ciqlts9_2-CVE-batch-37]	_kabi_check_kernel__x86_64--test--ciqlts9_2-CVE-batch-37
    + dist_git_version=el-9.2
    + local_version=ciqlts9_2-CVE-batch-37
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts9_2
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-9.2
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts9_2-CVE-batch-37
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-9.2/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts9_2 ''\''/mnt/code/kernel-dist-git-el-9.2/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts9_2-CVE-batch-37/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-batch-37/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/29311484/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/29311486/kselftests--ciqlts9_2--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-batch-37&#x2013;run1.log](<https://github.com/user-attachments/files/29311490/kselftests--ciqlts9_2-CVE-batch-37--run1.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-batch-37&#x2013;run2.log](<https://github.com/user-attachments/files/29311493/kselftests--ciqlts9_2-CVE-batch-37--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff  kselftests*.log

[full-test-results-comparison.log](<https://github.com/user-attachments/files/29311485/full-test-results-comparison.log>)

