### PR TITLE
[LTS 9.2] CVE-2025-38022, CVE-2025-38129

### DIFF
--- a/drivers/infiniband/core/device.c
+++ b/drivers/infiniband/core/device.c
@@ -1441,8 +1441,13 @@ int ib_register_device(struct ib_device *device, const char *name,
 		return ret;
 	}
 	dev_set_uevent_suppress(&device->dev, false);
+
+	down_read(&devices_rwsem);
+
 	/* Mark for userspace that device is ready */
 	kobject_uevent(&device->dev.kobj, KOBJ_ADD);
+
+	up_read(&devices_rwsem);
 	ib_device_put(device);
 
 	return 0;

--- a/include/net/page_pool.h
+++ b/include/net/page_pool.h
@@ -386,7 +386,7 @@ static inline void page_pool_nid_changed(struct page_pool *pool, int new_nid)
 static inline void page_pool_ring_lock(struct page_pool *pool)
 	__acquires(&pool->ring.producer_lock)
 {
-	if (in_serving_softirq())
+	if (in_softirq())
 		spin_lock(&pool->ring.producer_lock);
 	else
 		spin_lock_bh(&pool->ring.producer_lock);
@@ -395,7 +395,7 @@ static inline void page_pool_ring_lock(struct page_pool *pool)
 static inline void page_pool_ring_unlock(struct page_pool *pool)
 	__releases(&pool->ring.producer_lock)
 {
-	if (in_serving_softirq())
+	if (in_softirq())
 		spin_unlock(&pool->ring.producer_lock);
 	else
 		spin_unlock_bh(&pool->ring.producer_lock);

--- a/include/net/page_pool.h
+++ b/include/net/page_pool.h
@@ -383,22 +383,4 @@ static inline void page_pool_nid_changed(struct page_pool *pool, int new_nid)
 		page_pool_update_nid(pool, new_nid);
 }
 
-static inline void page_pool_ring_lock(struct page_pool *pool)
-	__acquires(&pool->ring.producer_lock)
-{
-	if (in_softirq())
-		spin_lock(&pool->ring.producer_lock);
-	else
-		spin_lock_bh(&pool->ring.producer_lock);
-}
-
-static inline void page_pool_ring_unlock(struct page_pool *pool)
-	__releases(&pool->ring.producer_lock)
-{
-	if (in_softirq())
-		spin_unlock(&pool->ring.producer_lock);
-	else
-		spin_unlock_bh(&pool->ring.producer_lock);
-}
-
 #endif /* _NET_PAGE_POOL_H */

--- a/net/core/page_pool.c
+++ b/net/core/page_pool.c
@@ -511,8 +511,8 @@ static void page_pool_return_page(struct page_pool *pool, struct page *page)
 static bool page_pool_recycle_in_ring(struct page_pool *pool, struct page *page)
 {
 	int ret;
-	/* BH protection not needed if current is serving softirq */
-	if (in_serving_softirq())
+	/* BH protection not needed if current is softirq */
+	if (in_softirq())
 		ret = ptr_ring_produce(&pool->ring, page);
 	else
 		ret = ptr_ring_produce_bh(&pool->ring, page);
@@ -570,7 +570,7 @@ __page_pool_put_page(struct page_pool *pool, struct page *page,
 			page_pool_dma_sync_for_device(pool, page,
 						      dma_sync_size);
 
-		if (allow_direct && in_serving_softirq() &&
+		if (allow_direct && in_softirq() &&
 		    page_pool_recycle_in_cache(page, pool))
 			return NULL;
 

--- a/net/core/page_pool.c
+++ b/net/core/page_pool.c
@@ -133,6 +133,29 @@ EXPORT_SYMBOL(page_pool_ethtool_stats_get);
 #define recycle_stat_add(pool, __stat, val)
 #endif
 
+static bool page_pool_producer_lock(struct page_pool *pool)
+	__acquires(&pool->ring.producer_lock)
+{
+	bool in_softirq = in_softirq();
+
+	if (in_softirq)
+		spin_lock(&pool->ring.producer_lock);
+	else
+		spin_lock_bh(&pool->ring.producer_lock);
+
+	return in_softirq;
+}
+
+static void page_pool_producer_unlock(struct page_pool *pool,
+				      bool in_softirq)
+	__releases(&pool->ring.producer_lock)
+{
+	if (in_softirq)
+		spin_unlock(&pool->ring.producer_lock);
+	else
+		spin_unlock_bh(&pool->ring.producer_lock);
+}
+
 static int page_pool_init(struct page_pool *pool,
 			  const struct page_pool_params *params)
 {
@@ -615,6 +638,7 @@ void page_pool_put_page_bulk(struct page_pool *pool, void **data,
 			     int count)
 {
 	int i, bulk_len = 0;
+	bool in_softirq;
 
 	for (i = 0; i < count; i++) {
 		struct page *page = virt_to_head_page(data[i]);
@@ -633,7 +657,7 @@ void page_pool_put_page_bulk(struct page_pool *pool, void **data,
 		return;
 
 	/* Bulk producer into ptr_ring page_pool cache */
-	page_pool_ring_lock(pool);
+	in_softirq = page_pool_producer_lock(pool);
 	for (i = 0; i < bulk_len; i++) {
 		if (__ptr_ring_produce(&pool->ring, data[i])) {
 			/* ring full */
@@ -642,7 +666,7 @@ void page_pool_put_page_bulk(struct page_pool *pool, void **data,
 		}
 	}
 	recycle_stat_add(pool, ring, i);
-	page_pool_ring_unlock(pool);
+	page_pool_producer_unlock(pool, in_softirq);
 
 	/* Hopefully all pages was return into ptr_ring */
 	if (likely(i == bulk_len))

--- a/net/core/page_pool.c
+++ b/net/core/page_pool.c
@@ -128,9 +128,9 @@ u64 *page_pool_ethtool_stats_get(u64 *data, void *stats)
 EXPORT_SYMBOL(page_pool_ethtool_stats_get);
 
 #else
-#define alloc_stat_inc(pool, __stat)
-#define recycle_stat_inc(pool, __stat)
-#define recycle_stat_add(pool, __stat, val)
+#define alloc_stat_inc(...)	do { } while (0)
+#define recycle_stat_inc(...)	do { } while (0)
+#define recycle_stat_add(...)	do { } while (0)
 #endif
 
 static bool page_pool_producer_lock(struct page_pool *pool)
@@ -533,19 +533,16 @@ static void page_pool_return_page(struct page_pool *pool, struct page *page)
 
 static bool page_pool_recycle_in_ring(struct page_pool *pool, struct page *page)
 {
-	int ret;
+	bool in_softirq, ret;
+
 	/* BH protection not needed if current is softirq */
-	if (in_softirq())
-		ret = ptr_ring_produce(&pool->ring, page);
-	else
-		ret = ptr_ring_produce_bh(&pool->ring, page);
-
-	if (!ret) {
+	in_softirq = page_pool_producer_lock(pool);
+	ret = !__ptr_ring_produce(&pool->ring, page);
+	if (ret)
 		recycle_stat_inc(pool, ring);
-		return true;
-	}
+	page_pool_producer_unlock(pool, in_softirq);
 
-	return false;
+	return ret;
 }
 
 /* Only allow direct recycling in special circumstances, into the
@@ -820,10 +817,14 @@ static void page_pool_scrub(struct page_pool *pool)
 
 static int page_pool_release(struct page_pool *pool)
 {
+	bool in_softirq;
 	int inflight;
 
 	page_pool_scrub(pool);
 	inflight = page_pool_inflight(pool);
+	/* Acquire producer lock to make sure producers have exited. */
+	in_softirq = page_pool_producer_lock(pool);
+	page_pool_producer_unlock(pool, in_softirq);
 	if (!inflight)
 		page_pool_free(pool);
 


### PR DESCRIPTION
[LTS 9.2]

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<tbody>
<tr>
<td class="org-left">CVE-2025-38129</td>
<td class="org-left">VULN-71838</td>
</tr>


<tr>
<td class="org-left">CVE-2025-38022</td>
<td class="org-left">VULN-71153</td>
</tr>
</tbody>
</table>


# Commits


## CVE-2025-38129

0:

    page_pool: Fix use-after-free in page_pool_recycle_in_ring
    
    jira VULN-71838
    cve CVE-2025-38129
    commit-author Dong Chenchen <dongchenchen2@huawei.com>
    commit 271683bb2cf32e5126c592b5d5e6a756fa374fd9
    upstream-diff Used linux-6.1.y backport
      1a8c0b61d4cb55c5440583ec9e7f86a730369e32 for a clean pick. It accounts
      for the similarly non-backported commit
      4dec64c52e24c2c9a15f81c115f1be5ea35121cb ("page_pool: convert to use
      netmem") and deals with the same context conflicts in
      `page_pool_release()'.

1:

    page_pool: fix inconsistency for page_pool_ring_[un]lock()
    
    jira VULN-71838
    cve-pre CVE-2025-38129
    commit-author Yunsheng Lin <linyunsheng@huawei.com>
    commit 368d3cb406cdd074d1df2ad9ec06d1bfcb664882

This commit introduces `page_pool_producer_lock()` / `page_pool_producer_unlock()` functions on which the CVE-2025-38129 fix is based.

2:

    net: page_pool: use in_softirq() instead
    
    jira VULN-71838
    cve-pre CVE-2025-38129
    commit-author Qingfang DENG <qingfang.deng@siflower.com.cn>
    commit 542bcea4be866b14b3a5c8e90773329066656c43

This prerequisite may not have been strictly necessary as the `in_softirq()~/~in_serving_softirq()` branching in `page_pool_recycle_in_ring()` is discarded in the CVE-2025-38129 fix anyway, but it simplifies patch backporting and is bugfix worthy of backporting in itself.

This solution is the same as in `linux-6.1.y`, with which LTS 9.2 has very similar `net/core/page_pool.c` history (`=`: same commit, `~`: backported commit):

       File
       --------------------
       net/core/page_pool.c
       
       kernel-mainline                                                                                                   ciqlts9_2               linux-6.1.y           
       ---------------------------------------------------------------------------------------------------------------   ----------------------  ----------------------
       81a4d039537a89e 2026-05-28 net: make page_pool_get_stats() void
       ac0056e4f14b03e 2026-05-28 docs: page_pool: drop the mention of the legacy stats API
       54cf41c969da663 2026-05-21 Revert "mm: introduce a new page type for page pool in page type"
       5ef343614db766a 2026-04-29 page_pool: fix memory-provider leak in page_pool_create_percpu() error path                                                          
       db359fccf212e7f 2026-04-05 mm: introduce a new page type for page pool in page type
       9954464d737dd12 2025-12-02 net: page_pool: sanitise allocation order
       854858848bc7ac6 2025-12-02 net: page pool: xa init with destroy on pp init
       95920c2ed02bde5 2025-10-06 page_pool: Fix PP_MAGIC_MASK to avoid crashing on some 32-bit arches                                                                 
       a1b501a8c6a87c9 2025-09-30 page_pool: Clamp pool size to max 16K pages                                                                    ~ c5eb9ae97 2025-12-07
       f3b52167a0cb23b 2025-09-15 page_pool: always add GFP_NOWARN for ATOMIC allocations                                                        ~ 9835a0fd5 2025-12-07
       abadf0ff63be488 2025-08-22 page_pool: fix incorrect mp_ops error handling                                                                                       
       64fdaa94bfe0cca 2025-08-08 net: page_pool: allow enabling recycling late, fix false positive warning                                                            
       b56ce86846225d6 2025-07-07 page_pool: rename __page_pool_alloc_pages_slow() to __page_pool_alloc_netmems_slow()
       4ad125ae380bf0b 2025-07-07 page_pool: rename __page_pool_release_page_dma() to __page_pool_release_netmem_dma()
       61a33247533465c 2025-07-07 page_pool: rename page_pool_return_page() to page_pool_return_netmem()
    0> 271683bb2cf32e5 2025-05-28 page_pool: Fix use-after-free in page_pool_recycle_in_ring                                                     ~ 1a8c0b61d 2026-01-11
       170ebc60b79a574 2025-05-27 page_pool: fix ugly page_pool formatting
       32471b2f481dea8 2025-05-15 net: page_pool: Don't recycle into cache on PREEMPT_RT                                                                               
       ee62ce7a1d909cc 2025-04-14 page_pool: Track DMA-mapped pages and unmap them when destroying the pool                                                            
       b52458652eca5a5 2025-03-25 net: protect rxq->mp_params with the instance lock                                                                                   
       43130d02baa1370 2025-02-18 page_pool: avoid infinite loop to schedule delayed worker                                                      ~ 90e089a64 2025-04-25
       c1e00bc4be06cac 2025-02-07 net: page_pool: avoid false positive warning if NAPI was never added                                                                 
       56102c013fa7b8d 2025-02-06 net: page_pool: add memory provider helpers                                                                                          
       [... no commits backported to either version...]
       2da0cac1e9494f3 2023-11-21 net: page_pool: avoid touching slow on the fastpath                                                                                  
       5027ec19f1049a0 2023-11-21 net: page_pool: split the page_pool_params into fast and slow                                                                        
       8ffbd1669ed1d58 2023-11-02 net: page_pool: add missing free_percpu when page_pool_init fail                                               ~ e129327d8 2023-11-20
       de97502e16fc406 2023-10-23 page_pool: introduce page_pool_alloc() API                                                                                           
       09d96ee5674a0ea 2023-10-23 page_pool: remove PP_FLAG_PAGE_FRAG                                                                                                  
       58d53d8f7da63dd 2023-10-23 page_pool: unify frag_count handling in page_pool_is_last_frag()                                                                     
       90de47f020db086 2023-10-16 page_pool: fragment API support for 32-bit arch with 64-bit DMA                                                                      
       ff4e538c8c3e675 2023-08-07 page_pool: add a lockdep check for recycling in hardirq                                                                              
       75eaf63ea7afeaf 2023-08-07 net: skbuff: don't include <net/page_pool/types.h> to <linux/skbuff.h>                                                               
       a9ca9f9ceff382b 2023-08-07 page_pool: split types and declarations from page_pool.h                                                                             
       82e896d992fa631 2023-08-03 docs: net: page_pool: use kdoc to avoid duplicating the information                                                                  
       07e0c7d3179da5d 2023-07-21 net: page_pool: merge page_pool_release_page() with page_pool_return_page()                                                          
       535b9c61bdef601 2023-07-21 net: page_pool: hide page_pool_release_page()                                                                                        
    1> 368d3cb406cdd07 2023-05-23 page_pool: fix inconsistency for page_pool_ring_[un]lock()                                                     ~ 7c95f5699 2023-06-05
       dd64b232deb8d48 2023-04-20 page_pool: unlink from napi during destroy                                                                                           
       8e4c62c7d980eaf 2023-04-19 page_pool: add DMA_ATTR_WEAK_ORDERING on all mappings                                                                                
       8c48eea3adf3119 2023-04-14 page_pool: allow caching from safely localized NAPI                                                                                  
    2> 542bcea4be866b1 2023-02-06 net: page_pool: use in_softirq() instead                                                                       ~ 7dccd5fa7 2023-06-05
       d810d367ec40a10 2022-07-07 net: page_pool: optimize page pool page allocation in NUMA scenario                    ~ 1cc26eafb 2023-01-05  = d810d367e 2022-07-07
       8d29c7036f5ff36 2022-07-03 mm/swap: convert __put_page() to __folio_put()                                                                 = 8d29c7036 2022-07-03
       0f6deac3a079581 2022-05-13 net: page_pool: add page allocation stats for two fast page allocate path              ~ 88509dacf 2022-11-30  = 0f6deac3a 2022-05-13
       f3c5264f452a5b0 2022-04-15 net: page_pool: introduce ethtool stats                                                ~ e4c225200 2022-11-30  = f3c5264f4 2022-04-15
       590032a4d2133ec 2022-04-12 page_pool: Add recycle stats to page_pool_put_page_bulk                                ~ 3c9b8c39b 2022-11-28  = 590032a4d 2022-04-12
       6b95e3388b1ea0c 2022-03-03 page_pool: Add function to batch and return stats                                      ~ b52705c25 2022-10-25  = 6b95e3388 2022-03-03
       ad6fa1e1ab1b816 2022-03-03 page_pool: Add recycle stats                                                           ~ 249dfc0fd 2022-10-25  = ad6fa1e1a 2022-03-03
       8610037e8106b48 2022-03-03 page_pool: Add allocation stats                                                        ~ ff8569059 2022-10-25  = 8610037e8 2022-03-03
       52cc6ffc0ab2c61 2022-02-03 page_pool: Refactor page_pool to enable fragmenting after allocation                   ~ 0700a9a4b 2022-10-25  = 52cc6ffc0 2022-02-03
       07b17f0f7485bcb 2022-01-09 page_pool: remove spinlock in page_pool_refill_alloc_cache()                           ~ 559e95e23 2022-08-24  = 07b17f0f7 2022-01-09
       64693ec7774e471 2022-01-05 page_pool: Store the XDP mem id                                                        ~ 9d38cafdb 2022-08-24  = 64693ec77 2022-01-05
       35b2e549894b7ef 2022-01-05 page_pool: Add callback to init pages when they are allocated                          ~ e33883538 2022-08-24  = 35b2e5498 2022-01-05
       f915b75bffb7257 2021-11-18 page_pool: Revert "page_pool: disable dma mapping support..."                                                  = f915b75bf 2021-11-18
       d00e60ee54b12de 2021-10-15 page_pool: disable dma mapping support for 32-bit arch with 64-bit DMA                                         = d00e60ee5 2021-10-15
       7fb9b66dc9ce52b 2021-08-24 page_pool: use relaxed atomic for release side accounting                              ~ 643fe5322 2022-05-12  = 7fb9b66dc 2021-08-24
       53e0961da1c7bbd 2021-08-09 page_pool: add frag page recycling support in page pool                                ~ 44b3ff853 2022-05-12  = 53e0961da 2021-08-09
       0e9d2a0a3a836c3 2021-08-09 page_pool: add interface to manipulate frag count in page pool                         ~ f60c1855e 2022-05-12  = 0e9d2a0a3 2021-08-09
       57f05bc2ab2443b 2021-08-09 page_pool: keep pp info as long as page pool owns the page                             ~ 2844f31ff 2022-05-12  = 57f05bc2a 2021-08-09
       0fa32ca438b42fa 2021-08-09 page_pool: mask the page->signature before the checking                                = 0fa32ca43 2021-08-09  = 0fa32ca43 2021-08-09
       6a5bcd84e886a9a 2021-06-07 page_pool: Allow drivers to hint on SKB recycling                                      = 6a5bcd84e 2021-06-07  = 6a5bcd84e 2021-06-07
       [... common git history ...]


## CVE-2025-38022

    RDMA/core: Fix "KASAN: slab-use-after-free Read in ib_register_device" problem
    
    jira VULN-71153
    cve CVE-2025-38022
    commit-author Zhu Yanjun <yanjun.zhu@linux.dev>
    commit d0706bfd3ee40923c001c6827b786a309e2a8713
    upstream-diff Used linux-5.15.y backport
      5629064f92f0de6d6b3572055cd35361c3ad953c for the clean pick. In LTS
      9.2 the `ib_device_notify_register()' function, where the
      `kobject_uevent()' call wa moved in the upstream fix, doesn't exist.
      It was introduced in 9cbed5aab5aeea420d0aa945733bf608449d44fb
      ("RDMA/nldev: Add support for RDMA monitoring"), with locks put in
      place in 1d6a9e7449e2a0c1e2934eee7880ba8bd1e464cd ("RDMA/core: Fix
      use-after-free when rename device name"). Wrapping the
      `kobject_uevent()' call in `down_read(&devices_rwsem)' and
      `up_read(&devices_rwsem)' results in the same protection.

Since the fix looks completely different from upstream here's the breakdown of the issue. The fix message:

> The root cause is: the function ib\_device\_rename() renames the name with
> lock. But in the function kobject\_uevent(), this name is accessed without
> lock protection at the same time.
> 
> The solution is to add the lock protection when this name is accessed in
> the function kobject\_uevent().

The `ib_device_rename()` function:

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/infiniband/core/device.c#L385-L426>

The lock is 

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/infiniband/core/device.c#L391>

and

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/infiniband/core/device.c#L424>

The renaming appears in

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/infiniband/core/device.c#L420>

This is a function pointer of the `struct ib_client` structure

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/include/rdma/ib_verbs.h#L2854>

The only instance found in the codebase with this pointer set to non-null is `srp_client`:

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/infiniband/ulp/srp/ib_srp.c#L153-L158>

Definition:

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/infiniband/ulp/srp/ib_srp.c#L3986-L3998>

Renaming takes place in `device_rename()`, using `kobject_rename()`:

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/base/core.c#L4526>

This function is a part of kernel's library for drivers, it operates on kobjects - core mechanism for reference-counted objects that organize system components into sysfs hierarchies and enable device hotplug notifications. This is the most likely `free` after which the use was done in `kobject_uevent()`:

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/lib/kobject.c#L524>

Tracking the KASAN stack trace from d0706bfd3ee40923c001c6827b786a309e2a8713's message it can be seen that the UAF occured in this line of the `kobject_uevent_env()` function (to which `kobject_uevent()` delegates with no additional logic):

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/lib/kobject_uevent.c#L545>

In the upstream the function was called here

<https://github.com/ctrliq/kernel-src-tree/blob/4bcc063939a560f05b05b34be68d20045a646e6e/drivers/infiniband/core/device.c#L1471-L1472>

The d0706bfd3ee40923c001c6827b786a309e2a8713 fix moved it inside the `ib_device_notify_register()` call appearing in the next line:

<https://github.com/ctrliq/kernel-src-tree/blob/4bcc063939a560f05b05b34be68d20045a646e6e/drivers/infiniband/core/device.c#L1474>

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/infiniband/core/device.c#L1355-L1356>

between

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/infiniband/core/device.c#L1353>

and

<https://github.com/ctrliq/kernel-src-tree/blob/d0706bfd3ee40923c001c6827b786a309e2a8713/drivers/infiniband/core/device.c#L1375>

In LTS 9.2 this function doesn't exist, introduced in 9cbed5aab5aeea420d0aa945733bf608449d44fb, with locks put in place in 1d6a9e7449e2a0c1e2934eee7880ba8bd1e464cd. The latter is what was referenced in the CVE-2025-38022 fix commit's message

> This problem is similar to the problem that the
> commit 1d6a9e7449e2 ("RDMA/core: Fix use-after-free when rename device name")
> fixes.

Wrapping the `kobject_uevent()` call in `down_read(&devices_rwsem)` and `up_read(&devices_rwsem)` effetcively gives the same protection which was achieved in the upstream. The renaming function `ib_device_rename()` in LTS 9.2 doesn't differ much from the upstream and uses the same locks

<https://github.com/ctrliq/kernel-src-tree/blob/17e4221ec8cdb53e91a2d3a6e5833332820cb789/drivers/infiniband/core/device.c#L402-L442>


# kABI check: passed

    [1/2] kabi_check_kernel	Check ABI of kernel [ciqlts9_2-CVE-batch-40]	_kabi_check_kernel__x86_64--test--ciqlts9_2-CVE-batch-40
    + dist_git_version=el-9.2
    + local_version=ciqlts9_2-CVE-batch-40
    + arch=x86_64
    + user=pvts
    + buildmachine=x86_64--build--ciqlts9_2
    + virsh_timeout=600
    + ssh_daemon_wait=20
    + src_dir=/mnt/code/kernel-dist-git-el-9.2
    + build_dir=/mnt/build_files/kernel-src-tree-ciqlts9_2-CVE-batch-40
    + sudo chmod +x /data/src/ctrliq-github-haskell/kernel-dist-git-el-9.2/SOURCES/check-kabi
    + ninja-back/virssh.xsh --max 8 --shutdown-on-success --shutdown-on-failure --timeout 600 --ssh-daemon-wait 20 pvts x86_64--build--ciqlts9_2 ''\''/mnt/code/kernel-dist-git-el-9.2/SOURCES/check-kabi'\'' -k '\''/mnt/code/kernel-dist-git-el-9.2/SOURCES/Module.kabi_x86_64'\'' -s '\''/mnt/build_files/kernel-src-tree-ciqlts9_2-CVE-batch-40/Module.symvers'\'''
    kABI check passed
    + touch state/kernels/ciqlts9_2-CVE-batch-40/x86_64/kabi_checked


# Boot test: passed

[boot-test.log](<https://github.com/user-attachments/files/29439963/boot-test.log>)


# Kselftests: passed relative


## Reference

[kselftests&#x2013;ciqlts9\_2&#x2013;run1.log](<https://github.com/user-attachments/files/29439966/kselftests--ciqlts9_2--run1.log>)


## Patch

[kselftests&#x2013;ciqlts9\_2-CVE-batch-40&#x2013;run1.log](<https://github.com/user-attachments/files/29439968/kselftests--ciqlts9_2-CVE-batch-40--run1.log>)
[kselftests&#x2013;ciqlts9\_2-CVE-batch-40&#x2013;run2.log](<https://github.com/user-attachments/files/29439969/kselftests--ciqlts9_2-CVE-batch-40--run2.log>)


## Comparison

The tests results for the reference and the patch are the same.

    $ ktests.xsh diff -d kselftests*.log

    Column    File
    --------  --------------------------------------------
    Status0   kselftests--ciqlts9_2--run1.log
    Status1   kselftests--ciqlts9_2-CVE-batch-40--run1.log
    Status2   kselftests--ciqlts9_2-CVE-batch-40--run2.log

[full-test-results-comparison.log](<https://github.com/user-attachments/files/29439964/full-test-results-comparison.log>)

