### PR TITLE
github-actions: fix YAML parse error in lt-rebase-merge heredocs

### DIFF
--- a/.github/workflows/lt-rebase-merge.yml
+++ b/.github/workflows/lt-rebase-merge.yml
@@ -254,11 +254,8 @@ jobs:
           for pr in $OPEN_PRS; do
             echo "Parking PR #$pr on ${TEMP_BRANCH}"
             gh pr edit "$pr" --repo "$REPOSITORY" --base "${TEMP_BRANCH}"
-            gh pr comment "$pr" --repo "$REPOSITORY" --body-file - <<EOF || true
-:hourglass_flowing_sand: A rebase of \`${TARGET_BRANCH}\` to the latest upstream stable release is in progress. This PR has been temporarily moved to \`${TEMP_BRANCH}\` while the branch is updated.
-
-Workflow run: ${RUN_URL}
-EOF
+            printf -v COMMENT_BODY ':hourglass_flowing_sand: A rebase of `%s` to the latest upstream stable release is in progress. This PR has been temporarily moved to `%s` while the branch is updated.\n\nWorkflow run: %s' "$TARGET_BRANCH" "$TEMP_BRANCH" "$RUN_URL"
+            gh pr comment "$pr" --repo "$REPOSITORY" --body "$COMMENT_BODY" || true
           done
 
       - name: Setup branch references and execute lt_rebase_merge.sh
@@ -327,19 +324,13 @@ EOF
               echo "Retargeting PR #$pr to ${TARGET_BRANCH}"
               if ! gh pr edit "$pr" --repo "$REPOSITORY" --base "${TARGET_BRANCH}"; then
                 echo "❌ Failed to retarget PR #$pr"
-                gh pr comment "$pr" --repo "$REPOSITORY" --body-file - <<EOF || true
-:warning: Failed to retarget this PR back to \`${TARGET_BRANCH}\` after rebase. This PR may still be on temporary branch \`${TEMP_BRANCH}\`. Please manually update the base branch.
-
-Workflow run: ${RUN_URL}
-EOF
+                printf -v COMMENT_BODY ':warning: Failed to retarget this PR back to `%s` after rebase. This PR may still be on temporary branch `%s`. Please manually update the base branch.\n\nWorkflow run: %s' "$TARGET_BRANCH" "$TEMP_BRANCH" "$RUN_URL"
+                gh pr comment "$pr" --repo "$REPOSITORY" --body "$COMMENT_BODY" || true
                 RESTORE_FAILURES=$((RESTORE_FAILURES + 1))
                 continue
               fi
-              gh pr comment "$pr" --repo "$REPOSITORY" --body-file - <<EOF || true
-:white_check_mark: \`${TARGET_BRANCH}\` has been rebased to \`${NEW_VERSION}\`. This PR has been retargeted to the updated branch. You will need to rebase your PR branch onto the new \`${TARGET_BRANCH}\`.
-
-Workflow run: ${RUN_URL}
-EOF
+              printf -v COMMENT_BODY ':white_check_mark: `%s` has been rebased to `%s`. This PR has been retargeted to the updated branch. You will need to rebase your PR branch onto the new `%s`.\n\nWorkflow run: %s' "$TARGET_BRANCH" "$NEW_VERSION" "$TARGET_BRANCH" "$RUN_URL"
+              gh pr comment "$pr" --repo "$REPOSITORY" --body "$COMMENT_BODY" || true
             done
 
             if [ "$RESTORE_FAILURES" -gt 0 ]; then
@@ -356,19 +347,13 @@ EOF
               echo "Restoring PR #$pr to ${TARGET_BRANCH}"
               if ! gh pr edit "$pr" --repo "$REPOSITORY" --base "${TARGET_BRANCH}"; then
                 echo "❌ Failed to restore PR #$pr"
-                gh pr comment "$pr" --repo "$REPOSITORY" --body-file - <<EOF || true
-:warning: Failed to move this PR back to \`${TARGET_BRANCH}\`. This PR may still be on temporary branch \`${TEMP_BRANCH}\`. Please manually update the base branch.
-
-Workflow run: ${RUN_URL}
-EOF
+                printf -v COMMENT_BODY ':warning: Failed to move this PR back to `%s`. This PR may still be on temporary branch `%s`. Please manually update the base branch.\n\nWorkflow run: %s' "$TARGET_BRANCH" "$TEMP_BRANCH" "$RUN_URL"
+                gh pr comment "$pr" --repo "$REPOSITORY" --body "$COMMENT_BODY" || true
                 RESTORE_FAILURES=$((RESTORE_FAILURES + 1))
                 continue
               fi
-              gh pr comment "$pr" --repo "$REPOSITORY" --body-file - <<EOF || true
-:warning: The rebase of \`${TARGET_BRANCH}\` could not proceed. This PR has been moved back to \`${TARGET_BRANCH}\`. No changes were made to the branch.
-
-Workflow run: ${RUN_URL}
-EOF
+              printf -v COMMENT_BODY ':warning: The rebase of `%s` could not proceed. This PR has been moved back to `%s`. No changes were made to the branch.\n\nWorkflow run: %s' "$TARGET_BRANCH" "$TARGET_BRANCH" "$RUN_URL"
+              gh pr comment "$pr" --repo "$REPOSITORY" --body "$COMMENT_BODY" || true
             done
 
             if [ "$RESTORE_FAILURES" -gt 0 ]; then
@@ -382,11 +367,8 @@ EOF
             # Script ran and failed — TARGET_BRANCH may be in unknown state, don't move PRs
             echo "⚠️ Rebase merge failed, leaving PRs on ${TEMP_BRANCH}"
             for pr in $PARKED_PRS; do
-              gh pr comment "$pr" --repo "$REPOSITORY" --body-file - <<EOF || true
-:warning: The rebase of \`${TARGET_BRANCH}\` failed. This PR remains on temporary branch \`${TEMP_BRANCH}\` to prevent it from being closed. The kernel team is investigating the failure.
-
-Workflow run: ${RUN_URL}
-EOF
+              printf -v COMMENT_BODY ':warning: The rebase of `%s` failed. This PR remains on temporary branch `%s` to prevent it from being closed. The kernel team is investigating the failure.\n\nWorkflow run: %s' "$TARGET_BRANCH" "$TEMP_BRANCH" "$RUN_URL"
+              gh pr comment "$pr" --repo "$REPOSITORY" --body "$COMMENT_BODY" || true
             done
           fi
 


### PR DESCRIPTION
Heredocs (<<EOF...EOF) inside YAML run: | blocks had their EOF terminators at column 1, which the YAML parser interprets as ending the block scalar. This caused the entire workflow file to fail parsing, silently preventing issue_comment events from triggering the workflow since commit a4bd60ad.

Replace --body-file heredocs with --body using shell variables, which avoids the YAML indentation conflict entirely.